### PR TITLE
fix(md_stats): count every heading line, not just a leading one (#17)

### DIFF
--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -358,18 +358,37 @@ MarkdownStats CalculateStats(const std::string &markdown_str) {
 	stats.char_count = markdown_str.length();
 	stats.line_count = static_cast<idx_t>(std::count(markdown_str.begin(), markdown_str.end(), '\n')) + 1;
 
-	// Count headings. Faithful to the previous std::regex R"(^#{1,6}\s+)"
-	// which (default, non-multiline) only anchors at the START of the string,
-	// so this is 0 or 1: 1 iff the document opens with 1-6 '#' then whitespace.
+	// Count headings (#17: this previously returned 0 unless the document *opened* with a
+	// heading — a single-pass `^#{1,6}` only anchors at string start). Scan line-by-line,
+	// skipping fenced code blocks. Regex-free, matching this file's linear-scanning
+	// convention (#22, ReDoS hardening).
 	stats.heading_count = 0;
 	{
-		size_t h = 0;
-		while (h < markdown_str.size() && markdown_str[h] == '#') {
-			h++;
-		}
-		if (h >= 1 && h <= 6 && h < markdown_str.size() &&
-		    std::isspace(static_cast<unsigned char>(markdown_str[h]))) {
-			stats.heading_count = 1;
+		std::istringstream heading_stream(markdown_str);
+		std::string heading_line;
+		bool in_fence = false;
+		while (std::getline(heading_stream, heading_line)) {
+			// Fence toggle: optional leading whitespace then ``` or ~~~.
+			size_t p = 0;
+			while (p < heading_line.size() && (heading_line[p] == ' ' || heading_line[p] == '\t')) {
+				p++;
+			}
+			if (heading_line.compare(p, 3, "```") == 0 || heading_line.compare(p, 3, "~~~") == 0) {
+				in_fence = !in_fence;
+				continue;
+			}
+			if (in_fence) {
+				continue;
+			}
+			// Heading line: 1-6 '#' at column 0 then a space or tab.
+			size_t h = 0;
+			while (h < heading_line.size() && heading_line[h] == '#') {
+				h++;
+			}
+			if (h >= 1 && h <= 6 && h < heading_line.size() &&
+			    (heading_line[h] == ' ' || heading_line[h] == '\t')) {
+				stats.heading_count++;
+			}
 		}
 	}
 

--- a/test/sql/markdown_security_regression.test
+++ b/test/sql/markdown_security_regression.test
@@ -117,13 +117,14 @@ SELECT t.num_rows FROM (
 ----
 2
 
-# md_stats on a normal doc keeps its (documented) counts
+# md_stats on a normal doc: heading_count now counts every heading line (#17), not just a
+# leading one. This doc has two headings (# H1, ## H2); the fenced ``` lines are not headings.
 query III
 SELECT (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```')).heading_count,
        (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```')).link_count,
        (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```')).code_block_count;
 ----
-1	2	1
+2	2	1
 
 # Reference-style and direct links both resolved
 query I

--- a/test/sql/md_stats_heading_count.test
+++ b/test/sql/md_stats_heading_count.test
@@ -1,0 +1,48 @@
+# name: test/sql/md_stats_heading_count.test
+# description: md_stats().heading_count counts every ATX heading line (issue #17)
+# group: [markdown]
+
+require markdown
+
+# Core bug (#17): headings that do NOT open the document were previously missed
+# (a single-pass ^#{1,6} only anchors at string start), so this returned 0.
+query I
+SELECT (md_stats(E'Intro paragraph.\n\n# First heading\n\nBody.')).heading_count;
+----
+1
+
+# Every heading line is counted, at any level (h1..h6)
+query I
+SELECT (md_stats(E'# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6')).heading_count;
+----
+6
+
+# Headings inside a fenced code block are NOT counted
+query I
+SELECT (md_stats(E'# Real\n```\n# not a heading\n## also not\n```\n## Real2')).heading_count;
+----
+2
+
+# ~~~ fences are honored too
+query I
+SELECT (md_stats(E'# Real\n~~~\n# fenced\n~~~\n# Real2')).heading_count;
+----
+2
+
+# A run of '#' with no following space/tab is not a heading; >6 '#' is not a heading
+query I
+SELECT (md_stats(E'#nospace\n####### too many\n# yes')).heading_count;
+----
+1
+
+# No headings -> 0
+query I
+SELECT (md_stats(E'just some text\nwith no headings')).heading_count;
+----
+0
+
+# Tab after the '#' run also delimits a heading
+query I
+SELECT (md_stats(E'#\ttab heading')).heading_count;
+----
+1


### PR DESCRIPTION
## What

`md_stats().heading_count` used a single-pass `^#{1,6}` which — with `std::regex`'s default (non-multiline) `^` — only anchors at the **start of the string**. So it returned **0** for any document that didn't *open* with a heading, and never counted more than one.

This replaces it with a regex-free, line-by-line scan that:
- counts each ATX heading line (1–6 `#` then space/tab at column 0),
- skips fenced code blocks (` ``` ` / `~~~`),
- stays regex-free to match this file's linear-scanning convention (#22, ReDoS hardening) rather than re-introducing `std::regex` on untrusted input.

## Tests

- New `test/sql/md_stats_heading_count.test`: non-leading headings (the core bug), h1–h6, fenced-code exclusion, `~~~` fences, `#`-runs without a following space, tab delimiter, zero-heading docs.
- `markdown_security_regression.test`: the two-heading sample doc's documented `heading_count` moves **1 → 2** (the old value reflected the bug; the fenced `code` line is correctly *not* counted).
- Full local suite green: 1192 assertions, 24 cases, no regressions (built against DuckDB v1.5.3-496 / variegata).

## Scope

This lands **only** the `heading_count` portion of #17. The wikilink/tag extraction proposed in #18 is deferred to a follow-up that will use **linear scanning** instead of `std::regex` — #18's extractors reintroduce `std::regex` over untrusted input, which #22 (+ a security advisory) deliberately removed, and don't compile against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)