### PR TITLE
test(wasm): WASM load/symbol check (#19) + clarify frontmatter docs (#21)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -41,3 +41,40 @@ jobs:
       ci_tools_version: main
       extension_name: markdown
       format_checks: 'format'
+
+  # Guards against the LINKED_LIBS class of WASM bug (issue #19): the reusable
+  # distribution workflow builds and uploads the .wasm but never inspects or
+  # loads it, so a side module with unresolved cmark-gfm symbols ships green.
+  # Two layers (see test/wasm/):
+  #   1. static symbol check (hard gate) — no duckdb-wasm runtime needed.
+  #   2. live load+query in duckdb-wasm (informational / continue-on-error) —
+  #      expected-red until an official duckdb-wasm ships a matching v1.5.4
+  #      build (a version/emscripten skew surfaces as an ABI mismatch on LOAD).
+  wasm-load-test:
+    name: WASM load test
+    needs: [duckdb-stable-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: markdown-v1.5.4-extension-wasm_*
+          path: wasm-artifacts
+      - name: Static symbol check (cmark-gfm must be linked, not unresolved)
+        run: bash test/wasm/run_wasm_checks.sh wasm-artifacts
+      - name: Live load test in duckdb-wasm (informational until engine matches)
+        continue-on-error: true
+        timeout-minutes: 10
+        working-directory: test/wasm
+        run: |
+          set -uo pipefail
+          timeout 300 npm install --no-save
+          mkdir -p repo/v1.5.4/wasm_eh
+          cp "$GITHUB_WORKSPACE/wasm-artifacts/markdown-v1.5.4-extension-wasm_eh/markdown.duckdb_extension.wasm" \
+             repo/v1.5.4/wasm_eh/
+          timeout 240 node load_test.cjs --repo repo --name markdown --platform eh \
+            --query "SELECT md_to_html('# H') AS h" --expect "<h1>"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Reads Markdown files and returns one row per file.
 - `include_filepath := false` - Include file_path column in output (alias: `filename`)
 - `content_as_varchar := false` - Return content as VARCHAR instead of MARKDOWN type
 - `maximum_file_size := 16777216` - Maximum file size in bytes (16MB default)
-- `extract_metadata := true` - Extract frontmatter metadata
+- `extract_metadata := true` - Extract frontmatter into the `metadata` column. This uses the same **line-split key/value** reader as [`md_extract_metadata`](#content-extraction-functions) — each line split on the first `:`, typed as `MAP(VARCHAR, VARCHAR)` — **not** a full YAML parser (nested maps, lists, and multiline `|`/`>` scalars are not interpreted). For full YAML fidelity, read the raw block with `md_extract_frontmatter` and parse it with [`duckdb_yaml`](https://github.com/teaguesterling/duckdb_yaml).
 - `normalize_content := true` - Normalize Markdown content
 
 **Returns:** `(content MARKDOWN, metadata MAP(VARCHAR, VARCHAR))` or `(file_path VARCHAR, content MARKDOWN, metadata MAP(VARCHAR, VARCHAR))` with `include_filepath := true`

--- a/test/wasm/README.md
+++ b/test/wasm/README.md
@@ -1,0 +1,45 @@
+# WASM tests
+
+Two layers guard the WASM build of the markdown extension against the
+`LINKED_LIBS` class of bug (issue #19), where the loadable
+`.duckdb_extension.wasm` is produced by a separate
+`emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` link. That link only pulls in
+libraries named in `LINKED_LIBS` in `extension_config.cmake` — `cmark-gfm`
+must be listed there or its symbols end up imported by the module but defined
+nowhere, and the module fails to load ("could not load dynamic lib") or throws
+on first call. CI builds the `.wasm` but never inspects it, so a broken module
+otherwise ships green.
+
+## 1. Static import check (hard gate) — `run_wasm_checks.sh`
+
+Statically inspects the side module's imports for unresolved **cmark-gfm**
+dependency symbols (`cmark_*`). No duckdb-wasm runtime and no matching duckdb
+version needed, so a failure is unambiguously the `LINKED_LIBS` bug — not an
+ABI/version mismatch. This is the deterministic gate.
+
+```bash
+make wasm_mvp          # or wasm_eh / wasm_threads
+test/wasm/run_wasm_checks.sh
+# or point it at explicit build dirs:
+test/wasm/run_wasm_checks.sh build/wasm_eh
+```
+
+`check_wasm_imports.mjs` is the generic engine (shared, byte-for-byte, with the
+other extensions); `run_wasm_checks.sh` supplies the markdown-specific
+`--forbid cmark` pattern. See the header comment in `check_wasm_imports.mjs`
+for why "is it imported?" is the wrong question and how self-resolution
+(interposition) is handled.
+
+## 2. Live load test (informational) — `load_test.cjs`
+
+Actually `LOAD`s the built `.wasm` into a version-matched duckdb-wasm engine and
+runs a cmark-gfm-backed query (`md_to_html`). End-to-end counterpart to the
+static gate. Expected-red until an official duckdb-wasm ships a matching
+v1.5.4 build (an engine/extension version skew surfaces as an ABI mismatch on
+`LOAD`), so CI runs it `continue-on-error`.
+
+```bash
+cd test/wasm && npm install --no-save
+node load_test.cjs --repo <repo-dir> --name markdown --platform eh \
+  --query "SELECT md_to_html('# H') AS h" --expect "<h1>"
+```

--- a/test/wasm/check_wasm_imports.mjs
+++ b/test/wasm/check_wasm_imports.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// WASM side-module unresolved-dependency-symbol check.
+//
+// Why this exists: the loadable `.duckdb_extension.wasm` is produced by a
+// separate `emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` step (see duckdb's
+// extension/extension_build_tools.cmake). That link ONLY pulls in libraries
+// named in `LINKED_LIBS` in extension_config.cmake -- `target_link_libraries`
+// in CMakeLists.txt is ignored for it. If a dependency (yaml-cpp here, LibXml2
+// for webbed) is not in LINKED_LIBS, its symbols end up imported by the module
+// but defined nowhere; since the duckdb-wasm host does not provide them the
+// module fails to load ("could not load dynamic lib") or throws at first call.
+// CI builds the .wasm but never inspects it, so this ships green.
+//
+// What it checks -- and why "is it imported" is the WRONG question:
+// emscripten side modules use position-independent / interposition linking, so
+// a module legitimately IMPORTS many symbols it also DEFINES/EXPORTS, and also
+// imports host-provided symbols (duckdb's C++ runtime; core deps bundled into
+// the duckdb-wasm host such as yyjson). The genuine bug is a dependency symbol
+// that is imported, NOT defined by this module, and not host-provided -- i.e.
+// genuinely unresolved.
+//
+// Imports come in three relevant buckets and must be resolved against the
+// right export kind (functions vs data globals):
+//   - module "env",      kind function  -> direct call          -> exported fn
+//   - module "GOT.func", kind global    -> function address slot -> exported fn
+//   - module "GOT.mem",  kind global    -> data address slot     -> exported global
+// A GOT.mem entry is how data symbols (vtables _ZTV*, typeinfo _ZTI*) are
+// referenced, so checking only function imports would miss an unresolved
+// vtable that breaks loading just like a missing function.
+//
+// Static parse only (WebAssembly.Module) -- no instantiation, no duckdb-wasm
+// runtime, no duckdb version match -- so a failure is unambiguously the
+// LINKED_LIBS bug and not an ABI/version mismatch.
+//
+// Usage:
+//   node check_wasm_imports.mjs <path-to.wasm> --forbid <regex> [--forbid <regex> ...] [--verbose]
+//
+// Exit: 0 = clean, 1 = unresolved dependency symbols found, 2 = usage/file error.
+
+import { readFileSync } from "node:fs";
+
+const argv = process.argv.slice(2);
+const forbid = [];
+let wasmPath = null;
+let verbose = false;
+
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--forbid") forbid.push(new RegExp(argv[++i]));
+  else if (a === "--verbose" || a === "-v") verbose = true;
+  else if (!wasmPath) wasmPath = a;
+  else { console.error(`unexpected argument: ${a}`); process.exit(2); }
+}
+
+if (!wasmPath || forbid.length === 0) {
+  console.error("usage: node check_wasm_imports.mjs <path-to.wasm> --forbid <regex> [--forbid <regex> ...] [--verbose]");
+  process.exit(2);
+}
+
+let bytes;
+try { bytes = readFileSync(wasmPath); }
+catch (e) { console.error(`cannot read ${wasmPath}: ${e.message}`); process.exit(2); }
+
+let mod;
+try { mod = new WebAssembly.Module(bytes); }
+catch (e) { console.error(`not a valid wasm module: ${e.message}`); process.exit(2); }
+
+const matches = (name) => forbid.some((re) => re.test(name));
+
+const imports = WebAssembly.Module.imports(mod);
+const exports = WebAssembly.Module.exports(mod);
+const expFn = new Set(exports.filter((e) => e.kind === "function").map((e) => e.name));
+const expGl = new Set(exports.filter((e) => e.kind === "global").map((e) => e.name));
+
+// Does this module itself satisfy the import? (interposition self-resolution)
+function selfResolved(imp) {
+  if (imp.kind === "function") return expFn.has(imp.name);     // env.<fn>
+  if (imp.module === "GOT.func") return expFn.has(imp.name);   // function address
+  if (imp.module === "GOT.mem") return expGl.has(imp.name) || expFn.has(imp.name); // data address
+  if (imp.kind === "global") return expGl.has(imp.name);       // env global / data
+  return false; // tables/memories etc. are host-provided runtime, never dep symbols
+}
+
+const depImports = imports.filter((i) => matches(i.name));
+const unresolved = depImports.filter((i) => !selfResolved(i));
+
+if (verbose) {
+  const byBucket = {};
+  for (const u of unresolved) byBucket[u.module] = (byBucket[u.module] || 0) + 1;
+  console.error(`[check] ${wasmPath}`);
+  console.error(`  imports: ${imports.length} | exports: ${expFn.size} fn, ${expGl.size} global`);
+  console.error(`  dependency-matching imports: ${depImports.length} | unresolved: ${unresolved.length} ${JSON.stringify(byBucket)}`);
+}
+
+if (unresolved.length > 0) {
+  console.error(`FAIL: ${unresolved.length} unresolved dependency symbol(s) in ${wasmPath} (imported, not defined by the module, not host-provided). The dependency is missing from LINKED_LIBS:`);
+  for (const o of unresolved.slice(0, 40)) console.error(`  ${o.module}.${o.name}`);
+  if (unresolved.length > 40) console.error(`  ... and ${unresolved.length - 40} more`);
+  process.exit(1);
+}
+
+console.error(`PASS: ${wasmPath} -- ${depImports.length} dependency import(s) all resolved by the module, 0 unresolved (${imports.length} imports inspected).`);
+process.exit(0);

--- a/test/wasm/load_test.cjs
+++ b/test/wasm/load_test.cjs
@@ -1,0 +1,69 @@
+// duckdb-wasm load test: actually LOAD a locally-built extension .wasm into a
+// version-matched duckdb-wasm engine and run a query. End-to-end counterpart to
+// the static check_wasm_imports.mjs gate. Uses the ASYNC API (the blocking API
+// deadlocks on LOAD, which needs async wasm instantiation).
+//
+// Usage:
+//   node load_test.cjs --repo <repository-dir> --name <ext> --query <sql>
+//       [--expect <substr>] [--platform eh|mvp] [--engine <npm-pkg>]
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const Worker = require("web-worker");
+
+function arg(name, def) { const i = process.argv.indexOf(`--${name}`); return i >= 0 ? process.argv[i + 1] : def; }
+
+const repoDir = arg("repo"), name = arg("name"), platform = arg("platform", "eh");
+const enginePkg = arg("engine", "@haybarn/haybarn-wasm"), query = arg("query"), expect = arg("expect");
+
+if (!repoDir || !name || !query) {
+  console.error("usage: node load_test.cjs --repo <dir> --name <ext> --query <sql> [--expect s] [--platform eh|mvp] [--engine pkg]");
+  process.exit(2);
+}
+
+const duckdb = require(`${enginePkg}/dist/duckdb-node`);
+const dist = path.dirname(require.resolve(`${enginePkg}/dist/duckdb-node.cjs`));
+const BUNDLES = {
+  mvp: { mainModule: path.join(dist, "duckdb-mvp.wasm"), mainWorker: path.join(dist, "duckdb-node-mvp.worker.cjs") },
+  eh: { mainModule: path.join(dist, "duckdb-eh.wasm"), mainWorker: path.join(dist, "duckdb-node-eh.worker.cjs") },
+};
+
+const server = http.createServer((req, res) => {
+  const fp = path.join(repoDir, decodeURIComponent(req.url.split("?")[0]));
+  if (!fp.startsWith(path.resolve(repoDir))) { res.writeHead(403); return res.end(); }
+  fs.readFile(fp, (err, buf) => {
+    if (err) { res.writeHead(404); return res.end(String(err)); }
+    res.writeHead(200, { "Content-Type": "application/wasm" }); res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const repoUrl = `http://127.0.0.1:${server.address().port}`;
+  console.error(`[load_test] serving ${repoDir} at ${repoUrl}; engine=${enginePkg} platform=${platform}`);
+
+  const bundle = BUNDLES[platform];
+  const worker = new Worker(bundle.mainWorker);
+  const db = new duckdb.AsyncDuckDB(new duckdb.VoidLogger(), worker);
+  await db.instantiate(bundle.mainModule);
+  await db.open({ allowUnsignedExtensions: true });
+  const conn = await db.connect();
+
+  const ver = (await conn.query("SELECT version() AS v")).toArray()[0].v;
+  console.error(`[load_test] engine duckdb version: ${ver}`);
+  await conn.query(`SET custom_extension_repository='${repoUrl}'`);
+  console.error(`[load_test] INSTALL ${name}`); await conn.query(`INSTALL ${name}`);
+  console.error(`[load_test] LOAD ${name}`); await conn.query(`LOAD ${name}`);
+  console.error(`[load_test] query: ${query}`);
+  const rows = (await conn.query(query)).toArray();
+  const out = JSON.stringify(rows.map((r) => Object.fromEntries(Object.entries(r))));
+  console.error(`[load_test] result: ${out}`);
+
+  await conn.close(); await db.terminate(); await worker.terminate(); server.close();
+
+  if (expect !== undefined && !out.includes(expect)) {
+    console.error(`FAIL: expected substring '${expect}' not in result ${out}`); process.exit(1);
+  }
+  console.log(`PASS: ${name} loaded into duckdb-wasm ${ver} (${platform}) and query returned ${out}`);
+  process.exit(0);
+})().catch((e) => { console.error("FAIL:", e && e.message ? e.message : e); try { server.close(); } catch {} process.exit(1); });

--- a/test/wasm/package.json
+++ b/test/wasm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "markdown-wasm-tests",
+  "private": true,
+  "description": "Dependencies for the duckdb-wasm live load test (load_test.cjs). The static check (check_wasm_imports.mjs / run_wasm_checks.sh) needs no dependencies.",
+  "dependencies": {
+    "@haybarn/haybarn-wasm": "1.5.3-rc15",
+    "web-worker": "1.2.0"
+  }
+}

--- a/test/wasm/run_wasm_checks.sh
+++ b/test/wasm/run_wasm_checks.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Run the WASM dependency-symbol check against built .wasm artifacts.
+#
+# This is the fast, deterministic gate for the LINKED_LIBS class of bug
+# (issue #19; see check_wasm_imports.mjs for the full explanation). It does NOT
+# need a duckdb-wasm runtime or a matching duckdb version — it statically
+# inspects the side module's imports. Run it after `make wasm_mvp` / `wasm_eh`.
+#
+# Usage: test/wasm/run_wasm_checks.sh [build-dir ...]
+#   defaults to build/wasm_mvp build/wasm_eh build/wasm_threads if present.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+
+# Dependency symbols that MUST be resolved internally (not left as imports).
+# markdown's native dependency is cmark-gfm (C library); all of its symbols are
+# prefixed `cmark_` (e.g. cmark_parser_new, cmark_markdown_to_html,
+# cmark_gfm_core_extensions_ensure_registered). If cmark-gfm is missing from
+# LINKED_LIBS these become unresolved imports and the .wasm fails to load.
+FORBID=( --forbid 'cmark' )
+
+dirs=("$@")
+if [ ${#dirs[@]} -eq 0 ]; then
+  for d in build/wasm_mvp build/wasm_eh build/wasm_threads; do
+    [ -d "$repo_root/$d" ] && dirs+=("$repo_root/$d")
+  done
+fi
+
+if [ ${#dirs[@]} -eq 0 ]; then
+  echo "no wasm build dirs found; build first (e.g. make wasm_mvp)" >&2
+  exit 2
+fi
+
+found_any=0
+rc=0
+for d in "${dirs[@]}"; do
+  while IFS= read -r -d '' wasm; do
+    found_any=1
+    echo "==> checking $wasm"
+    node "$here/check_wasm_imports.mjs" "$wasm" "${FORBID[@]}" || rc=1
+  done < <(find "$d" -name '*.duckdb_extension.wasm' -print0 2>/dev/null)
+done
+
+if [ "$found_any" -eq 0 ]; then
+  echo "no *.duckdb_extension.wasm found under: ${dirs[*]}" >&2
+  exit 2
+fi
+exit $rc


### PR DESCRIPTION
Two items from the #21 review, plus a real WASM gate for #19.

## WASM load/symbol check (#19)
The loadable `.duckdb_extension.wasm` is linked by a separate `emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` step that **only** pulls in libs named in `extension_config.cmake`'s `LINKED_LIBS`. CI built the `.wasm` but never inspected it, so a module with unresolved **cmark-gfm** symbols could ship green (the exact #19 failure mode). Adds `test/wasm/` + a `wasm-load-test` CI job:

1. **Static import check** (hard gate) — statically inspects the side module for unresolved `cmark_*` imports. No duckdb-wasm runtime / version match needed, so a failure is unambiguously the `LINKED_LIBS` bug, not an ABI/version skew.
2. **Live LOAD + `md_to_html` query** in duckdb-wasm (informational / `continue-on-error` until an official duckdb-wasm ships a matching v1.5.4 build).

`check_wasm_imports.mjs` / `load_test.cjs` are the **same generic harness** already used by [duckdb_yaml](https://github.com/teaguesterling/duckdb_yaml/tree/main/test/wasm); only the forbid pattern (`cmark`) and the query differ. Scripts validated locally (syntax + usage); the real artifact is exercised in CI.

## Frontmatter docs (#21)
The review flagged that `md_extract_metadata` is described as "YAML frontmatter" but is actually a **line-split key/value** reader (each line split on the first `:`), not a YAML parser — nested maps/lists/multiline scalars are silently mis-parsed. The `md_extract_metadata` entry already carried that caveat; this makes the `read_markdown` `extract_metadata` param consistent — it now states the line-split behavior and points to `md_extract_frontmatter` + `duckdb_yaml` for full YAML fidelity.

No C++ changes (workflow + docs + test harness only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)