### PR TITLE
fix: emit structured inline duck_blocks (read_markdown_blocks + parse_markdown_to_duck_blocks)

### DIFF
--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1,5 +1,6 @@
 #include "duck_block_functions.hpp"
 #include "markdown_types.hpp"
+#include "markdown_utils.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/exception.hpp"
@@ -1166,10 +1167,59 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 // Register All Functions
 //===--------------------------------------------------------------------===//
 
+// Build a duck_block STRUCT Value from a parsed MarkdownBlock. Empty content
+// becomes NULL (the spec's convention for containers with structured children).
+static Value MakeDuckBlockValue(const markdown_utils::MarkdownBlock &b) {
+	child_list_t<Value> fields;
+	fields.emplace_back("kind", Value(b.kind));
+	fields.emplace_back("element_type", Value(b.block_type));
+	fields.emplace_back("content", b.content.empty() ? Value(LogicalType::VARCHAR) : Value(b.content));
+	fields.emplace_back("level", b.level >= 0 ? Value::INTEGER(b.level) : Value(LogicalType::INTEGER));
+	fields.emplace_back("encoding", Value(b.encoding));
+	vector<Value> keys, vals;
+	for (const auto &a : b.attributes) {
+		keys.push_back(Value(a.first));
+		vals.push_back(Value(a.second));
+	}
+	fields.emplace_back("attributes", Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, keys, vals));
+	fields.emplace_back("element_order", Value::INTEGER(b.block_order));
+	return Value::STRUCT(fields);
+}
+
+// parse_markdown_to_duck_blocks(md VARCHAR) -> LIST(duck_block)
+// Scalar counterpart of read_markdown_blocks that emits the canonical structured
+// representation: rich text as kind='inline' children, not markdown-in-content.
+static void RegisterParseMarkdownToDuckBlocks(ExtensionLoader &loader) {
+	auto duck_block_type = MarkdownTypes::DuckBlockType();
+	auto duck_block_list_type = LogicalType::LIST(duck_block_type);
+
+	ScalarFunction fn("parse_markdown_to_duck_blocks", {LogicalType::VARCHAR}, duck_block_list_type,
+	                  [](DataChunk &args, ExpressionState &state, Vector &result) {
+		                  auto &in = args.data[0];
+		                  auto dtype = MarkdownTypes::DuckBlockType();
+		                  for (idx_t i = 0; i < args.size(); i++) {
+			                  auto v = in.GetValue(i);
+			                  if (v.IsNull()) {
+				                  result.SetValue(i, Value());
+				                  continue;
+			                  }
+			                  auto blocks = markdown_utils::ParseBlocks(v.ToString(), /*structured_inlines=*/true);
+			                  vector<Value> vals;
+			                  vals.reserve(blocks.size());
+			                  for (const auto &b : blocks) {
+				                  vals.push_back(MakeDuckBlockValue(b));
+			                  }
+			                  result.SetValue(i, Value::LIST(dtype, vals));
+		                  }
+	                  });
+	loader.RegisterFunction(fn);
+}
+
 void DuckBlockFunctions::Register(ExtensionLoader &loader) {
 	RegisterDuckBlockToMdFunction(loader);
 	RegisterDuckBlocksToMdFunction(loader);
 	RegisterDuckBlocksToSectionsFunction(loader);
+	RegisterParseMarkdownToDuckBlocks(loader);
 }
 
 } // namespace duckdb

