### PR TITLE
Fix md_extract_sections binder ambiguity on VARCHAR input

### DIFF
--- a/src/markdown_extraction_functions.cpp
+++ b/src/markdown_extraction_functions.cpp
@@ -429,11 +429,6 @@ void MarkdownExtractionFunctions::Register(ExtensionLoader &loader) {
 	                             LogicalType::LIST(section_struct_type), SectionExtractionFunction);
 	loader.RegisterFunction(sections_func);
 
-	// Register overload for VARCHAR input
-	ScalarFunction sections_varchar_func("md_extract_sections", {LogicalType::VARCHAR},
-	                                     LogicalType::LIST(section_struct_type), SectionExtractionFunction);
-	loader.RegisterFunction(sections_varchar_func);
-
 	// Register overload for VARCHAR with level filtering
 	ScalarFunction sections_levels_func("md_extract_sections",
 	                                    {LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER},

--- a/test/sql/markdown_sections_varchar.test
+++ b/test/sql/markdown_sections_varchar.test
@@ -1,0 +1,17 @@
+# name: test/sql/markdown_sections_varchar.test
+# description: md_extract_sections resolves on VARCHAR / md inputs (Issue: binder ambiguity)
+# group: [markdown]
+
+require markdown
+
+# VARCHAR column input (previously: Could not choose a best candidate function)
+query I
+SELECT len(md_extract_sections(body)) FROM (VALUES (E'# A\n## B\nx')) t(body);
+----
+2
+
+# Explicit ::md cast (previously also ambiguous)
+query I
+SELECT len(md_extract_sections(E'# A\n## B\nx'::md));
+----
+2


### PR DESCRIPTION
Fixes a binder ambiguity that made `md_extract_sections` unusable on any single `VARCHAR` or `md` value.

The `md` type is a `VARCHAR` alias with cost-0 bidirectional implicit casts (`src/markdown_types.cpp`). `md_extract_sections` registered two equal-arity single-argument overloads returning the same type: one taking `VARCHAR`, one taking `md`. Because the `VARCHAR`↔`md` cast costs 0, every single-argument call reached both candidates at equal cost, so the binder refused to pick one:

```
Binder Error: Could not choose a best candidate function for the function call
"md_extract_sections(VARCHAR)". In order to select one, please add explicit type casts.
```

A caller-side cast did not help. Even `md_extract_sections(body::md)` stayed ambiguous, since the `md` argument still casts to `VARCHAR` at cost 0. Only the disk path (`read_markdown_sections` over files) worked. Extracting sections from an in-memory string was impossible.

This removes the redundant `VARCHAR` overload and keeps the `md`-typed one. A `VARCHAR` argument now implicitly casts to `md` (cost 0) and resolves to a single candidate, matching how `md_to_text` and `md_valid` already accept raw `VARCHAR`.

The 3-arg `{VARCHAR, INTEGER, INTEGER}` (level filtering) and 4-arg `{VARCHAR, INTEGER, INTEGER, VARCHAR}` (content_mode) variants are untouched. They add real functionality, have no equal-arity `md` competitor, and accept `md` inputs via the `md`→`VARCHAR` cast. `md_extract_section` (singular) was already unambiguous and is unchanged.

## Testing

Added `test/sql/markdown_sections_varchar.test`, which reproduces the two reported failures: a non-literal `VARCHAR` column and an explicit `::md` cast. It fails on `main` with the binder error and passes here.