### PR TITLE
Replace backtracking regex extractors with linear scanning

### DIFF
--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -2,9 +2,14 @@
 #include "markdown_types.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/common/exception.hpp"
 #include <sstream>
 
 namespace duckdb {
+
+// Maximum Pandoc inline-nesting depth walked by ExtractPandocText. Guards
+// against unbounded recursion (stack overflow) on adversarially nested JSON.
+static constexpr int MAX_PANDOC_DEPTH = 1000;
 
 //===--------------------------------------------------------------------===//
 // Helper Functions
@@ -142,7 +147,10 @@ void DuckBlockFunctions::ParseJsonTable(const string &content, vector<string> &h
 // Helper to extract text with markdown formatting from Pandoc AST inline elements
 // Handles {"t":"Str","c":"text"}, {"t":"Space"}, {"t":"Strong","c":[...]}, {"t":"Emph","c":[...]},
 // {"t":"Code","c":[[attr],text]}, {"t":"Link","c":[[attr],[inlines],[url,title]]}, etc.
-string DuckBlockFunctions::ExtractPandocText(const string &content) {
+string DuckBlockFunctions::ExtractPandocText(const string &content, int depth) {
+	if (depth > MAX_PANDOC_DEPTH) {
+		throw InvalidInputException("Pandoc inline nesting exceeds maximum supported depth (%d)", MAX_PANDOC_DEPTH);
+	}
 	string result;
 	size_t pos = 0;
 
@@ -298,7 +306,7 @@ string DuckBlockFunctions::ExtractPandocText(const string &content) {
 					size_t arr_end = find_bracket_end(arr_start);
 					if (arr_end != string::npos) {
 						string inner = content.substr(arr_start, arr_end - arr_start + 1);
-						result += "**" + ExtractPandocText(inner) + "**";
+						result += "**" + ExtractPandocText(inner, depth + 1) + "**";
 						pos = arr_end + 1;
 						continue;
 					}
@@ -313,7 +321,7 @@ string DuckBlockFunctions::ExtractPandocText(const string &content) {
 					size_t arr_end = find_bracket_end(arr_start);
 					if (arr_end != string::npos) {
 						string inner = content.substr(arr_start, arr_end - arr_start + 1);
-						result += "*" + ExtractPandocText(inner) + "*";
+						result += "*" + ExtractPandocText(inner, depth + 1) + "*";
 						pos = arr_end + 1;
 						continue;
 					}
@@ -362,7 +370,7 @@ string DuckBlockFunctions::ExtractPandocText(const string &content) {
 								size_t inlines_end = find_bracket_end(inlines_arr);
 								if (inlines_end != string::npos) {
 									string inlines = content.substr(inlines_arr, inlines_end - inlines_arr + 1);
-									string link_text = ExtractPandocText(inlines);
+									string link_text = ExtractPandocText(inlines, depth + 1);
 
 									// Find the target array (third element) [url, title]
 									size_t target_arr = content.find('[', inlines_end + 1);

--- a/src/include/duck_block_functions.hpp
+++ b/src/include/duck_block_functions.hpp
@@ -70,8 +70,9 @@ private:
 	// Helper to parse JSON table
 	static void ParseJsonTable(const string &content, vector<string> &headers, vector<vector<string>> &rows);
 
-	// Helper to extract plain text from Pandoc AST inline elements
-	static string ExtractPandocText(const string &content);
+	// Helper to extract plain text from Pandoc AST inline elements.
+	// depth guards against unbounded recursion on adversarially nested input.
+	static string ExtractPandocText(const string &content, int depth = 0);
 
 	// Check if content looks like Pandoc table format
 	static bool IsPandocTableFormat(const string &content);

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -2,7 +2,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception.hpp"
 #include <algorithm>
-#include <regex>
+#include <cctype>
 #include <set>
 #include <sstream>
 #include <unordered_map>
@@ -16,6 +16,131 @@
 namespace duckdb {
 
 namespace markdown_utils {
+
+//===--------------------------------------------------------------------===//
+// Linear (non-backtracking) scanners
+//
+// These replace hand-rolled std::regex patterns that ran over untrusted,
+// potentially large input. libstdc++'s std::regex recurses while matching
+// greedy quantifiers, so a long run with no terminator (e.g. an unclosed
+// frontmatter block, a giant table line, or a long unterminated "[") could
+// overflow the stack and SIGSEGV the whole DuckDB process. A stack overflow
+// is not a catchable C++ exception, so the scalar functions' try/catch did
+// not help. Every scanner below runs in O(n) with bounded stack usage.
+//===--------------------------------------------------------------------===//
+
+// Result of locating a leading YAML-style frontmatter block.
+struct FrontmatterMatch {
+	bool found = false;
+	size_t body_start = 0; // offset of first byte of the frontmatter body
+	size_t body_len = 0;   // length of the body (delimiters excluded)
+	size_t after_close = 0; // offset just past the closing "---"
+};
+
+// Faithful linear replacement for R"(^---\r?\n([\s\S]*?)\r?\n---)".
+// Requires the string to begin with "---" then \r?\n, then finds the earliest
+// following "\r?\n---". Returns the body between the delimiters. O(n), no
+// recursion.
+static FrontmatterMatch FindFrontmatter(const std::string &s) {
+	FrontmatterMatch m;
+	// Opening delimiter: "---" then \r?\n
+	if (s.size() < 4 || s[0] != '-' || s[1] != '-' || s[2] != '-') {
+		return m;
+	}
+	size_t p = 3;
+	if (p < s.size() && s[p] == '\r') {
+		p++;
+	}
+	if (p >= s.size() || s[p] != '\n') {
+		return m;
+	}
+	p++; // start of body
+	size_t body_start = p;
+
+	// Closing delimiter: earliest '\n' immediately followed by "---".
+	while (p < s.size()) {
+		if (s[p] == '\n' && p + 4 <= s.size() && s[p + 1] == '-' && s[p + 2] == '-' && s[p + 3] == '-') {
+			size_t body_end = p; // at the '\n'
+			// The delimiter is \r?\n, so drop a trailing '\r' from the body.
+			if (body_end > body_start && s[body_end - 1] == '\r') {
+				body_end--;
+			}
+			m.found = true;
+			m.body_start = body_start;
+			m.body_len = body_end - body_start;
+			m.after_close = p + 4; // just past the closing "---"
+			return m;
+		}
+		p++;
+	}
+	return m;
+}
+
+// True if a single line (without its trailing '\n') is a GFM pipe-table row:
+// starts with '|', has at least two '|', and only spaces/tabs after the last
+// '|'. Faithful to R"(\|[^\n]*\|[ \t]*)" applied per line. A trailing '\r'
+// (CRLF input) is tolerated, matching the original regex behaviour.
+static bool IsPipeTableLine(const std::string &line_in) {
+	std::string line = line_in;
+	if (!line.empty() && line.back() == '\r') {
+		line.pop_back();
+	}
+	if (line.empty() || line[0] != '|') {
+		return false;
+	}
+	size_t last = line.rfind('|');
+	if (last == 0) {
+		return false; // only one '|'
+	}
+	for (size_t i = last + 1; i < line.size(); i++) {
+		if (line[i] != ' ' && line[i] != '\t') {
+			return false;
+		}
+	}
+	return true;
+}
+
+// True if a (trimmed, non-empty) table line is an alignment/separator row:
+// contains only '-', '|', ':', and whitespace, with at least one of '-|:'.
+// Linear replacement for R"(^\s*\|?\s*[-|:\s]+\s*\|?\s*$)" restricted to the
+// non-empty lines the table scanner actually feeds it.
+static bool IsSeparatorLine(const std::string &line) {
+	bool has_core = false;
+	for (char c : line) {
+		if (c == '-' || c == '|' || c == ':') {
+			has_core = true;
+		} else if (c == ' ' || c == '\t' || c == '\r') {
+			// allowed whitespace
+		} else {
+			return false;
+		}
+	}
+	return has_core;
+}
+
+// Split a table row into cells. Faithful to the previous R"([^|]+)" iterator:
+// split on '|', drop segments that are empty *before* trimming, then trim each
+// kept segment. Leading/trailing pipes therefore produce no empty cells.
+static std::vector<std::string> SplitTableCells(const std::string &line) {
+	std::vector<std::string> cells;
+	std::string cur;
+	auto flush = [&]() {
+		if (!cur.empty()) {
+			StringUtil::Trim(cur);
+			cells.push_back(cur);
+		}
+		cur.clear();
+	};
+	for (char c : line) {
+		if (c == '|') {
+			flush();
+		} else {
+			cur += c;
+		}
+	}
+	flush();
+	return cells;
+}
 
 //===--------------------------------------------------------------------===//
 // Core Conversion Functions
@@ -65,7 +190,9 @@ std::string MarkdownToHTML(const std::string &markdown_str, MarkdownFlavor flavo
 	cmark_node *doc = cmark_parser_finish(parser);
 	char *html = cmark_render_html(doc, options, nullptr);
 
-	std::string result(html);
+	// cmark can return NULL on allocation failure; guard against constructing
+	// a std::string from a NULL pointer (undefined behaviour).
+	std::string result(html ? html : "");
 
 	// Clean up
 	free(html);
@@ -88,7 +215,8 @@ std::string MarkdownToText(const std::string &markdown_str) {
 	// Render as plain text
 	char *text = cmark_render_plaintext(doc, CMARK_OPT_DEFAULT, 0);
 
-	std::string result(text);
+	// Guard against a NULL return (see MarkdownToHTML).
+	std::string result(text ? text : "");
 
 	// Clean up
 	free(text);
@@ -101,14 +229,11 @@ std::string MarkdownToText(const std::string &markdown_str) {
 MarkdownMetadata ExtractMetadata(const std::string &markdown_str) {
 	MarkdownMetadata metadata;
 
-	// Check for YAML frontmatter - handle both LF and CRLF line endings
-	// Use match.position() == 0 to ensure we only match at the start of the string
-	// (MSVC regex has issues with ^ anchor not working correctly)
-	std::regex frontmatter_regex(R"(^---\r?\n([\s\S]*?)\r?\n---)");
-	std::smatch match;
-
-	if (std::regex_search(markdown_str, match, frontmatter_regex) && match.position() == 0) {
-		std::string yaml_content = match[1].str();
+	// Locate a leading YAML-style frontmatter block with a linear scanner
+	// (see FindFrontmatter) instead of a backtracking std::regex.
+	auto fm = FindFrontmatter(markdown_str);
+	if (fm.found) {
+		std::string yaml_content = markdown_str.substr(fm.body_start, fm.body_len);
 
 		// Basic YAML parsing for common fields (placeholder)
 		std::istringstream stream(yaml_content);
@@ -121,8 +246,8 @@ MarkdownMetadata ExtractMetadata(const std::string &markdown_str) {
 				StringUtil::Trim(key);
 				StringUtil::Trim(value);
 
-				// Remove quotes if present
-				if (value.front() == '"' && value.back() == '"') {
+				// Remove surrounding quotes if present (guard against empty value)
+				if (value.size() >= 2 && value.front() == '"' && value.back() == '"') {
 					value = value.substr(1, value.length() - 2);
 				}
 
@@ -137,33 +262,30 @@ MarkdownMetadata ExtractMetadata(const std::string &markdown_str) {
 }
 
 std::string ExtractRawFrontmatter(const std::string &markdown_str) {
-	// Check for YAML frontmatter - handle both LF and CRLF line endings
-	// Use match.position() == 0 to ensure we only match at the start of the string
-	// (MSVC regex has issues with ^ anchor not working correctly)
-	std::regex frontmatter_regex(R"(^---\r?\n([\s\S]*?)\r?\n---)");
-	std::smatch match;
-
-	if (std::regex_search(markdown_str, match, frontmatter_regex) && match.position() == 0) {
-		return match[1].str();
+	// Linear scan (see FindFrontmatter) instead of a backtracking std::regex.
+	auto fm = FindFrontmatter(markdown_str);
+	if (fm.found) {
+		return markdown_str.substr(fm.body_start, fm.body_len);
 	}
-
 	return "";
 }
 
 std::string StripFrontmatter(const std::string &markdown_str) {
-	// Match frontmatter block including trailing newlines - handle both LF and CRLF
-	// Use match.position() == 0 to ensure we only match at the start of the string
-	// (MSVC regex has issues with ^ anchor not working correctly)
-	std::regex frontmatter_regex(R"(^---\r?\n[\s\S]*?\r?\n---\r?\n*)");
-	std::smatch match;
-
-	// Only strip if frontmatter is at the very start of the string
-	if (std::regex_search(markdown_str, match, frontmatter_regex) && match.position() == 0) {
-		return markdown_str.substr(match.length());
+	// Linear scan (see FindFrontmatter) instead of a backtracking std::regex.
+	// Faithful to R"(^---\r?\n[\s\S]*?\r?\n---\r?\n*)": strip through the closing
+	// "---" plus a single optional '\r' and any following '\n' characters.
+	auto fm = FindFrontmatter(markdown_str);
+	if (!fm.found) {
+		return markdown_str; // no frontmatter at start, return original
 	}
-
-	// No frontmatter found at start, return original
-	return markdown_str;
+	size_t end = fm.after_close;
+	if (end < markdown_str.size() && markdown_str[end] == '\r') {
+		end++;
+	}
+	while (end < markdown_str.size() && markdown_str[end] == '\n') {
+		end++;
+	}
+	return markdown_str.substr(end);
 }
 
 Value MetadataToMap(const MarkdownMetadata &metadata) {
@@ -192,21 +314,68 @@ MarkdownStats CalculateStats(const std::string &markdown_str) {
 	stats.char_count = markdown_str.length();
 	stats.line_count = static_cast<idx_t>(std::count(markdown_str.begin(), markdown_str.end(), '\n')) + 1;
 
-	// Count headings
-	std::regex heading_regex(R"(^#{1,6}\s+)");
-	stats.heading_count = static_cast<idx_t>(std::distance(
-	    std::sregex_iterator(markdown_str.begin(), markdown_str.end(), heading_regex), std::sregex_iterator()));
+	// Count headings. Faithful to the previous std::regex R"(^#{1,6}\s+)"
+	// which (default, non-multiline) only anchors at the START of the string,
+	// so this is 0 or 1: 1 iff the document opens with 1-6 '#' then whitespace.
+	stats.heading_count = 0;
+	{
+		size_t h = 0;
+		while (h < markdown_str.size() && markdown_str[h] == '#') {
+			h++;
+		}
+		if (h >= 1 && h <= 6 && h < markdown_str.size() &&
+		    std::isspace(static_cast<unsigned char>(markdown_str[h]))) {
+			stats.heading_count = 1;
+		}
+	}
 
-	// Count code blocks
-	std::regex code_block_regex(R"(```)");
-	auto code_matches = std::distance(std::sregex_iterator(markdown_str.begin(), markdown_str.end(), code_block_regex),
-	                                  std::sregex_iterator());
-	stats.code_block_count = static_cast<idx_t>(code_matches) / 2; // Opening and closing
+	// Count code fences ("```"); pairs of fences == code blocks.
+	{
+		idx_t fence_count = 0;
+		size_t pos = 0;
+		while ((pos = markdown_str.find("```", pos)) != std::string::npos) {
+			fence_count++;
+			pos += 3;
+		}
+		stats.code_block_count = fence_count / 2; // Opening and closing
+	}
 
-	// Count links
-	std::regex link_regex(R"(\[([^\]]+)\]\([^)]+\))");
-	stats.link_count = static_cast<idx_t>(std::distance(
-	    std::sregex_iterator(markdown_str.begin(), markdown_str.end(), link_regex), std::sregex_iterator()));
+	// Count inline links. Linear replacement for R"(\[([^\]]+)\]\([^)]+\))":
+	// non-overlapping "[" non-"]"+ "]" "(" non-")"+ ")".
+	stats.link_count = 0;
+	{
+		const std::string &s = markdown_str;
+		size_t i = 0;
+		size_t n = s.size();
+		while (i < n) {
+			if (s[i] != '[') {
+				i++;
+				continue;
+			}
+			size_t j = i + 1;
+			while (j < n && s[j] != ']') {
+				j++;
+			}
+			if (j >= n || j == i + 1) { // no closing ']' or empty label
+				i++;
+				continue;
+			}
+			if (j + 1 >= n || s[j + 1] != '(') {
+				i++;
+				continue;
+			}
+			size_t k = j + 2;
+			while (k < n && s[k] != ')') {
+				k++;
+			}
+			if (k >= n || k == j + 2) { // no closing ')' or empty target
+				i++;
+				continue;
+			}
+			stats.link_count++;
+			i = k + 1; // non-overlapping: resume past the match
+		}
+	}
 
 	// Estimate reading time (200 words per minute average)
 	stats.reading_time_minutes = static_cast<double>(stats.word_count) / 200.0;
@@ -226,14 +395,36 @@ std::string GenerateSectionId(const std::string &heading_text,
 	// Convert to lowercase
 	std::transform(id.begin(), id.end(), id.begin(), ::tolower);
 
-	// Replace spaces and special chars with hyphens
-	id = std::regex_replace(id, std::regex(R"([^a-z0-9\-_])"), "-");
-
-	// Remove multiple consecutive hyphens
-	id = std::regex_replace(id, std::regex(R"(-+)"), "-");
-
-	// Trim leading/trailing hyphens
-	id = std::regex_replace(id, std::regex(R"(^-+|-+$)"), "");
+	// Linear replacement for the three std::regex passes that previously ran
+	// on (untrusted, possibly large) heading text:
+	//   1. R"([^a-z0-9\-_])" -> "-"   (replace disallowed chars with '-')
+	//   2. R"(-+)"           -> "-"   (collapse consecutive hyphens)
+	//   3. R"(^-+|-+$)"      -> ""    (trim leading/trailing hyphens)
+	{
+		std::string out;
+		out.reserve(id.size());
+		bool prev_dash = false;
+		for (char c : id) {
+			bool keep = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_';
+			char oc = keep ? c : '-';
+			if (oc == '-') {
+				if (!prev_dash) {
+					out += '-';
+				}
+				prev_dash = true;
+			} else {
+				out += oc;
+				prev_dash = false;
+			}
+		}
+		size_t b = out.find_first_not_of('-');
+		if (b == std::string::npos) {
+			id.clear();
+		} else {
+			size_t e = out.find_last_not_of('-');
+			id = out.substr(b, e - b + 1);
+		}
+	}
 
 	// Handle duplicates
 	auto it = id_counts.find(id);
@@ -598,8 +789,16 @@ static std::string RenderNodeContent(cmark_node *node) {
 	return result;
 }
 
+// Maximum inline-nesting depth walked by GetInlineText. Far above any
+// legitimate document; guards against unbounded recursion (stack overflow) on
+// adversarially deep nesting.
+static constexpr int MAX_INLINE_DEPTH = 1000;
+
 // Helper to get text content from inline children
-static std::string GetInlineText(cmark_node *node) {
+static std::string GetInlineText(cmark_node *node, int depth = 0) {
+	if (depth > MAX_INLINE_DEPTH) {
+		throw InvalidInputException("Markdown inline nesting exceeds maximum supported depth (%d)", MAX_INLINE_DEPTH);
+	}
 	std::string result;
 	cmark_node *child = cmark_node_first_child(node);
 	while (child) {
@@ -614,7 +813,7 @@ static std::string GetInlineText(cmark_node *node) {
 			result += "\n";
 		} else {
 			// Recursively get text from nested nodes
-			result += GetInlineText(child);
+			result += GetInlineText(child, depth + 1);
 		}
 		child = cmark_node_next(child);
 	}
@@ -959,20 +1158,59 @@ std::vector<MarkdownLink> ExtractLinks(const std::string &markdown_str) {
 		return links;
 	}
 
-	// Pre-scan for reference link definitions to detect reference-style links
-	// Reference definitions look like: [id]: url "optional title"
-	// Pattern matches: [id]: followed by URL (optionally in angle brackets)
-	// Process line-by-line for MSVC compatibility (no std::regex::multiline)
+	// Pre-scan for reference link definitions to detect reference-style links.
+	// Reference definitions look like: [id]: url "optional title".
+	// Linear per-line parser replacing R"(^\s*\[([^\]]+)\]:\s+<?([^\s>]+)>?)"
+	// (a single unterminated "[" line could otherwise overflow the stack).
 	std::set<std::string> reference_urls;
-	std::regex ref_pattern(R"(^\s*\[([^\]]+)\]:\s+<?([^\s>]+)>?)");
 	std::istringstream stream(markdown_str);
 	std::string line;
 	while (std::getline(stream, line)) {
-		std::smatch match;
-		if (std::regex_search(line, match, ref_pattern)) {
-			std::string url = match[2].str();
-			reference_urls.insert(url);
+		std::string url;
+		size_t i = 0;
+		size_t n = line.size();
+		// ^\s*
+		while (i < n && std::isspace(static_cast<unsigned char>(line[i]))) {
+			i++;
 		}
+		if (i >= n || line[i] != '[') {
+			continue;
+		}
+		i++; // past '['
+		size_t label_start = i;
+		while (i < n && line[i] != ']') {
+			i++;
+		}
+		if (i >= n || i == label_start) { // no closing ']' or empty label
+			continue;
+		}
+		i++; // past ']'
+		if (i >= n || line[i] != ':') {
+			continue;
+		}
+		i++; // past ':'
+		// \s+
+		size_t ws_start = i;
+		while (i < n && std::isspace(static_cast<unsigned char>(line[i]))) {
+			i++;
+		}
+		if (i == ws_start) { // need at least one whitespace
+			continue;
+		}
+		// optional '<'
+		if (i < n && line[i] == '<') {
+			i++;
+		}
+		// ([^\s>]+)
+		size_t url_start = i;
+		while (i < n && !std::isspace(static_cast<unsigned char>(line[i])) && line[i] != '>') {
+			i++;
+		}
+		if (i == url_start) { // empty URL
+			continue;
+		}
+		url = line.substr(url_start, i - url_start);
+		reference_urls.insert(url);
 	}
 
 	// Parse with cmark-gfm
@@ -1093,33 +1331,55 @@ std::vector<MarkdownTable> ExtractTables(const std::string &markdown_str) {
 		return tables;
 	}
 
-	// For now, use a simpler regex-based approach for tables since the cmark-gfm table
-	// extension node types are not easily accessible. We can revisit this later.
+	// Locate GFM pipe-table blocks with a linear line scanner instead of a
+	// backtracking std::regex. A block is a maximal run of consecutive pipe
+	// table lines (see IsPipeTableLine); this replaces
+	// R"((?:^|\n)((?:\|[^\n]*\|[ \t]*\n?)+))" which could overflow the stack on
+	// a very long table line or many rows.
+	const std::string &s = markdown_str;
+	size_t n = s.size();
+	size_t i = 0;
 
-	// Parse tables using simple regex - this handles basic GFM tables
-	std::regex table_regex(R"((?:^|\n)((?:\|[^\n]*\|[ \t]*\n?)+))");
-	std::sregex_iterator iter(markdown_str.begin(), markdown_str.end(), table_regex);
-	std::sregex_iterator end;
+	while (i < n) {
+		// Current line spans [line_start, line_end); nl is the '\n' index or npos.
+		size_t line_start = i;
+		size_t nl = s.find('\n', i);
+		size_t line_end = (nl == std::string::npos) ? n : nl;
+		std::string line = s.substr(line_start, line_end - line_start);
 
-	for (; iter != end; ++iter) {
-		const std::smatch &match = *iter;
-		std::string table_content = match[1].str();
-
-		// Calculate line number
-		auto match_pos = match.position();
-		idx_t line_number = 1 + std::count(markdown_str.begin(), markdown_str.begin() + match_pos, '\n');
-
-		// Split into lines
-		std::istringstream table_stream(table_content);
-		std::string line;
-		std::vector<std::string> table_lines;
-
-		while (std::getline(table_stream, line)) {
-			StringUtil::Trim(line);
-			if (!line.empty()) {
-				table_lines.push_back(line);
-			}
+		if (!IsPipeTableLine(line)) {
+			i = (nl == std::string::npos) ? n : nl + 1;
+			continue;
 		}
+
+		// Faithful to the old regex's line_number: the match began at the '\n'
+		// preceding the block (or at offset 0), and newlines strictly before
+		// that position were counted.
+		idx_t line_number;
+		if (line_start == 0) {
+			line_number = 1;
+		} else {
+			line_number = 1 + static_cast<idx_t>(std::count(s.begin(), s.begin() + (line_start - 1), '\n'));
+		}
+
+		// Gather the maximal run of consecutive pipe-table lines.
+		std::vector<std::string> table_lines;
+		size_t j = i;
+		while (j < n) {
+			size_t ls = j;
+			size_t jnl = s.find('\n', j);
+			size_t le = (jnl == std::string::npos) ? n : jnl;
+			std::string l = s.substr(ls, le - ls);
+			if (!IsPipeTableLine(l)) {
+				break;
+			}
+			StringUtil::Trim(l);
+			if (!l.empty()) {
+				table_lines.push_back(l);
+			}
+			j = (jnl == std::string::npos) ? n : jnl + 1;
+		}
+		i = j; // continue scanning after the block
 
 		if (table_lines.size() < 2) {
 			continue; // Need at least header and separator
@@ -1130,10 +1390,7 @@ std::vector<MarkdownTable> ExtractTables(const std::string &markdown_str) {
 
 		// Find header row (first non-separator line)
 		size_t header_idx = 0;
-
-		// Skip separator lines (lines with only |, -, :, and whitespace)
-		std::regex separator_regex(R"(^\s*\|?\s*[-|:\s]+\s*\|?\s*$)");
-		while (header_idx < table_lines.size() && std::regex_match(table_lines[header_idx], separator_regex)) {
+		while (header_idx < table_lines.size() && IsSeparatorLine(table_lines[header_idx])) {
 			header_idx++;
 		}
 
@@ -1141,52 +1398,16 @@ std::vector<MarkdownTable> ExtractTables(const std::string &markdown_str) {
 			continue; // No valid header found
 		}
 
-		// Additional check: ensure this is the actual header row by checking if next line is separator
-		if (header_idx + 1 < table_lines.size() && !std::regex_match(table_lines[header_idx + 1], separator_regex)) {
-			// This might not be a proper markdown table format, but let's try anyway
-		}
-
 		// Parse header row
-		std::string header_line = table_lines[header_idx];
-		// DEBUG: Output table parsing info to stderr (will show in build log)
-		// fprintf(stderr, "DEBUG: Header idx=%zu, line='%s'\n", header_idx, header_line.c_str());
-		if (header_line.front() == '|')
-			header_line = header_line.substr(1);
-		if (header_line.back() == '|')
-			header_line = header_line.substr(0, header_line.length() - 1);
-
-		std::regex cell_regex(R"([^|]+)");
-		std::sregex_iterator cell_iter(header_line.begin(), header_line.end(), cell_regex);
-		std::sregex_iterator cell_end;
-
-		for (; cell_iter != cell_end; ++cell_iter) {
-			std::string cell = (*cell_iter).str();
-			StringUtil::Trim(cell);
-			table.headers.push_back(cell);
-		}
-
+		table.headers = SplitTableCells(table_lines[header_idx]);
 		table.num_columns = table.headers.size();
 
 		// Find data rows (skip separator lines)
-		for (size_t i = header_idx + 1; i < table_lines.size(); i++) {
-			// Skip separator lines
-			if (std::regex_match(table_lines[i], separator_regex)) {
+		for (size_t k = header_idx + 1; k < table_lines.size(); k++) {
+			if (IsSeparatorLine(table_lines[k])) {
 				continue;
 			}
-			std::string data_line = table_lines[i];
-			if (data_line.front() == '|')
-				data_line = data_line.substr(1);
-			if (data_line.back() == '|')
-				data_line = data_line.substr(0, data_line.length() - 1);
-
-			std::vector<std::string> row_data;
-			std::sregex_iterator data_cell_iter(data_line.begin(), data_line.end(), cell_regex);
-
-			for (; data_cell_iter != cell_end; ++data_cell_iter) {
-				std::string cell = (*data_cell_iter).str();
-				StringUtil::Trim(cell);
-				row_data.push_back(cell);
-			}
+			std::vector<std::string> row_data = SplitTableCells(table_lines[k]);
 
 			// Pad row to match header column count
 			while (row_data.size() < table.num_columns) {

--- a/test/sql/markdown_security_regression.test
+++ b/test/sql/markdown_security_regression.test
@@ -1,0 +1,139 @@
+# name: test/sql/markdown_security_regression.test
+# description: Regression tests for the linear-scanning extractors (GHSA-qv83-qqvf-72v9).
+#              The previous hand-rolled std::regex extractors recursed while
+#              matching greedy quantifiers over untrusted input; an unclosed
+#              frontmatter block, a many-cell table, or a long unterminated "["
+#              could overflow the stack and SIGSEGV the whole DuckDB process.
+#              A stack overflow is not a catchable C++ exception, so these
+#              inputs took down the base binary (verified out-of-process). The
+#              cases below all use BOUNDED inputs that tripped the old regexes
+#              and must now resolve cleanly in O(n).
+# group: [sql]
+
+require markdown
+
+#===================================================================
+# Frontmatter scanner: unclosed block (~128 KB body, no closing ---)
+# Reaches ExtractMetadata / StripFrontmatter / ExtractRawFrontmatter.
+#===================================================================
+
+# md_extract_metadata: unclosed frontmatter -> empty map, no crash
+query I
+SELECT cardinality(md_extract_metadata('---' || chr(10) || repeat('a', 131072)));
+----
+0
+
+# md_extract_sections routes through StripFrontmatter -> clean (no headings)
+query I
+SELECT count(*) FROM (SELECT unnest(md_extract_sections('---' || chr(10) || repeat('a', 131072))) AS s);
+----
+0
+
+#===================================================================
+# Table scanner: many-cell / many-row tables (~30 K cells)
+# Reaches ExtractTables via md_extract_tables_json / md_extract_table_rows.
+#===================================================================
+
+# One very long table line (~60 KB): tripped the \|[^\n]*\| backtracking.
+# A single line is not a full table (no separator) -> 0 tables, no crash.
+query I
+SELECT len(md_extract_tables_json(repeat('|x', 30000) || '|'));
+----
+0
+
+# Many table rows: tripped the (...)+ grouping. Resolves to one table.
+query I
+SELECT len(md_extract_tables_json(repeat('|x|' || chr(10), 30000)));
+----
+1
+
+# Same input via md_extract_table_rows -> all rows emitted, no crash.
+query I
+SELECT len(md_extract_table_rows(repeat('|x|' || chr(10), 30000)));
+----
+30000
+
+#===================================================================
+# md_stats scanners: link / heading regex over long input
+#===================================================================
+
+# Long unterminated "[" tripped \[([^\]]+)\] ... -> 0 links, no crash
+query I
+SELECT (md_stats(repeat('a', 5) || '[' || repeat('b', 300000))).link_count;
+----
+0
+
+# Long run after a "#" tripped ^#{1,6}\s+ -> heading_count preserved (1)
+query I
+SELECT (md_stats('#' || repeat(' ', 300000))).heading_count;
+----
+1
+
+#===================================================================
+# md_extract_links reference-definition scanner
+#===================================================================
+
+# Long unterminated "[" line tripped the per-line ref_pattern -> 0 links
+query I
+SELECT len(md_extract_links('[' || repeat('b', 300000)));
+----
+0
+
+#===================================================================
+# Positive: normal inputs still parse to the same results (no regression)
+#===================================================================
+
+# Normal frontmatter parses to a MAP with the expected fields
+query TT
+SELECT md_extract_metadata(E'---\ntitle: My Title\nauthor: John Doe\n---\nContent')['title'],
+       md_extract_metadata(E'---\ntitle: My Title\nauthor: John Doe\n---\nContent')['author'];
+----
+My Title	John Doe
+
+# CRLF frontmatter still recognized
+query I
+SELECT cardinality(md_extract_metadata(E'---\ntitle: T\r\nauthor: A\r\n---\r\nBody'));
+----
+2
+
+# Quoted values still unquoted; empty value handled (no crash on value.front())
+query TT
+SELECT md_extract_metadata(E'---\nq: "quoted"\nempty:\n---\nx')['q'],
+       md_extract_metadata(E'---\nq: "quoted"\nempty:\n---\nx')['empty'];
+----
+quoted	(empty)
+
+# Normal GFM table still parses (header + separator + one data row = 4 rows)
+query I
+SELECT len(md_extract_table_rows(E'| Name | Age |\n|------|-----|\n| John | 25  |'));
+----
+4
+
+# Table with alignment separators and an empty cell still parses correctly
+query I
+SELECT t.num_rows FROM (
+  SELECT unnest(md_extract_tables_json(E'| A | B | C |\n|---|:-:|--:|\n| 1 |  | 3 |\n| x | y | z |')) AS t
+) LIMIT 1;
+----
+2
+
+# md_stats on a normal doc keeps its (documented) counts
+query III
+SELECT (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```')).heading_count,
+       (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```')).link_count,
+       (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```')).code_block_count;
+----
+1	2	1
+
+# Reference-style and direct links both resolved
+query I
+SELECT len(md_extract_links('[ref]: http://ex.com' || chr(10) || 'see [x][ref] and [y](http://direct.com)'));
+----
+2
+
+# A legitimately deep (but legal) nested-emphasis document still renders,
+# exercising the inline walkers below their depth cap.
+query T
+SELECT md_to_text('# ' || repeat('*', 20) || 'deep' || repeat('*', 20)) <> '';
+----
+true


### PR DESCRIPTION
## Summary

Hardens the hand-rolled extractors in `src/markdown_utils.cpp` by replacing their
`std::regex` patterns with linear, bounded-stack scanners, so parsing untrusted or
large Markdown runs in guaranteed O(n) time with predictable stack usage. Behaviour
is preserved.

References `GHSA-qv83-qqvf-72v9` (private); advisory to be published at release.

## What changed

Each extractor that previously used `std::regex` over document text is now an O(n)
scanner. Observable behaviour is unchanged — verified by diffing a base build
against this build across normal inputs (identical outputs, including CRLF
frontmatter, table alignment rows, empty cells, reference links, and `line_number`
values):

- **Frontmatter** (`ExtractMetadata` / `ExtractRawFrontmatter` / `StripFrontmatter`)
  → `FindFrontmatter`, an opening/closing-delimiter scan. Also guards
  `ExtractMetadata` against reading `value.front()` on an empty value.
- **GFM pipe tables** (`ExtractTables`) → a line scanner
  (`IsPipeTableLine` / `IsSeparatorLine` / `SplitTableCells`), faithful to the old
  grouping/separator/cell patterns including CRLF handling.
- **`md_stats` counts** (`CalculateStats`) → linear heading / code-fence / link
  counting, numerically identical to the prior patterns (including the prior
  non-multiline heading anchor; count fidelity itself is tracked separately in #21).
- **`md_extract_links`** reference-definition pre-scan → a linear per-line parser.
- **`GenerateSectionId`** three `regex_replace` passes → one linear pass.

Defence in depth (hardening, lower confidence):

- NULL-guard cmark render output in `MarkdownToHTML` / `MarkdownToText` (the other
  cmark consumers already used ternary guards).
- Depth caps on the recursive inline walkers `GetInlineText` / `ExtractPandocText`
  → a clean `InvalidInputException` past the cap.

No `std::regex` remains in `markdown_utils.cpp`.

## Tests

`test/sql/markdown_security_regression.test` adds bounded regression cases that
exercise both the frontmatter and table scanners (plus the `md_stats` and
reference-link scanners) and pin the unchanged behaviour on normal inputs. Full
suite: **1185 assertions across 23 test cases pass**.

## Not addressed here

- The `#21` correctness items (frontmatter is line-split not real YAML, two
  different table parsers, table-cell JSON under-escaping, `md_stats` count
  fidelity) are intentionally out of scope for this change.
- The depth caps (1000) are generous belt-and-suspenders; cmark's own parser
  already bounds nesting in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n
