### PR TITLE
feat(readers): accept LIST(VARCHAR); tolerate VFS decoration in the markdown guard (#30, #31)

### DIFF
--- a/src/markdown_reader_files.cpp
+++ b/src/markdown_reader_files.cpp
@@ -13,6 +13,63 @@
 namespace duckdb {
 
 //===--------------------------------------------------------------------===//
+// Markdown File Name Recognition
+//===--------------------------------------------------------------------===//
+
+//! The final component of a path, i.e. everything after the last separator.
+static string PathFileName(const string &path) {
+	auto sep_pos = path.find_last_of("/\\");
+	return sep_pos == string::npos ? path : path.substr(sep_pos + 1);
+}
+
+//! Lowercased extension of a file name ("" when it has none).
+static string LowerExtension(const string &file_name) {
+	auto dot_pos = file_name.find_last_of('.');
+	if (dot_pos == string::npos) {
+		return string();
+	}
+	// ASCII-only: a path byte >= 0x80 is negative as a signed char, which ::tolower
+	// is not defined for.
+	return StringUtil::Lower(file_name.substr(dot_pos + 1));
+}
+
+static bool IsMarkdownExtension(const string &extension) {
+	return extension == "md" || extension == "markdown";
+}
+
+//! Does this path name a markdown file?
+//!
+//! Virtual filesystems supplied by other extensions decorate the path with a
+//! revision, query or fragment (`git://docs/SCHEMAS.md@HEAD`, `...md?version=2`,
+//! `...md#frag`), so the raw suffix is not `.md` even though the file behind it is
+//! markdown (issue #31). Two spellings of the file name are therefore accepted:
+//! the literal one, and the one with VFS decoration removed. Testing the literal
+//! name first means this check can only ever accept more than the plain suffix
+//! test did -- a local file that genuinely contains '@', '?' or '#' in its name,
+//! such as `my@file.md`, is still matched on its literal name and is never newly
+//! rejected.
+static bool IsMarkdownFileName(const string &path) {
+	// 1. The literal file name.
+	if (IsMarkdownExtension(LowerExtension(PathFileName(path)))) {
+		return true;
+	}
+
+	// 2. The same name with VFS decoration stripped. A query or fragment terminates
+	//    the path (RFC 3986) so it is cut from the whole string, while a '@revision'
+	//    suffix is cut from the final component only -- that way the '@' of a URI
+	//    authority such as `sftp://user@host/doc.md` is never mistaken for
+	//    decoration. Only this recognition test sees the stripped name -- the file is
+	//    always opened under the original, fully decorated path.
+	auto query_pos = path.find_first_of("?#");
+	auto undecorated = PathFileName(query_pos == string::npos ? path : path.substr(0, query_pos));
+	auto revision_pos = undecorated.find_last_of('@');
+	if (revision_pos != string::npos) {
+		undecorated = undecorated.substr(0, revision_pos);
+	}
+	return IsMarkdownExtension(LowerExtension(undecorated));
+}
+
+//===--------------------------------------------------------------------===//
 // File Path Resolution
 //===--------------------------------------------------------------------===//
 
@@ -87,17 +144,8 @@ vector<string> MarkdownReader::GetFiles(ClientContext &context, const Value &pat
 	vector<string> markdown_files;
 
 	for (const auto &file : result) {
-		// Check if file has markdown extension
-		string extension = "";
-		auto dot_pos = file.find_last_of('.');
-		if (dot_pos != string::npos) {
-			extension = file.substr(dot_pos + 1);
-		}
-		// ASCII-only: a path byte >= 0x80 is negative as a signed char, which ::tolower
-		// is not defined for.
-		extension = StringUtil::Lower(extension);
-
-		if (extension == "md" || extension == "markdown") {
+		// Check if the file names a markdown file (tolerating VFS decoration)
+		if (IsMarkdownFileName(file)) {
 			try {
 				if (fs.FileExists(file)) {
 					markdown_files.push_back(file);
@@ -232,8 +280,7 @@ unique_ptr<TableRef> MarkdownReader::ReadMarkdownReplacement(ClientContext &cont
 	auto &fs = FileSystem::GetFileSystem(context);
 
 	// Check if this looks like a markdown file or pattern
-	bool is_markdown_file = StringUtil::EndsWith(StringUtil::Lower(table_name), ".md") ||
-	                        StringUtil::EndsWith(StringUtil::Lower(table_name), ".markdown");
+	bool is_markdown_file = IsMarkdownFileName(table_name);
 
 	// Check if this is a glob pattern that might contain markdown files
 	bool is_glob_pattern = false;

--- a/src/markdown_reader_functions.cpp
+++ b/src/markdown_reader_functions.cpp
@@ -77,8 +77,8 @@ static std::string UnescapeMarkdownInline(const std::string &in) {
 	for (size_t i = 0; i < in.size(); i++) {
 		if (in[i] == '\\' && i + 1 < in.size()) {
 			char next = in[i + 1];
-			if (next == '[' || next == ']' || next == '#' || next == '^' ||
-			    next == '|' || next == '!' || next == '\\') {
+			if (next == '[' || next == ']' || next == '#' || next == '^' || next == '|' || next == '!' ||
+			    next == '\\') {
 				out.push_back(next);
 				i++;
 				continue;
@@ -191,10 +191,9 @@ static void ParseMarkdownOptions(TableFunctionBindInput &input, MarkdownReader::
 					} else if (tok == "tags") {
 						options.extract_tags = true;
 					} else {
-						throw InvalidInputException(
-						    "Unknown extract_extensions feature: '%s'. Known: 'obsidian' "
-						    "(flavor expanding to wikilinks+tags), 'wikilinks', 'tags'.",
-						    tok);
+						throw InvalidInputException("Unknown extract_extensions feature: '%s'. Known: 'obsidian' "
+						                            "(flavor expanding to wikilinks+tags), 'wikilinks', 'tags'.",
+						                            tok);
 					}
 				}
 			}
@@ -741,6 +740,21 @@ void MarkdownReader::MarkdownReadBlocksFunction(ClientContext &context, TableFun
 // Registration
 //===--------------------------------------------------------------------===//
 
+// Register a reader under both a single VARCHAR path and a LIST(VARCHAR) of paths.
+// MarkdownReader::GetFiles() already resolves either shape; only the binder needs
+// to be told the list form is legal (issue #30).
+static void RegisterPathAndListVariants(ExtensionLoader &loader, TableFunction function) {
+	TableFunctionSet function_set(function.name);
+
+	function.arguments = {LogicalType::VARCHAR};
+	function_set.AddFunction(function);
+
+	function.arguments = {LogicalType::LIST(LogicalType::VARCHAR)};
+	function_set.AddFunction(function);
+
+	loader.RegisterFunction(std::move(function_set));
+}
+
 void MarkdownReader::RegisterFunction(ExtensionLoader &loader) {
 	// Register read_markdown function
 	TableFunction read_markdown_func("read_markdown", {LogicalType(LogicalTypeId::VARCHAR)},
@@ -757,7 +771,7 @@ void MarkdownReader::RegisterFunction(ExtensionLoader &loader) {
 	read_markdown_func.named_parameters["filename"] = LogicalType(LogicalTypeId::BOOLEAN); // Alias for include_filepath
 	read_markdown_func.named_parameters["content_as_varchar"] = LogicalType(LogicalTypeId::BOOLEAN);
 
-	loader.RegisterFunction(read_markdown_func);
+	RegisterPathAndListVariants(loader, read_markdown_func);
 
 	// Register read_markdown_sections function
 	TableFunction read_sections_func("read_markdown_sections", {LogicalType(LogicalTypeId::VARCHAR)},
@@ -783,7 +797,7 @@ void MarkdownReader::RegisterFunction(ExtensionLoader &loader) {
 	read_sections_func.named_parameters["max_depth"] = LogicalType(LogicalTypeId::INTEGER);
 	read_sections_func.named_parameters["max_content_length"] = LogicalType(LogicalTypeId::UBIGINT);
 
-	loader.RegisterFunction(read_sections_func);
+	RegisterPathAndListVariants(loader, read_sections_func);
 
 	// Register read_markdown_blocks function
 	TableFunction read_blocks_func("read_markdown_blocks", {LogicalType(LogicalTypeId::VARCHAR)},
@@ -797,7 +811,7 @@ void MarkdownReader::RegisterFunction(ExtensionLoader &loader) {
 	read_blocks_func.named_parameters["include_filepath"] = LogicalType(LogicalTypeId::BOOLEAN);
 	read_blocks_func.named_parameters["filename"] = LogicalType(LogicalTypeId::BOOLEAN); // Alias for include_filepath
 
-	loader.RegisterFunction(read_blocks_func);
+	RegisterPathAndListVariants(loader, read_blocks_func);
 }
 
 } // namespace duckdb

--- a/test/data/local@name.md
+++ b/test/data/local@name.md
@@ -1,0 +1,3 @@
+# Local At Name
+
+A real local file whose name contains an at-sign.

--- a/test/data/vfs_decorated.md@HEAD
+++ b/test/data/vfs_decorated.md@HEAD
@@ -1,0 +1,7 @@
+# VFS Decorated Doc
+
+Body text.
+
+## Child Section
+
+More text.

--- a/test/data/vfs_decorated.png@HEAD
+++ b/test/data/vfs_decorated.png@HEAD
@@ -1,0 +1,1 @@
+not markdown, pretend binary

--- a/test/sql/markdown_list_input.test
+++ b/test/sql/markdown_list_input.test
@@ -1,0 +1,81 @@
+# name: test/sql/markdown_list_input.test
+# description: Readers accept LIST(VARCHAR) of paths/globs (issue #30)
+# group: [sql]
+
+require markdown
+
+#===================================================================
+# read_markdown
+#===================================================================
+
+query I
+SELECT count(*) FROM read_markdown(['test/docs/*.md', 'test/markdown/*.md']);
+----
+13
+
+# The list form must equal the UNION ALL of the separate calls
+query I
+SELECT (SELECT count(*) FROM read_markdown(['test/docs/*.md', 'test/markdown/*.md']))
+     = (SELECT count(*) FROM (
+           SELECT * FROM read_markdown('test/docs/*.md')
+           UNION ALL
+           SELECT * FROM read_markdown('test/markdown/*.md')));
+----
+true
+
+# Named parameters work identically for the list form
+query I
+SELECT count(DISTINCT file_path) FROM read_markdown(['test/docs/*.md', 'test/markdown/*.md'], include_filepath := true);
+----
+13
+
+# A list of explicit files
+query I
+SELECT count(*) FROM read_markdown(['test/markdown/simple.md', 'test/markdown/links.md']);
+----
+2
+
+#===================================================================
+# read_markdown_sections
+#===================================================================
+
+query I
+SELECT (SELECT count(*) FROM read_markdown_sections(['test/docs/*.md', 'test/markdown/*.md']))
+     = (SELECT count(*) FROM (
+           SELECT * FROM read_markdown_sections('test/docs/*.md')
+           UNION ALL
+           SELECT * FROM read_markdown_sections('test/markdown/*.md')));
+----
+true
+
+query I
+SELECT count(*) > 0 FROM read_markdown_sections(['test/docs/*.md', 'test/markdown/*.md'], include_content := true);
+----
+true
+
+#===================================================================
+# read_markdown_blocks
+#===================================================================
+
+query I
+SELECT (SELECT count(*) FROM read_markdown_blocks(['test/docs/*.md', 'test/markdown/*.md']))
+     = (SELECT count(*) FROM (
+           SELECT * FROM read_markdown_blocks('test/docs/*.md')
+           UNION ALL
+           SELECT * FROM read_markdown_blocks('test/markdown/*.md')));
+----
+true
+
+query I
+SELECT count(DISTINCT file_path) FROM read_markdown_blocks(['test/docs/*.md', 'test/markdown/*.md'], include_filepath := true);
+----
+13
+
+#===================================================================
+# Existing single-VARCHAR behavior unchanged
+#===================================================================
+
+query I
+SELECT count(*) FROM read_markdown('test/markdown/simple.md');
+----
+1

--- a/test/sql/markdown_vfs_paths.test
+++ b/test/sql/markdown_vfs_paths.test
@@ -1,0 +1,70 @@
+# name: test/sql/markdown_vfs_paths.test
+# description: The markdown-file guard tolerates VFS/URI decoration on the path (issue #31)
+# group: [sql]
+
+require markdown
+
+#===================================================================
+# A path whose final component carries VFS decoration (`name.md@REF`)
+# is still a markdown file. All three readers share the same guard in
+# MarkdownReader::GetFiles(), so all three must accept it.
+#===================================================================
+
+query I
+SELECT count(*) FROM read_markdown('test/data/vfs_decorated.md@HEAD');
+----
+1
+
+query I
+SELECT count(*) FROM read_markdown_sections('test/data/vfs_decorated.md@HEAD') WHERE level > 0;
+----
+2
+
+query I
+SELECT count(*) > 0 FROM read_markdown_blocks('test/data/vfs_decorated.md@HEAD');
+----
+true
+
+# The content really is parsed, not just accepted
+query I
+SELECT title FROM read_markdown_sections('test/data/vfs_decorated.md@HEAD') WHERE level = 1;
+----
+VFS Decorated Doc
+
+# Decoration also survives inside a list argument
+query I
+SELECT count(*) FROM read_markdown(['test/data/vfs_decorated.md@HEAD', 'test/markdown/simple.md']);
+----
+2
+
+# The replacement scan shares the same recognition test, so a bare decorated
+# markdown path in FROM position is routed to read_markdown as well
+query I
+SELECT count(*) FROM 'test/data/vfs_decorated.md@HEAD';
+----
+1
+
+#===================================================================
+# The guard's intent is preserved: stripping decoration must not turn
+# a non-markdown file into a markdown one.
+#===================================================================
+
+statement error
+SELECT * FROM read_markdown('test/data/vfs_decorated.png@HEAD');
+----
+File is not a markdown file
+
+#===================================================================
+# Ordinary local filenames containing '@' keep working unchanged: the
+# literal name is tested before any decoration is stripped
+#===================================================================
+
+query I
+SELECT title FROM read_markdown_sections('test/data/local@name.md') WHERE level = 1;
+----
+Local At Name
+
+query I
+SELECT count(*) FROM read_markdown('test/markdown/simple.md');
+----
+1

--- a/test/sql/markdown_vfs_paths_notwindows.test
+++ b/test/sql/markdown_vfs_paths_notwindows.test
@@ -1,0 +1,33 @@
+# name: test/sql/markdown_vfs_paths_notwindows.test
+# description: VFS query/fragment decoration on markdown paths (issue #31); '?' is not a legal Windows filename character
+# group: [sql]
+
+require markdown
+
+require notwindows
+
+statement ok
+COPY (SELECT '# Query Decorated' AS c) TO '__TEST_DIR__/vfs_q.md?version=2' (FORMAT csv, HEADER false, QUOTE '', ESCAPE '');
+
+statement ok
+COPY (SELECT '# Fragment Decorated' AS c) TO '__TEST_DIR__/vfs_f.md#intro' (FORMAT csv, HEADER false, QUOTE '', ESCAPE '');
+
+query I
+SELECT count(*) FROM read_markdown('__TEST_DIR__/vfs_q.md?version=2');
+----
+1
+
+query I
+SELECT title FROM read_markdown_sections('__TEST_DIR__/vfs_q.md?version=2') WHERE level = 1;
+----
+Query Decorated
+
+query I
+SELECT count(*) FROM read_markdown('__TEST_DIR__/vfs_f.md#intro');
+----
+1
+
+query I
+SELECT count(*) > 0 FROM read_markdown_blocks('__TEST_DIR__/vfs_f.md#intro');
+----
+true


### PR DESCRIPTION
Fixes #30. Fixes #31.

## #30 — readers accept `LIST(VARCHAR)`

```sql
SELECT * FROM read_markdown_blocks(['docs/a/*.md', 'docs/b/*.md']);   -- was a Binder Error
```

`read_markdown`, `read_markdown_sections` and `read_markdown_blocks` are now registered as a
`TableFunctionSet` with `VARCHAR` and `LIST(VARCHAR)` overloads sharing one bind, scan and
named-parameter set — matching `read_csv` / `read_parquet` / `read_json`.

The reporter's diagnosis was correct and verified: `MarkdownReader::GetFiles()` was already
list-aware, so only the registration was blocking. Combining two folders no longer needs
`UNION ALL`, and brace-globs remain unsupported (DuckDB does not expand them) — the list is
the answer.

## #31 — the markdown-file guard tolerates VFS decoration

```sql
SELECT level, title FROM read_markdown_sections('git://docs/SCHEMAS.md@HEAD');
-- was: Invalid Input Error: File is not a markdown file
```

The guard tested the filename suffix, and a VFS URI usually ends in `@HEAD`, `?version=` or
`#frag`. Fixed in `GetFiles()`, which all three readers share.

**The matching rule is deliberately monotone**, because the risk here is breaking real local
files whose names legitimately contain `@`, `?` or `#`:

> match if **either** the literal final path component, **or** that component with `?`/`#`
> cut from the whole path and a trailing `@rev` cut from the component alone, ends in
> `.md` / `.markdown`.

Testing the literal name *first* means nothing that matched before can be newly rejected —
`my@file.md`, `notes?.md` and `a#b.md` all still resolve. Scoping the `@` strip to the last
path component keeps `sftp://user@host/doc.md` working, which a whole-path strip would have
broken.

The guard's intent is unchanged: `foo.png` is still rejected, and so is `foo.png@HEAD`.

Only option 1 from the issue is implemented — no content sniffing, no `force` parameter.

## Testing

**1308 → 1332 assertions**, 26 → 29 test cases. Both new tests were confirmed **red on the
baseline** with the issues' exact error messages.

The `git://` path itself is not tested — that needs `duck_tails` installed. The tests instead
drive the identical guard code with real local files carrying `@`, `?` and `#` decoration, so
none of them pass vacuously.

## Two judgement calls for review

1. **Extended #31's fix to `ReadMarkdownReplacement()`'s own suffix test**, so
   `FROM 'x.md@HEAD'` behaves like the explicit `read_markdown('x.md@HEAD')` call. One line
   to revert if you would rather keep the replacement scan strict.
2. **`make format` reformats 9 files unrelated to either issue** — that drift is pre-existing
   on `main`. Those reverts were dropped so each commit stays on-topic; worth a standalone
   reformat commit rather than smuggling it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjgU52vGS3mpSAwwgJD5C4