--- a/src/include/markdown_utils.hpp
+++ b/src/include/markdown_utils.hpp
@@ -107,16 +107,21 @@ std::string ExtractSection(const std::string &markdown_str, const std::string &s
 //===--------------------------------------------------------------------===//
 
 struct MarkdownBlock {
-	std::string block_type; // heading, paragraph, code, blockquote, list, table, image, hr, html, raw, frontmatter
-	std::string content;    // Primary content
-	int32_t level;          // Heading level (1-6), nesting depth, or 0
-	std::string encoding;   // text, json, yaml, base64
+	std::string kind = "block"; // 'block' or 'inline' (structured inline children)
+	std::string block_type;     // heading, paragraph, code, blockquote, list, table, image, hr, html, raw, frontmatter
+	std::string content;        // Primary content ("" for containers with structured children)
+	int32_t level;              // Heading level (1-6), nesting depth, or 0
+	std::string encoding;       // text, json, yaml, base64
 	std::map<std::string, std::string> attributes; // language, id, class, etc.
 	int32_t block_order;                           // Optional ordering for table storage
 };
 
-// Parse document into blocks (block-level AST)
-std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str);
+// Parse document into blocks (block-level AST). When structured_inlines is true,
+// formatted paragraphs/headings emit their rich text as kind='inline' child
+// blocks (bold/italic/code/link/text at level+1) instead of markdown-in-content;
+// a block whose inline content is a single plain-text run keeps that text in
+// `content` (per the duck_blocks spec's content rules).
+std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool structured_inlines = false);
 
 //===--------------------------------------------------------------------===//
 // Content Extraction

--- a/src/markdown_reader_functions.cpp
+++ b/src/markdown_reader_functions.cpp
@@ -608,7 +608,9 @@ unique_ptr<FunctionData> MarkdownReader::MarkdownReadBlocksBind(ClientContext &c
 	for (const auto &file_path : result->files) {
 		try {
 			string content = ReadMarkdownFile(context, file_path, result->options);
-			auto blocks = markdown_utils::ParseBlocks(content);
+			// Emit the canonical structured representation: rich text as kind='inline'
+			// child rows, not markdown syntax inside `content`.
+			auto blocks = markdown_utils::ParseBlocks(content, /*structured_inlines=*/true);
 			for (auto &block : blocks) {
 				result->all_blocks.push_back({file_path, block});
 			}
@@ -681,16 +683,17 @@ void MarkdownReader::MarkdownReadBlocksFunction(ClientContext &context, TableFun
 			column_idx++;
 		}
 
-		// kind (always 'block' for read_markdown_blocks)
-		output.data[column_idx].SetValue(output_idx, Value("block"));
+		// kind ('block', or 'inline' for structured rich-text children)
+		output.data[column_idx].SetValue(output_idx, Value(block.kind));
 		column_idx++;
 
 		// element_type (was block_type)
 		output.data[column_idx].SetValue(output_idx, Value(block.block_type));
 		column_idx++;
 
-		// content
-		output.data[column_idx].SetValue(output_idx, Value(block.content));
+		// content (NULL for containers whose text lives in structured inline children)
+		output.data[column_idx].SetValue(output_idx,
+		                                 block.content.empty() ? Value(LogicalType::VARCHAR) : Value(block.content));
 		column_idx++;
 
 		// level (NULL if -1, meaning "not applicable")

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -32,8 +32,8 @@ namespace markdown_utils {
 // Result of locating a leading YAML-style frontmatter block.
 struct FrontmatterMatch {
 	bool found = false;
-	size_t body_start = 0; // offset of first byte of the frontmatter body
-	size_t body_len = 0;   // length of the body (delimiters excluded)
+	size_t body_start = 0;  // offset of first byte of the frontmatter body
+	size_t body_len = 0;    // length of the body (delimiters excluded)
 	size_t after_close = 0; // offset just past the closing "---"
 };
 
@@ -385,8 +385,7 @@ MarkdownStats CalculateStats(const std::string &markdown_str) {
 			while (h < heading_line.size() && heading_line[h] == '#') {
 				h++;
 			}
-			if (h >= 1 && h <= 6 && h < heading_line.size() &&
-			    (heading_line[h] == ' ' || heading_line[h] == '\t')) {
+			if (h >= 1 && h <= 6 && h < heading_line.size() && (heading_line[h] == ' ' || heading_line[h] == '\t')) {
 				stats.heading_count++;
 			}
 		}
@@ -883,7 +882,118 @@ static std::string GetInlineText(cmark_node *node, int depth = 0) {
 	return result;
 }
 
-std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str) {
+// True if `container`'s inline content is a single plain-text run (or empty),
+// in which case `text` holds it and no structured decomposition is needed.
+static bool SingleTextChild(cmark_node *container, std::string &text) {
+	cmark_node *c = cmark_node_first_child(container);
+	if (!c) {
+		text.clear();
+		return true;
+	}
+	if (cmark_node_next(c) != nullptr) {
+		return false;
+	}
+	if (cmark_node_get_type(c) != CMARK_NODE_TEXT) {
+		return false;
+	}
+	const char *lit = cmark_node_get_literal(c);
+	text = lit ? lit : "";
+	return true;
+}
+
+// Walk `container`'s inline children, appending kind='inline' MarkdownBlocks
+// (bold/italic/code/link/image/text) at `level`. Containers with formatting emit
+// an empty-content element then their children at level+1; a leaf with a single
+// text run carries that run in `content`.
+static void WalkInlines(cmark_node *container, int level, int32_t &order, std::vector<MarkdownBlock> &out,
+                        int depth = 0) {
+	if (depth > MAX_INLINE_DEPTH) {
+		throw InvalidInputException("Markdown inline nesting exceeds maximum supported depth (%d)", MAX_INLINE_DEPTH);
+	}
+	for (cmark_node *c = cmark_node_first_child(container); c; c = cmark_node_next(c)) {
+		cmark_node_type t = cmark_node_get_type(c);
+		MarkdownBlock ib;
+		ib.kind = "inline";
+		ib.level = level;
+		ib.encoding = "text";
+		ib.block_order = order++;
+		const char *lit = cmark_node_get_literal(c);
+
+		switch (t) {
+		case CMARK_NODE_TEXT:
+			ib.block_type = "text";
+			ib.content = lit ? lit : "";
+			out.push_back(ib);
+			break;
+		case CMARK_NODE_CODE:
+			ib.block_type = "code";
+			ib.content = lit ? lit : "";
+			out.push_back(ib);
+			break;
+		case CMARK_NODE_SOFTBREAK:
+			ib.block_type = "text";
+			ib.content = " ";
+			out.push_back(ib);
+			break;
+		case CMARK_NODE_LINEBREAK:
+			ib.block_type = "linebreak";
+			ib.content = "";
+			out.push_back(ib);
+			break;
+		case CMARK_NODE_STRONG:
+		case CMARK_NODE_EMPH: {
+			ib.block_type = (t == CMARK_NODE_STRONG) ? "bold" : "italic";
+			std::string simple;
+			if (SingleTextChild(c, simple)) {
+				ib.content = simple;
+				out.push_back(ib);
+			} else {
+				ib.content = "";
+				out.push_back(ib);
+				WalkInlines(c, level + 1, order, out, depth + 1);
+			}
+			break;
+		}
+		case CMARK_NODE_LINK:
+		case CMARK_NODE_IMAGE: {
+			bool is_image = (t == CMARK_NODE_IMAGE);
+			ib.block_type = is_image ? "image" : "link";
+			const char *url = cmark_node_get_url(c);
+			if (url && strlen(url) > 0) {
+				ib.attributes[is_image ? "src" : "href"] = url;
+			}
+			const char *title = cmark_node_get_title(c);
+			if (title && strlen(title) > 0) {
+				ib.attributes["title"] = title;
+			}
+			if (is_image) {
+				// image label is alt text; keep it in content, no children walked
+				ib.content = GetInlineText(c);
+				out.push_back(ib);
+			} else {
+				std::string simple;
+				if (SingleTextChild(c, simple)) {
+					ib.content = simple;
+					out.push_back(ib);
+				} else {
+					ib.content = "";
+					out.push_back(ib);
+					WalkInlines(c, level + 1, order, out, depth + 1);
+				}
+			}
+			break;
+		}
+		default:
+			// Unknown inline node: fall back to its flattened text.
+			ib.block_type = "text";
+			ib.content = GetInlineText(c);
+			out.push_back(ib);
+			break;
+		}
+	}
+}
+
+std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool structured_inlines) {
 	std::vector<MarkdownBlock> blocks;
 
 	if (markdown_str.empty()) {
@@ -934,33 +1044,45 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str) {
 		block.encoding = "text";
 		block.level = 1; // Document-level blocks have level=1
 		block.block_order = block_order++;
+		bool emit_inlines = false;            // structured inline children follow this block
+		cmark_node *inline_container = child; // node whose inline children to walk
 
 		switch (node_type) {
 		case CMARK_NODE_HEADING: {
 			block.block_type = "heading";
 			int heading_level = cmark_node_get_heading_level(child);
+			// Headings keep their title as plain text (title semantics: TOC and
+			// heading extraction want a string). Inline formatting in a heading is
+			// flattened rather than decomposed into structured children.
 			block.content = GetInlineText(child);
 
 			// Store heading level as attribute (H1=1, H2=2, etc.)
 			block.attributes["heading_level"] = std::to_string(heading_level);
 
-			// Generate ID from heading text
+			// Generate ID from the heading text
 			std::unordered_map<std::string, int32_t> id_counts;
-			std::string id = GenerateSectionId(block.content, id_counts);
-			block.attributes["id"] = id;
+			block.attributes["id"] = GenerateSectionId(block.content, id_counts);
 			break;
 		}
 
 		case CMARK_NODE_PARAGRAPH: {
 			block.block_type = "paragraph";
-			// Render paragraph to markdown to preserve inline formatting
-			char *md = cmark_render_commonmark(child, CMARK_OPT_DEFAULT, 0);
-			if (md) {
-				block.content = md;
-				free(md);
-				// Trim trailing newlines
-				while (!block.content.empty() && (block.content.back() == '\n' || block.content.back() == '\r')) {
-					block.content.pop_back();
+			std::string simple;
+			if (structured_inlines && !SingleTextChild(child, simple)) {
+				block.content = ""; // rich text carried by inline children
+				emit_inlines = true;
+			} else if (structured_inlines) {
+				block.content = simple; // single plain-text run
+			} else {
+				// Legacy path: render inline formatting back to markdown text.
+				char *md = cmark_render_commonmark(child, CMARK_OPT_DEFAULT, 0);
+				if (md) {
+					block.content = md;
+					free(md);
+					// Trim trailing newlines
+					while (!block.content.empty() && (block.content.back() == '\n' || block.content.back() == '\r')) {
+						block.content.pop_back();
+					}
 				}
 			}
 			break;
@@ -992,30 +1114,48 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str) {
 		case CMARK_NODE_BLOCK_QUOTE: {
 			block.block_type = "blockquote";
 			block.level = 1; // Could calculate nesting depth
-			// Render blockquote content without the > prefix
-			char *md = cmark_render_commonmark(child, CMARK_OPT_DEFAULT, 0);
-			if (md) {
-				block.content = md;
-				free(md);
-				// Remove leading > and trim
-				std::string result;
-				std::istringstream iss(block.content);
-				std::string line;
-				while (std::getline(iss, line)) {
-					// Remove leading "> " or ">"
-					if (line.length() >= 2 && line[0] == '>' && line[1] == ' ') {
-						result += line.substr(2) + "\n";
-					} else if (line.length() >= 1 && line[0] == '>') {
-						result += line.substr(1) + "\n";
-					} else {
-						result += line + "\n";
+			cmark_node *first = cmark_node_first_child(child);
+			bool single_para =
+			    first && cmark_node_get_type(first) == CMARK_NODE_PARAGRAPH && cmark_node_next(first) == nullptr;
+			if (structured_inlines && single_para) {
+				// Common case: a single paragraph -> emit its inlines structurally.
+				inline_container = first;
+				std::string simple;
+				if (SingleTextChild(first, simple)) {
+					block.content = simple;
+				} else {
+					block.content = "";
+					emit_inlines = true;
+				}
+			} else if (structured_inlines) {
+				// Multi-block blockquote: flatten to plain text (no markdown syntax).
+				block.content = GetInlineText(child);
+			} else {
+				// Legacy path: render blockquote content back to markdown, strip '>'.
+				char *md = cmark_render_commonmark(child, CMARK_OPT_DEFAULT, 0);
+				if (md) {
+					block.content = md;
+					free(md);
+					// Remove leading > and trim
+					std::string result;
+					std::istringstream iss(block.content);
+					std::string line;
+					while (std::getline(iss, line)) {
+						// Remove leading "> " or ">"
+						if (line.length() >= 2 && line[0] == '>' && line[1] == ' ') {
+							result += line.substr(2) + "\n";
+						} else if (line.length() >= 1 && line[0] == '>') {
+							result += line.substr(1) + "\n";
+						} else {
+							result += line + "\n";
+						}
 					}
+					// Trim trailing newlines
+					while (!result.empty() && result.back() == '\n') {
+						result.pop_back();
+					}
+					block.content = result;
 				}
-				// Trim trailing newlines
-				while (!result.empty() && result.back() == '\n') {
-					result.pop_back();
-				}
-				block.content = result;
 			}
 			break;
 		}
@@ -1167,6 +1307,9 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str) {
 		}
 
 		blocks.push_back(block);
+		if (emit_inlines) {
+			WalkInlines(inline_container, block.level + 1, block_order, blocks);
+		}
 		child = cmark_node_next(child);
 	}
 

--- a/test/sql/duck_block.test
+++ b/test/sql/duck_block.test
@@ -519,3 +519,50 @@ SELECT duck_block_to_md({
 }) LIKE '%| A | B | C |%|---|---|---|%| 1 | 2 | 3 |%';
 ----
 true
+
+# =============================================================================
+# Test: parse_markdown_to_duck_blocks - markdown -> canonical structured blocks
+# Rich text becomes kind='inline' children, NOT markdown syntax in content.
+# =============================================================================
+
+# a plain heading keeps its text in content (single plain-text child)
+query TTT
+SELECT b.kind, b.element_type, b.content
+FROM (SELECT unnest(parse_markdown_to_duck_blocks('# Title')) AS b);
+----
+block	heading	Title
+
+# a formatted paragraph decomposes into structured inline children in order
+query T
+SELECT string_agg(b.element_type, ',' ORDER BY b.element_order)
+FROM (SELECT unnest(parse_markdown_to_duck_blocks('Plain **bold** and *em* and `code`.')) AS b);
+----
+paragraph,text,bold,text,italic,text,code,text
+
+# the paragraph container has NULL content; children carry the literal text
+query I
+SELECT b.content IS NULL
+FROM (SELECT unnest(parse_markdown_to_duck_blocks('a **b**')) AS b) WHERE b.element_type = 'paragraph';
+----
+true
+
+# no markdown syntax leaks into inline content (bold child is 'bold', not '**bold**')
+query T
+SELECT b.content
+FROM (SELECT unnest(parse_markdown_to_duck_blocks('**bold**')) AS b) WHERE b.element_type = 'bold';
+----
+bold
+
+# links carry href in attributes and the label in content
+query TT
+SELECT b.content, b.attributes['href']
+FROM (SELECT unnest(parse_markdown_to_duck_blocks('[site](https://x.io)')) AS b) WHERE b.element_type = 'link';
+----
+site	https://x.io
+
+# inline children are at level 2 (parent block is level 1)
+query I
+SELECT DISTINCT b.level
+FROM (SELECT unnest(parse_markdown_to_duck_blocks('a **b**')) AS b) WHERE b.kind = 'inline';
+----
+2

--- a/test/sql/markdown_blocks.test
+++ b/test/sql/markdown_blocks.test
@@ -157,15 +157,24 @@ block	heading	true	1	text	true	1
 # =============================================================================
 
 query I
-SELECT count(*) FROM read_markdown_blocks('test/data/blocks_nested.md');
+SELECT count(*) FROM read_markdown_blocks('test/data/blocks_nested.md') WHERE kind = 'block';
 ----
 11
 
 # Verify all expected block types are present
 query I
-SELECT count(DISTINCT element_type) FROM read_markdown_blocks('test/data/blocks_nested.md');
+SELECT count(DISTINCT element_type) FROM read_markdown_blocks('test/data/blocks_nested.md') WHERE kind = 'block';
 ----
 7
+
+# Rich text is emitted as structured kind='inline' children at level 2 (not
+# markdown syntax inside content); the blockquote decomposes into inline rows
+query II
+SELECT count(*) > 0, bool_and(level = 2)
+FROM read_markdown_blocks('test/data/blocks_nested.md')
+WHERE kind = 'inline';
+----
+true	true
 
 # Check heading levels (heading_level attribute, all have level=1 as document-level blocks)
 query III
@@ -195,9 +204,11 @@ SELECT content FROM read_markdown_blocks('test/data/blocks_special.md') WHERE el
 ----
 Heading with bold and italic
 
-# Paragraph with inline code and links
+# Paragraph with inline code and a link decomposes into structured inline
+# children; the code span carries its literal text (no backticks in content)
 query I
-SELECT content LIKE '%inline code%' FROM read_markdown_blocks('test/data/blocks_special.md') WHERE element_type = 'paragraph';
+SELECT bool_or(element_type = 'code' AND content = 'inline code')
+FROM read_markdown_blocks('test/data/blocks_special.md') WHERE kind = 'inline';
 ----
 true
 
@@ -206,7 +217,7 @@ true
 # =============================================================================
 
 query I
-SELECT count(*) FROM read_markdown_blocks('test/data/blocks_*.md');
+SELECT count(*) FROM read_markdown_blocks('test/data/blocks_*.md') WHERE kind = 'block';
 ----
 33
 

--- a/test/sql/readme_integration.test
+++ b/test/sql/readme_integration.test
@@ -89,7 +89,7 @@ heading	DuckDB Markdown Extension
 query I
 SELECT
     bool_and(element_type IN ('heading', 'paragraph', 'list', 'code', 'blockquote', 'table', 'hr', 'html', 'frontmatter'))
-FROM read_markdown_blocks('README.md');
+FROM read_markdown_blocks('README.md') WHERE kind = 'block';
 ----
 true
 
@@ -99,9 +99,9 @@ SELECT min(element_order) FROM read_markdown_blocks('README.md');
 ----
 1
 
-# All blocks should have valid kind
+# All rows should have a valid kind (blocks, plus structured inline children)
 query I
-SELECT bool_and(kind = 'block') FROM read_markdown_blocks('README.md');
+SELECT bool_and(kind IN ('block', 'inline')) FROM read_markdown_blocks('README.md');
 ----
 true
 


### PR DESCRIPTION
Rich text (bold/italic/code/link) was flattened back into a paragraph's `content` as markdown syntax, mislabeled `encoding='text'` — a producer-side violation of the duck_blocks spec (rich text is structured `kind='inline'` children; `content` is literal). Consumers (e.g. duck_block_utils' renderer) were forced to re-parse markdown.

## Changes
- Type-aware cmark inline walker emits `kind='inline'` children (text/bold/italic/code/link/image at `level+1`); a single plain-text run stays in `content` (spec content rule). Paragraphs and single-paragraph blockquotes decompose; headings keep their title as plain text (TOC/title semantics).
- **`read_markdown_blocks` now emits structured inlines by default** (breaking — see below). Container `content` is NULL.
- New scalar **`parse_markdown_to_duck_blocks(VARCHAR) -> LIST(duck_block)`**; its rows are identical to `read_markdown_blocks`.

## Breaking change (bugfix)
`read_markdown_blocks` output shape changes: formatted paragraphs/blockquotes now yield `content=NULL` plus inline child rows instead of markdown-in-content. This is a **spec-conformance bugfix** — the prior output was non-conformant (markdown syntax mislabeled `encoding='text'`).

Full suite green (1203 assertions). Verified end-to-end with duck_block_utils' renderer (markdown → structured → styled ANSI, no raw markdown).