### PR TITLE
Work through the 2026-07 review findings: one table parser, JSON round-trip, BOM, malformed-input tests (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Reads Markdown files and returns one row per file.
 - `include_filepath := false` - Include file_path column in output (alias: `filename`)
 - `content_as_varchar := false` - Return content as VARCHAR instead of MARKDOWN type
 - `maximum_file_size := 16777216` - Maximum file size in bytes (16MB default)
-- `extract_metadata := true` - Extract frontmatter into the `metadata` column. This uses the same **line-split key/value** reader as [`md_extract_metadata`](#content-extraction-functions) — each line split on the first `:`, typed as `MAP(VARCHAR, VARCHAR)` — **not** a full YAML parser (nested maps, lists, and multiline `|`/`>` scalars are not interpreted). For full YAML fidelity, read the raw block with `md_extract_frontmatter` and parse it with [`duckdb_yaml`](https://github.com/teaguesterling/duckdb_yaml).
+- `extract_metadata := true` - Extract frontmatter into the `metadata` column. This uses the same **line-split key/value** reader as [`md_extract_metadata`](#content-extraction-functions) — each line split on the first `:`, typed as `MAP(VARCHAR, VARCHAR)` — **not** a full YAML parser (nested maps, lists, and multiline `|`/`>` scalars are not interpreted). For real YAML, use the `yaml` extension's `read_yaml_frontmatter` — see [Frontmatter Handling](#frontmatter-handling).
 - `normalize_content := true` - Normalize Markdown content
 - `extract_extensions := NULL` - Opt-in add-on extractors (comma-separated VARCHAR; see [Optional Add-On Extractors](#optional-add-on-extractors-extract_extensions)). When set, adds `wikilinks` and/or `tags` `LIST<STRUCT>` columns to the output
 
@@ -175,7 +175,7 @@ Reads Markdown files and parses them into hierarchical sections.
 **Returns:** `(section_id VARCHAR, section_path VARCHAR, level INTEGER, title VARCHAR, content MARKDOWN, parent_id VARCHAR, start_line BIGINT, end_line BIGINT)` or with `include_filepath := true` adds `file_path VARCHAR` column.
 
 **Notes:**
-- When `extract_metadata := true`, YAML frontmatter is included as a special section with `level=0`, `section_id='frontmatter'`, and the raw YAML content (without `---` delimiters) as the content.
+- When `extract_metadata := true`, the frontmatter block is included as a special section with `level=0`, `section_id='frontmatter'`, and the **raw, unparsed** text between the `---` delimiters as the content. Nothing in this extension interprets that text as YAML — see [Frontmatter Handling](#frontmatter-handling).
 - The `section_path` column provides hierarchical navigation paths like `"parent/child/grandchild"`.
 - Fragment syntax `'file.md#section-id'` returns the matching section and all its descendants.
 
@@ -227,12 +227,103 @@ Available tokens: `wikilinks`, `tags`, and the `obsidian` flavor (= both). Unkno
 - **`md_to_text(markdown)`** - Convert markdown to plain text (useful for full-text search)
 - **`md_valid(markdown)`** - Validate markdown content and return boolean
 - **`md_stats(markdown)`** - Get document statistics (word count, reading time, etc.)
-- **`md_extract_metadata(markdown)`** - Extract frontmatter as `MAP(VARCHAR, VARCHAR)`. This is a lightweight **line-split key/value** reader (each line split on the first `:`), *not* a full YAML parser — nested maps, lists, and multiline scalars are not interpreted. For full YAML fidelity, extract the raw block with `md_extract_frontmatter` (below) and hand it to the [`duckdb_yaml`](https://github.com/teaguesterling/duckdb_yaml) extension (`yaml`/`read_yaml_frontmatter`).
+- **`md_extract_metadata(markdown)`** - Extract frontmatter as `MAP(VARCHAR, VARCHAR)`. This is a lightweight **line-split key/value** reader (each line split on the first `:`), *not* a full YAML parser — nested maps, lists, and multiline scalars are not interpreted. For real YAML — nested maps, lists, `|`/`>` blocks — use the `yaml` extension's `read_yaml_frontmatter`; see [Frontmatter Handling](#frontmatter-handling).
 - **`md_extract_frontmatter(markdown)`** - Extract the **raw** frontmatter block (the text between the `---` fences) as `VARCHAR`, or `NULL` when there is no frontmatter. Composes with `duckdb_yaml` for real YAML parsing without this extension carrying a YAML parser: e.g. `SELECT yaml(md_extract_frontmatter(content))`.
 - **`md_extract_section(markdown, section_id, [include_subsections])`** - Extract specific section by ID. With `include_subsections := true`, includes all nested content (full mode); default is minimal mode.
 - **`md_extract_sections(markdown, [min_level, max_level, content_mode])`** - Extract all sections as a list. Supports optional level filtering and content_mode ('minimal', 'full', 'smart').
 - **`md_section_breadcrumb(markdown, section_id)`** - Generate breadcrumb path for a section (returns "Title1 > Title2 > Title3" format)
 - **`value_to_md(value)`** - Convert any value to markdown representation
+
+### Frontmatter Handling
+
+**This extension does not parse YAML.** Frontmatter — the block between the leading `---`
+delimiters — is read as **flat `key: value` pairs**: each line is split on its *first* `:`,
+both halves are whitespace-trimmed, and a pair of surrounding double quotes is stripped from
+the value. The result is typed `MAP(VARCHAR, VARCHAR)`.
+
+That is a deliberate design choice, not an approximation waiting to be upgraded. Keeping a
+YAML parser out of this extension is what lets it accept arbitrary untrusted documents
+without inheriting a YAML implementation's parsing surface (billion-laughs style alias
+expansion, custom tags, and so on). Markdown parsing goes to cmark-gfm; YAML parsing goes to
+the `yaml` extension; this extension does neither by hand.
+
+**What that means in practice.** Given this frontmatter:
+
+```yaml
+---
+title: My Post
+tags:
+  - duckdb
+  - markdown
+author:
+  name: Ada
+  email: ada@example.com
+summary: |
+  A multiline
+  summary.
+quoted: "double quoted"
+single: 'single quoted'
+url: https://example.com/a:b
+---
+```
+
+`md_extract_metadata` returns:
+
+| key | value | why |
+|---|---|---|
+| `title` | `My Post` | flat pair, as expected |
+| `tags` | *(empty string)* | the sequence below it is not read; `tags` just has no value |
+| `author` | *(empty string)* | the nested map is flattened away |
+| `name` | `Ada` | a nested key is hoisted to the top level, where it can collide |
+| `email` | `ada@example.com` | split on the *first* `:`, so the rest of the line survives |
+| `summary` | `\|` | the block-scalar indicator is taken as the literal value |
+| `quoted` | `double quoted` | a *paired* `"` is stripped |
+| `single` | `'single quoted'` | single quotes are **not** stripped |
+| `url` | `https://example.com/a:b` | first-`:` split keeps the remainder intact |
+
+Lines with no `:` at all — `- duckdb`, `- markdown`, and the body of the `|` block — produce
+no entry and are silently dropped. A sequence of mappings (`- name: Ada`) does produce an
+entry, under the key `- name`.
+
+So: **nested maps, lists, multiline `|`/`>` block scalars, single-quoted values, and anchors
+or aliases are not interpreted.** Flat `key: value` documents — the overwhelming majority of
+blog/Obsidian/Hugo frontmatter — come through exactly right.
+
+**If you need real YAML, use the `yaml` extension.** It ships `read_yaml_frontmatter`, which
+reads Markdown files and parses their frontmatter with an actual YAML parser:
+
+```sql
+INSTALL yaml FROM community;
+LOAD yaml;
+
+-- Fully typed frontmatter fields, nested structures included
+SELECT title, tags FROM read_yaml_frontmatter('posts/*.md');
+
+-- Keep the whole frontmatter document as a YAML/JSON-navigable value
+SELECT frontmatter FROM read_yaml_frontmatter('posts/*.md', as_yaml_objects := true);
+
+-- Frontmatter plus the Markdown body in one pass
+SELECT title, content FROM read_yaml_frontmatter('posts/*.md', content := true);
+```
+
+`read_yaml_frontmatter` takes `ANY`, so a single path, a glob, or a `LIST` of either all work,
+and it accepts the named parameters `as_yaml_objects`, `content`, and `filename`. See
+[`duckdb_yaml`](https://github.com/teaguesterling/duckdb_yaml).
+
+The two extensions compose in both directions:
+
+```sql
+-- markdown extension finds the documents and the body; yaml extension types the frontmatter
+SELECT y.title, y.tags, md_stats(m.content).word_count
+FROM read_yaml_frontmatter('posts/*.md', filename := true) y
+JOIN read_markdown('posts/*.md', include_filepath := true) m ON m.file_path = y.filename;
+
+-- or hand a single raw block to the YAML parser yourself
+SELECT yaml(md_extract_frontmatter(content)) FROM read_markdown('posts/*.md');
+```
+
+Use `md_extract_metadata` when you want a cheap flat `MAP` and your frontmatter is flat.
+Use `read_yaml_frontmatter` when the frontmatter is real YAML.
 
 ### Duck Block Functions
 
@@ -431,13 +522,13 @@ COPY sections TO 'doc.md' (FORMAT MARKDOWN,
     title_column 'title',      -- Column with heading text (default: 'title')
     content_column 'content',  -- Column with section body (default: 'content')
     frontmatter 'title: My Doc
-author: Me',                   -- Optional YAML frontmatter
+author: Me',                   -- Optional frontmatter block, emitted verbatim
     blank_lines 1              -- Blank lines between sections (default: 1)
 );
 ```
 
 **Level 0 as Frontmatter:**
-Rows with `level = 0` are rendered as YAML frontmatter blocks:
+Rows with `level = 0` are rendered as frontmatter blocks (the content is written between `---` delimiters verbatim; it is not validated as YAML):
 
 ```sql
 INSERT INTO doc VALUES (0, '', 'title: Generated Doc');
@@ -494,7 +585,7 @@ COPY blocks TO 'doc.md' (FORMAT MARKDOWN,
 - `list` - JSON array rendered as bullet/numbered list (uses `attributes['ordered']`)
 - `table` - JSON object rendered as markdown table
 - `hr` - Horizontal rule `---`
-- `frontmatter` - YAML block between `---` delimiters
+- `frontmatter` - Raw block between `---` delimiters (emitted verbatim, not YAML-validated)
 
 **Inline Rendering (`kind = 'inline'`):**
 - `bold` / `strong` - `**text**`

--- a/docs/doc_block_spec.md
+++ b/docs/doc_block_spec.md
@@ -113,7 +113,7 @@ These element types MUST be recognized by all compliant extensions:
 | `table` | Tabular data | json | NULL | - |
 | `hr` | Thematic break | text (empty) | NULL | - |
 | `metadata` | Document metadata | yaml or json | 0 | - |
-| `frontmatter` | Document metadata | yaml | 0 | - |
+| `frontmatter` | Document metadata (raw block text; this extension does not parse YAML) | yaml | 0 | - |
 | `image` | Block-level image | text (empty) | NULL | `src`, `alt`, `title` |
 | `raw` | Raw format-specific content | varies | NULL | `format` |
 

--- a/docs/markdown_doc_block.md
+++ b/docs/markdown_doc_block.md
@@ -47,8 +47,8 @@ STRUCT(
 | `list` | `-`, `*`, `1.` lists | JSON array of items |
 | `table` | GFM tables | JSON `{headers, rows}` |
 | `hr` | `---`, `***`, `___` | Normalized to `---` on output |
-| `metadata` | YAML frontmatter | Level 0, encoding 'yaml' |
-| `frontmatter` | YAML frontmatter | Alias for `metadata` |
+| `metadata` | Frontmatter block (raw text, not YAML-parsed) | Level 0, encoding 'yaml' |
+| `frontmatter` | Frontmatter block (raw text, not YAML-parsed) | Alias for `metadata` |
 | `image` | `![alt](src "title")` | Details in attributes |
 | `raw` | Raw HTML | Preserved HTML in markdown |
 | `html` | Raw HTML | Alias for raw |

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -14,6 +14,151 @@ namespace duckdb {
 static constexpr int MAX_PANDOC_DEPTH = 1000;
 
 //===--------------------------------------------------------------------===//
+// JSON string decoding
+//
+// The counterpart to markdown_utils' EscapeJSONString, which emits the RFC 8259
+// short escapes (\" \\ \b \f \n \r \t) plus \u00XX for any other control byte.
+// Three hand-rolled decoders used to sit here, each understanding a different
+// subset: ParseJsonListItems knew \n \t \r, ExtractPandocText knew \n \t \" \\,
+// and ParseJsonTable knew nothing at all -- it dropped the backslash and kept
+// the following letter, so a tab in a table cell came back out as a literal
+// 't'. That is the mirror image of the under-escaping fixed in #21, on the
+// decode side. One decoder now serves all three.
+//
+// `esc` is the character that followed the backslash; `i` indexes it in `src`
+// and is advanced past everything consumed.
+//===--------------------------------------------------------------------===//
+
+// Append the UTF-8 encoding of a Unicode code point.
+static void AppendUTF8(string &out, uint32_t cp) {
+	if (cp < 0x80) {
+		out += static_cast<char>(cp);
+	} else if (cp < 0x800) {
+		out += static_cast<char>(0xC0 | (cp >> 6));
+		out += static_cast<char>(0x80 | (cp & 0x3F));
+	} else if (cp < 0x10000) {
+		out += static_cast<char>(0xE0 | (cp >> 12));
+		out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+		out += static_cast<char>(0x80 | (cp & 0x3F));
+	} else {
+		out += static_cast<char>(0xF0 | (cp >> 18));
+		out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+		out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+		out += static_cast<char>(0x80 | (cp & 0x3F));
+	}
+}
+
+// Read exactly 4 hex digits at `pos`; returns false (and leaves `value`
+// untouched) if they are not all present.
+static bool ReadHex4(const string &src, size_t pos, uint32_t &value) {
+	if (pos + 4 > src.size()) {
+		return false;
+	}
+	uint32_t v = 0;
+	for (size_t k = 0; k < 4; k++) {
+		char c = src[pos + k];
+		uint32_t d;
+		if (c >= '0' && c <= '9') {
+			d = static_cast<uint32_t>(c - '0');
+		} else if (c >= 'a' && c <= 'f') {
+			d = static_cast<uint32_t>(c - 'a') + 10;
+		} else if (c >= 'A' && c <= 'F') {
+			d = static_cast<uint32_t>(c - 'A') + 10;
+		} else {
+			return false;
+		}
+		v = (v << 4) | d;
+	}
+	value = v;
+	return true;
+}
+
+// Decode one escape sequence. `i` points at the character after the backslash
+// and is left pointing at the last character consumed, so a `for`/`while` loop
+// that increments `i` afterwards lands on the next unread character.
+static void DecodeJSONEscape(const string &src, size_t &i, string &out) {
+	if (i >= src.size()) {
+		out += '\\'; // trailing backslash: keep it rather than losing a byte
+		return;
+	}
+	char esc = src[i];
+	switch (esc) {
+	case 'n':
+		out += '\n';
+		return;
+	case 't':
+		out += '\t';
+		return;
+	case 'r':
+		out += '\r';
+		return;
+	case 'b':
+		out += '\b';
+		return;
+	case 'f':
+		out += '\f';
+		return;
+	case '"':
+	case '\\':
+	case '/':
+		out += esc;
+		return;
+	case 'u': {
+		uint32_t cp;
+		if (!ReadHex4(src, i + 1, cp)) {
+			out += esc; // malformed \u: emit literally, consume nothing extra
+			return;
+		}
+		i += 4;
+		// Surrogate pair: \uD800-\uDBFF followed by \uDC00-\uDFFF.
+		if (cp >= 0xD800 && cp <= 0xDBFF && i + 2 < src.size() && src[i + 1] == '\\' && src[i + 2] == 'u') {
+			uint32_t lo;
+			if (ReadHex4(src, i + 3, lo) && lo >= 0xDC00 && lo <= 0xDFFF) {
+				cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+				i += 6;
+			}
+		}
+		if (cp >= 0xD800 && cp <= 0xDFFF) {
+			cp = 0xFFFD; // lone surrogate is not encodable as UTF-8
+		}
+		AppendUTF8(out, cp);
+		return;
+	}
+	default:
+		// Not a JSON escape. Keep the character as-is (the pre-existing
+		// behaviour for unknown escapes) rather than dropping it.
+		out += esc;
+		return;
+	}
+}
+
+// Split the body of a JSON array of strings (the text between the outer
+// brackets) into its decoded elements. Elements that are not strings are
+// ignored, which matches what the previous ad-hoc scanners did.
+static void ParseJSONStringArrayBody(const string &body, vector<string> &out) {
+	bool in_string = false;
+	bool escape_next = false;
+	string current;
+	for (size_t i = 0; i < body.size(); i++) {
+		char c = body[i];
+		if (escape_next) {
+			DecodeJSONEscape(body, i, current);
+			escape_next = false;
+		} else if (c == '\\') {
+			escape_next = true;
+		} else if (c == '"') {
+			if (in_string) {
+				out.push_back(current);
+				current.clear();
+			}
+			in_string = !in_string;
+		} else if (in_string) {
+			current += c;
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
 // Helper Functions
 //===--------------------------------------------------------------------===//
 
@@ -47,14 +192,7 @@ vector<string> DuckBlockFunctions::ParseJsonListItems(const string &content) {
 	for (size_t i = 0; i < items_str.length(); i++) {
 		char c = items_str[i];
 		if (escape_next) {
-			if (c == 'n')
-				current_item += '\n';
-			else if (c == 't')
-				current_item += '\t';
-			else if (c == 'r')
-				current_item += '\r';
-			else
-				current_item += c;
+			DecodeJSONEscape(items_str, i, current_item);
 			escape_next = false;
 		} else if (c == '\\') {
 			escape_next = true;
@@ -80,25 +218,7 @@ void DuckBlockFunctions::ParseJsonTable(const string &content, vector<string> &h
 		size_t arr_end = content.find(']', arr_start);
 		if (arr_start != string::npos && arr_end != string::npos) {
 			string headers_str = content.substr(arr_start + 1, arr_end - arr_start - 1);
-			bool in_string = false;
-			bool escape_next = false;
-			string current;
-			for (char c : headers_str) {
-				if (escape_next) {
-					current += c;
-					escape_next = false;
-				} else if (c == '\\') {
-					escape_next = true;
-				} else if (c == '"') {
-					if (in_string) {
-						headers.push_back(current);
-						current.clear();
-					}
-					in_string = !in_string;
-				} else if (in_string) {
-					current += c;
-				}
-			}
+			ParseJSONStringArrayBody(headers_str, headers);
 		}
 	}
 
@@ -118,25 +238,7 @@ void DuckBlockFunctions::ParseJsonTable(const string &content, vector<string> &h
 
 				string row_str = content.substr(row_start + 1, row_end - row_start - 1);
 				vector<string> row;
-				bool in_string = false;
-				bool escape_next = false;
-				string current;
-				for (char c : row_str) {
-					if (escape_next) {
-						current += c;
-						escape_next = false;
-					} else if (c == '\\') {
-						escape_next = true;
-					} else if (c == '"') {
-						if (in_string) {
-							row.push_back(current);
-							current.clear();
-						}
-						in_string = !in_string;
-					} else if (in_string) {
-						current += c;
-					}
-				}
+				ParseJSONStringArrayBody(row_str, row);
 				if (!row.empty()) {
 					rows.push_back(row);
 				}
@@ -174,26 +276,13 @@ string DuckBlockFunctions::ExtractPandocText(const string &content, int depth) {
 			end++;
 		}
 		string text = content.substr(start + 1, end - start - 1);
-		// Unescape
+		// Unescape (shared decoder: the full RFC 8259 escape set, including
+		// \r, \b, \f and \uXXXX -- see DecodeJSONEscape above).
 		string unescaped;
 		for (size_t i = 0; i < text.size(); i++) {
 			if (text[i] == '\\' && i + 1 < text.size()) {
-				char next = text[i + 1];
-				if (next == 'n') {
-					unescaped += '\n';
-					i++;
-				} else if (next == 't') {
-					unescaped += '\t';
-					i++;
-				} else if (next == '"') {
-					unescaped += '"';
-					i++;
-				} else if (next == '\\') {
-					unescaped += '\\';
-					i++;
-				} else {
-					unescaped += text[i];
-				}
+				i++;
+				DecodeJSONEscape(text, i, unescaped);
 			} else {
 				unescaped += text[i];
 			}

--- a/src/markdown_extraction_functions.cpp
+++ b/src/markdown_extraction_functions.cpp
@@ -367,7 +367,11 @@ static void TableJSONExtractionFunction(DataChunk &args, ExpressionState &state,
 			const auto &headers = table.headers;
 			const auto &rows = table.rows;
 
-			// Create header values
+			// Create header values. Always use the (child_type, values) overload:
+			// the single-argument Value::LIST infers the child type from the
+			// elements and throws an INTERNAL error on an empty vector. A table
+			// with a header but no data rows, or a row with no cells, is a
+			// perfectly ordinary document and must not abort the query (#21).
 			vector<Value> header_values;
 			for (const auto &header : headers) {
 				header_values.push_back(Value(header));
@@ -380,7 +384,7 @@ static void TableJSONExtractionFunction(DataChunk &args, ExpressionState &state,
 				for (const auto &cell : row) {
 					cell_values.push_back(Value(cell));
 				}
-				row_values.push_back(Value::LIST(cell_values));
+				row_values.push_back(Value::LIST(LogicalType::VARCHAR, std::move(cell_values)));
 			}
 
 			// Create struct for this table
@@ -389,8 +393,9 @@ static void TableJSONExtractionFunction(DataChunk &args, ExpressionState &state,
 			table_struct_children.push_back({"line_number", Value::BIGINT(static_cast<int64_t>(table.line_number))});
 			table_struct_children.push_back({"num_columns", Value::BIGINT(static_cast<int64_t>(headers.size()))});
 			table_struct_children.push_back({"num_rows", Value::BIGINT(static_cast<int64_t>(rows.size()))});
-			table_struct_children.push_back({"headers", Value::LIST(header_values)});
-			table_struct_children.push_back({"table_data", Value::LIST(row_values)});
+			table_struct_children.push_back({"headers", Value::LIST(LogicalType::VARCHAR, std::move(header_values))});
+			table_struct_children.push_back(
+			    {"table_data", Value::LIST(LogicalType::LIST(LogicalType::VARCHAR), std::move(row_values))});
 
 			struct_values.push_back(Value::STRUCT(table_struct_children));
 		}
@@ -439,8 +444,8 @@ void MarkdownExtractionFunctions::Register(ExtensionLoader &loader) {
 	                                                 {"is_embed", LogicalType(LogicalTypeId::BOOLEAN)},
 	                                                 {"line_number", LogicalType(LogicalTypeId::BIGINT)}});
 
-	auto tag_struct_type = LogicalType::STRUCT({{"tag", LogicalType(LogicalTypeId::VARCHAR)},
-	                                            {"line_number", LogicalType(LogicalTypeId::BIGINT)}});
+	auto tag_struct_type = LogicalType::STRUCT(
+	    {{"tag", LogicalType(LogicalTypeId::VARCHAR)}, {"line_number", LogicalType(LogicalTypeId::BIGINT)}});
 
 	auto table_row_struct_type = LogicalType::STRUCT({{"table_index", LogicalType(LogicalTypeId::BIGINT)},
 	                                                  {"row_type", LogicalType(LogicalTypeId::VARCHAR)},
@@ -480,8 +485,8 @@ void MarkdownExtractionFunctions::Register(ExtensionLoader &loader) {
 	loader.RegisterFunction(wikilinks_func);
 
 	// Register md_extract_tags scalar function (inline #tags)
-	ScalarFunction tags_func("md_extract_tags", {MarkdownTypes::MarkdownType()},
-	                         LogicalType::LIST(tag_struct_type), TagExtractionFunction);
+	ScalarFunction tags_func("md_extract_tags", {MarkdownTypes::MarkdownType()}, LogicalType::LIST(tag_struct_type),
+	                         TagExtractionFunction);
 	loader.RegisterFunction(tags_func);
 
 	// Register md_extract_table_rows scalar function (renamed from md_extract_tables)

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -120,71 +120,11 @@ static std::string EscapeJSONString(const std::string &s) {
 	return out;
 }
 
-// True if a single line (without its trailing '\n') is a GFM pipe-table row:
-// starts with '|', has at least two '|', and only spaces/tabs after the last
-// '|'. Faithful to R"(\|[^\n]*\|[ \t]*)" applied per line. A trailing '\r'
-// (CRLF input) is tolerated, matching the original regex behaviour.
-static bool IsPipeTableLine(const std::string &line_in) {
-	std::string line = line_in;
-	if (!line.empty() && line.back() == '\r') {
-		line.pop_back();
-	}
-	if (line.empty() || line[0] != '|') {
-		return false;
-	}
-	size_t last = line.rfind('|');
-	if (last == 0) {
-		return false; // only one '|'
-	}
-	for (size_t i = last + 1; i < line.size(); i++) {
-		if (line[i] != ' ' && line[i] != '\t') {
-			return false;
-		}
-	}
-	return true;
-}
-
-// True if a (trimmed, non-empty) table line is an alignment/separator row:
-// contains only '-', '|', ':', and whitespace, with at least one of '-|:'.
-// Linear replacement for R"(^\s*\|?\s*[-|:\s]+\s*\|?\s*$)" restricted to the
-// non-empty lines the table scanner actually feeds it.
-static bool IsSeparatorLine(const std::string &line) {
-	bool has_core = false;
-	for (char c : line) {
-		if (c == '-' || c == '|' || c == ':') {
-			has_core = true;
-		} else if (c == ' ' || c == '\t' || c == '\r') {
-			// allowed whitespace
-		} else {
-			return false;
-		}
-	}
-	return has_core;
-}
-
-// Split a table row into cells. Faithful to the previous R"([^|]+)" iterator:
-// split on '|', drop segments that are empty *before* trimming, then trim each
-// kept segment. Leading/trailing pipes therefore produce no empty cells.
-static std::vector<std::string> SplitTableCells(const std::string &line) {
-	std::vector<std::string> cells;
-	std::string cur;
-	auto flush = [&]() {
-		if (!cur.empty()) {
-			TrimWhitespace(cur);
-			cells.push_back(cur);
-		}
-		cur.clear();
-	};
-	for (char c : line) {
-		if (c == '|') {
-			flush();
-		} else {
-			cur += c;
-		}
-	}
-	flush();
-	return cells;
-}
+// NOTE: the hand-rolled pipe-table line scanner that used to live here
+// (IsPipeTableLine / IsSeparatorLine / SplitTableCells) was retired in favour
+// of cmark-gfm's table extension -- see ExtractTables below (#21).
+// TrimWhitespace stays: frontmatter parsing, wikilinks, tags and code-fence
+// info strings all still use it.
 
 //===--------------------------------------------------------------------===//
 // Core Conversion Functions
@@ -1501,99 +1441,125 @@ std::vector<MarkdownTable> ExtractTables(const std::string &markdown_str) {
 		return tables;
 	}
 
-	// Locate GFM pipe-table blocks with a linear line scanner instead of a
-	// backtracking std::regex. A block is a maximal run of consecutive pipe
-	// table lines (see IsPipeTableLine); this replaces
-	// R"((?:^|\n)((?:\|[^\n]*\|[ \t]*\n?)+))" which could overflow the stack on
-	// a very long table line or many rows.
-	const std::string &s = markdown_str;
-	size_t n = s.size();
-	size_t i = 0;
+	// Tables come from cmark-gfm's GFM table extension -- the same parser
+	// ParseBlocks uses (#21). There used to be a second, hand-rolled pipe-table
+	// scanner here whose own comment called itself a fallback, so the same
+	// document could yield different tables depending on which function you
+	// called: it found "tables" inside fenced code blocks, missed tables inside
+	// blockquotes and list items, missed tables written without leading pipes,
+	// split cells on escaped `\|`, and accepted header/delimiter rows whose cell
+	// counts disagreed (not a GFM table). One parser now serves both.
+	//
+	// The document is parsed whole, without stripping frontmatter, so
+	// line_number is an absolute line in the input -- matching ExtractLinks and
+	// ExtractImages, which also use cmark's native line tracking.
+	cmark_gfm_core_extensions_ensure_registered();
+	cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
+	if (!parser) {
+		return tables;
+	}
+	cmark_syntax_extension *table_ext = cmark_find_syntax_extension("table");
+	if (table_ext) {
+		cmark_parser_attach_syntax_extension(parser, table_ext);
+	}
+	cmark_parser_feed(parser, markdown_str.c_str(), markdown_str.length());
+	cmark_node *doc = cmark_parser_finish(parser);
+	cmark_parser_free(parser);
+	if (!doc) {
+		return tables;
+	}
 
-	while (i < n) {
-		// Current line spans [line_start, line_end); nl is the '\n' index or npos.
-		size_t line_start = i;
-		size_t nl = s.find('\n', i);
-		size_t line_end = (nl == std::string::npos) ? n : nl;
-		std::string line = s.substr(line_start, line_end - line_start);
+	cmark_iter *iter = cmark_iter_new(doc);
+	if (!iter) {
+		cmark_node_free(doc);
+		return tables;
+	}
 
-		if (!IsPipeTableLine(line)) {
-			i = (nl == std::string::npos) ? n : nl + 1;
+	cmark_event_type ev_type;
+	while ((ev_type = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
+		if (ev_type != CMARK_EVENT_ENTER) {
+			continue;
+		}
+		cmark_node *node = cmark_iter_get_node(iter);
+		const char *type_string = cmark_node_get_type_string(node);
+		if (!type_string || strcmp(type_string, "table") != 0) {
 			continue;
 		}
 
-		// Faithful to the old regex's line_number: the match began at the '\n'
-		// preceding the block (or at offset 0), and newlines strictly before
-		// that position were counted.
-		idx_t line_number;
-		if (line_start == 0) {
-			line_number = 1;
-		} else {
-			line_number = 1 + static_cast<idx_t>(std::count(s.begin(), s.begin() + (line_start - 1), '\n'));
-		}
-
-		// Gather the maximal run of consecutive pipe-table lines.
-		std::vector<std::string> table_lines;
-		size_t j = i;
-		while (j < n) {
-			size_t ls = j;
-			size_t jnl = s.find('\n', j);
-			size_t le = (jnl == std::string::npos) ? n : jnl;
-			std::string l = s.substr(ls, le - ls);
-			if (!IsPipeTableLine(l)) {
-				break;
-			}
-			TrimWhitespace(l);
-			if (!l.empty()) {
-				table_lines.push_back(l);
-			}
-			j = (jnl == std::string::npos) ? n : jnl + 1;
-		}
-		i = j; // continue scanning after the block
-
-		if (table_lines.size() < 2) {
-			continue; // Need at least header and separator
-		}
-
 		MarkdownTable table;
-		table.line_number = line_number;
+		table.line_number = static_cast<idx_t>(cmark_node_get_start_line(node));
 
-		// Find header row (first non-separator line)
-		size_t header_idx = 0;
-		while (header_idx < table_lines.size() && IsSeparatorLine(table_lines[header_idx])) {
-			header_idx++;
+		uint16_t n_columns = cmark_gfm_extensions_get_table_columns(node);
+		table.num_columns = static_cast<idx_t>(n_columns);
+
+		// Column alignments: cmark reports 0 (none), 'l', 'c' or 'r'. The
+		// previous scanner ignored the delimiter row entirely and reported
+		// every column as "left"; unset columns keep that default.
+		table.alignments.assign(table.num_columns, "left");
+		uint8_t *align = cmark_gfm_extensions_get_table_alignments(node);
+		if (align) {
+			for (idx_t c = 0; c < table.num_columns; c++) {
+				switch (align[c]) {
+				case 'c':
+					table.alignments[c] = "center";
+					break;
+				case 'r':
+					table.alignments[c] = "right";
+					break;
+				case 'l':
+				default:
+					table.alignments[c] = "left";
+					break;
+				}
+			}
 		}
 
-		if (header_idx >= table_lines.size()) {
-			continue; // No valid header found
-		}
-
-		// Parse header row
-		table.headers = SplitTableCells(table_lines[header_idx]);
-		table.num_columns = table.headers.size();
-
-		// Find data rows (skip separator lines)
-		for (size_t k = header_idx + 1; k < table_lines.size(); k++) {
-			if (IsSeparatorLine(table_lines[k])) {
+		for (cmark_node *row = cmark_node_first_child(node); row; row = cmark_node_next(row)) {
+			// cmark-gfm reports the header row as "table_header" in some
+			// builds and as "table_row" with the is_header flag in others;
+			// accept both, as ParseBlocks does.
+			const char *row_type = cmark_node_get_type_string(row);
+			if (!row_type || (strcmp(row_type, "table_row") != 0 && strcmp(row_type, "table_header") != 0)) {
 				continue;
 			}
-			std::vector<std::string> row_data = SplitTableCells(table_lines[k]);
+			bool is_header =
+			    cmark_gfm_extensions_get_table_row_is_header(row) != 0 || strcmp(row_type, "table_header") == 0;
 
-			// Pad row to match header column count
-			while (row_data.size() < table.num_columns) {
-				row_data.push_back("");
+			std::vector<std::string> cells;
+			for (cmark_node *cell = cmark_node_first_child(row); cell; cell = cmark_node_next(cell)) {
+				const char *cell_type = cmark_node_get_type_string(cell);
+				if (!cell_type || strcmp(cell_type, "table_cell") != 0) {
+					continue;
+				}
+				// Same cell text as ParseBlocks' table JSON: inline content
+				// flattened to text, so both surfaces agree cell for cell.
+				cells.push_back(GetInlineText(cell));
+			}
+			// cmark already normalises a row to the table's column count, but a
+			// short row is padded here as well so the invariant holds for any
+			// input.
+			while (cells.size() < table.num_columns) {
+				cells.push_back("");
 			}
 
-			table.rows.push_back(row_data);
+			if (is_header && table.headers.empty()) {
+				table.headers = std::move(cells);
+			} else {
+				table.rows.push_back(std::move(cells));
+			}
 		}
 
+		// A GFM table always has a header row; fall back to the column count if
+		// cmark ever reports one without.
+		if (table.headers.empty()) {
+			table.headers.assign(table.num_columns, "");
+		}
 		table.num_rows = table.rows.size();
-
-		// Default to left alignment for now
-		table.alignments.resize(table.num_columns, "left");
-
-		tables.push_back(table);
+		tables.push_back(std::move(table));
 	}
+
+	cmark_iter_free(iter);
+	cmark_node_free(doc);
 
 	return tables;
 }

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -37,17 +37,31 @@ struct FrontmatterMatch {
 	size_t after_close = 0; // offset just past the closing "---"
 };
 
+// A leading UTF-8 BOM (EF BB BF) is an encoding marker, not content. cmark
+// skips it, so every cmark-backed extractor here was always immune; the linear
+// scanners in this file have to skip it explicitly or they disagree with cmark
+// on the very same document -- a BOM-prefixed post silently got no frontmatter
+// and no tags (#21). Returns the offset of the first content byte.
+static size_t SkipBOM(const std::string &s) {
+	if (s.size() >= 3 && static_cast<unsigned char>(s[0]) == 0xEF && static_cast<unsigned char>(s[1]) == 0xBB &&
+	    static_cast<unsigned char>(s[2]) == 0xBF) {
+		return 3;
+	}
+	return 0;
+}
+
 // Faithful linear replacement for R"(^---\r?\n([\s\S]*?)\r?\n---)".
 // Requires the string to begin with "---" then \r?\n, then finds the earliest
 // following "\r?\n---". Returns the body between the delimiters. O(n), no
 // recursion.
 static FrontmatterMatch FindFrontmatter(const std::string &s) {
 	FrontmatterMatch m;
-	// Opening delimiter: "---" then \r?\n
-	if (s.size() < 4 || s[0] != '-' || s[1] != '-' || s[2] != '-') {
+	// Opening delimiter: an optional BOM, then "---" then \r?\n
+	const size_t b = SkipBOM(s);
+	if (s.size() < b + 4 || s[b] != '-' || s[b + 1] != '-' || s[b + 2] != '-') {
 		return m;
 	}
-	size_t p = 3;
+	size_t p = b + 3;
 	if (p < s.size() && s[p] == '\r') {
 		p++;
 	}
@@ -285,8 +299,15 @@ Value MetadataToMap(const MarkdownMetadata &metadata) {
 	return Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(keys), std::move(values));
 }
 
-MarkdownStats CalculateStats(const std::string &markdown_str) {
+MarkdownStats CalculateStats(const std::string &markdown_str_in) {
 	MarkdownStats stats = {};
+
+	// Skip a leading BOM before counting anything: it is an encoding marker,
+	// not a character of the document, and cmark does not see it either. Only
+	// copies when a BOM is actually present (#21).
+	const size_t bom = SkipBOM(markdown_str_in);
+	const std::string bom_stripped = bom ? markdown_str_in.substr(bom) : std::string();
+	const std::string &markdown_str = bom ? bom_stripped : markdown_str_in;
 
 	// Word count (approximate)
 	std::istringstream stream(markdown_str);
@@ -1791,11 +1812,17 @@ static std::string ScrubInlineCode(const std::string &line) {
 	return scrubbed;
 }
 
-std::vector<MarkdownTag> ExtractTags(const std::string &markdown_str) {
+std::vector<MarkdownTag> ExtractTags(const std::string &markdown_str_in) {
 	std::vector<MarkdownTag> tags;
-	if (markdown_str.empty()) {
+	if (markdown_str_in.empty()) {
 		return tags;
 	}
+
+	// A leading BOM is not whitespace, so without this the '#' of a first-line
+	// tag looks preceded by a non-space character and the tag is missed (#21).
+	const size_t bom = SkipBOM(markdown_str_in);
+	const std::string bom_stripped = bom ? markdown_str_in.substr(bom) : std::string();
+	const std::string &markdown_str = bom ? bom_stripped : markdown_str_in;
 
 	// Inline #tag / #nested/tag. v1 limitations (documented): tags inside link URLs or
 	// wikilink targets are not suppressed; fenced code blocks and inline code spans are.

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -800,7 +800,21 @@ static std::string RenderNodeContent(cmark_node *node) {
 // adversarially deep nesting.
 static constexpr int MAX_INLINE_DEPTH = 1000;
 
-// Helper to get text content from inline children
+// Flatten a node's inline children to a string.
+//
+// Formatting that carries no information beyond its text -- emphasis, strong,
+// code spans, strikethrough -- is dropped, so `**bold**` becomes `bold`. Nodes
+// that carry a URL are NOT dropped: a link or an image is written back out in
+// markdown form, because the URL cannot be recovered from the text and losing
+// it silently is a data loss, not a formatting choice (#21). A cell holding
+// `[DuckDB](https://duckdb.org)` therefore still yields
+// `[DuckDB](https://duckdb.org)`, byte for byte what v1.5.2 produced from the
+// raw source.
+//
+// Autolinks: cmark represents `<https://x>` as a link whose text equals its
+// URL, which is indistinguishable from an explicitly written
+// `[https://x](https://x)`. That shape is emitted as `<https://x>` -- lossless
+// either way, and the form the source is usually written in.
 static std::string GetInlineText(cmark_node *node, int depth = 0) {
 	if (depth > MAX_INLINE_DEPTH) {
 		throw InvalidInputException("Markdown inline nesting exceeds maximum supported depth (%d)", MAX_INLINE_DEPTH);
@@ -817,8 +831,27 @@ static std::string GetInlineText(cmark_node *node, int depth = 0) {
 			result += " ";
 		} else if (type == CMARK_NODE_LINEBREAK) {
 			result += "\n";
+		} else if (type == CMARK_NODE_LINK || type == CMARK_NODE_IMAGE) {
+			const char *url_c = cmark_node_get_url(child);
+			const char *title_c = cmark_node_get_title(child);
+			std::string url = url_c ? url_c : "";
+			std::string title = title_c ? title_c : "";
+			std::string label = GetInlineText(child, depth + 1);
+			if (type == CMARK_NODE_LINK && title.empty() && !url.empty() && label == url) {
+				result += "<" + url + ">"; // autolink shape
+			} else {
+				if (type == CMARK_NODE_IMAGE) {
+					result += "!";
+				}
+				result += "[" + label + "](" + url;
+				if (!title.empty()) {
+					result += " \"" + title + "\"";
+				}
+				result += ")";
+			}
 		} else {
-			// Recursively get text from nested nodes
+			// Emphasis, strong, strikethrough, and anything else whose text is
+			// its whole content: recurse and keep only the text.
 			result += GetInlineText(child, depth + 1);
 		}
 		child = cmark_node_next(child);

--- a/test/md/invalid_utf8.md
+++ b/test/md/invalid_utf8.md
@@ -1,0 +1,8 @@
+# Broken Encoding Fixture
+
+This file deliberately contains invalid UTF-8: a lone Latin-1 byte (é)
+and a UTF-16 BOM pair (ÿþ) in the middle of the text.
+
+| a | b |
+|---|---|
+| xÃ | y |

--- a/test/sql/markdown_extraction_errors.test
+++ b/test/sql/markdown_extraction_errors.test
@@ -206,9 +206,22 @@ SELECT len(md_extract_images('![Alt text(image.jpg)'));
 ----
 0
 
-# Test table with mismatched columns
+# Test table with mismatched columns.
+#
+# CHANGED in #21 (6 -> 0): the GFM spec requires the delimiter row to have the
+# same number of cells as the header row -- "if not, a table will not be
+# recognized". Three header cells against two delimiter cells is therefore not
+# a table, and GitHub renders it as a paragraph. The retired hand-rolled
+# scanner never looked at the delimiter row's cell count and reported a table
+# anyway. This is the parser becoming correct, not a test being relaxed.
 query I
 SELECT len(md_extract_table_rows(E'| A | B | C |\n|---|---|\n| 1 | 2 | 3 |'));
+----
+0
+
+# The same table with a matching delimiter row is still a table.
+query I
+SELECT len(md_extract_table_rows(E'| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |'));
 ----
 6
 

--- a/test/sql/markdown_json_escape.test
+++ b/test/sql/markdown_json_escape.test
@@ -1,0 +1,137 @@
+# name: test/sql/markdown_json_escape.test
+# description: JSON string escaping/unescaping symmetry for encoding='json' blocks (#21)
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# ESCAPE side (#21, fixed in v1.5.0 by the shared EscapeJSONString).
+#
+# The table-cell path used to escape only " \ \n while the list path also
+# escaped \r and \t, so a literal tab or CR in a table cell emitted a raw
+# control byte inside a JSON string -- invalid JSON out of an encoding='json'
+# field. These assertions pin the emitted text exactly, so they hold whichever
+# parser produces the cells and without needing the json extension loaded.
+#
+# Newlines/tabs are built with chr() -- sqllogictest forbids literal newlines
+# inside a SQL string literal.
+# =============================================================================
+
+# Tab in a table cell -> \t, never a raw 0x09 byte.
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x' || chr(9) || 'y | z |')) b)
+WHERE b.element_type = 'table';
+----
+{"headers": ["a", "b"], "rows": [["x\ty", "z"]]}
+
+# NOTE: a literal CR cannot reach a cell from Markdown source -- cmark
+# normalises CR and CRLF to LF before parsing, so `| x<CR>y | z |` is two
+# lines, not a cell containing a CR:
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x' || chr(13) || 'y | z |')) b)
+WHERE b.element_type = 'table';
+----
+{"headers": ["a", "b"], "rows": [["x", ""], ["y", "z"]]}
+
+# CR is still escaped correctly when it does occur (blocks can also be built by
+# hand and handed to duck_block_to_md), and must decode back to a real CR.
+query I
+SELECT duck_block_to_md({'kind': 'block', 'element_type': 'table', 'content':
+        '{"headers": ["a"], "rows": [["x' || chr(92) || 'ry"]]}', 'level': 1,
+        'encoding': 'json', 'attributes': MAP{}::MAP(VARCHAR, VARCHAR),
+        'element_order': 1}) LIKE '%x' || chr(13) || 'y%';
+----
+true
+
+# Control character (0x01) in a table cell -> \u0001, not a raw byte.
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x' || chr(1) || 'y | z |')) b)
+WHERE b.element_type = 'table';
+----
+{"headers": ["a", "b"], "rows": [["x\u0001y", "z"]]}
+
+# Quote and backslash in a table cell.
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| he said "hi" | c:' || chr(92) || chr(92) || 'tmp |')) b)
+WHERE b.element_type = 'table';
+----
+{"headers": ["a", "b"], "rows": [["he said \"hi\"", "c:\\tmp"]]}
+
+# The list path escapes the same set (it always did) -- kept so the two paths
+# are pinned side by side and cannot drift apart again.
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+        '- x' || chr(9) || 'y' || chr(10) || '- z' || chr(1) || 'w')) b)
+WHERE b.element_type = 'list';
+----
+["x\ty", "z\u0001w"]
+
+# =============================================================================
+# UNESCAPE side: the mirror-image gap. duck_blocks_to_md has to read those
+# JSON strings back. ParseJsonListItems handles \n \t \r; ParseJsonTable did
+# not decode anything -- it dropped the backslash and kept the letter, so a
+# tab in a cell round-tripped as a literal 't'. Same class of bug as #21, on
+# the decode side, and only reachable through the table path.
+# =============================================================================
+
+# Tab survives a blocks -> markdown round trip through the table path.
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x' || chr(9) || 'y | z |')) LIKE '%x' || chr(9) || 'y%';
+----
+true
+
+# ... and is not mangled into a literal 't'.
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x' || chr(9) || 'y | z |')) LIKE '%xty%';
+----
+false
+
+# Backslash and quote survive the table round trip.
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| he said "hi" | c:' || chr(92) || chr(92) || 'tmp |')) LIKE '%c:' || chr(92) || 'tmp%';
+----
+true
+
+# A control character round trips through \u0001 rather than being dropped or
+# turned into the letter 'u'.
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x' || chr(1) || 'y | z |')) LIKE '%x' || chr(1) || 'y%';
+----
+true
+
+# The list path round trips too (regression guard for the shared decoder).
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(
+        '- x' || chr(9) || 'y')) LIKE '%x' || chr(9) || 'y%';
+----
+true
+
+# \u escapes above the BMP-ASCII range decode to UTF-8, not to bytes.
+query I
+SELECT duck_block_to_md({'kind': 'block', 'element_type': 'table', 'content':
+        '{"headers": ["a"], "rows": [["caf\u00e9"]]}', 'level': 1,
+        'encoding': 'json', 'attributes': MAP{}::MAP(VARCHAR, VARCHAR),
+        'element_order': 1}) LIKE '%café%';
+----
+true

--- a/test/sql/markdown_malformed_inputs.test
+++ b/test/sql/markdown_malformed_inputs.test
@@ -1,0 +1,319 @@
+# name: test/sql/markdown_malformed_inputs.test
+# description: Malformed, large and deeply-nested inputs across the extraction surface (#21)
+# group: [sql]
+
+# The review that produced #21 noted the test suite was happy-path only, and
+# that this is how the std::regex stack-overflow in the private advisory
+# shipped. These are assertions about what the extension *does* with hostile
+# input, not smoke tests -- "does not crash" is stated as an explicit
+# assertion only where the correct output is genuinely a judgement call.
+
+require markdown
+
+#===================================================================
+# Unterminated and nested code fences
+#===================================================================
+
+# An unterminated ``` fence is a code block running to EOF (CommonMark 4.5:
+# "a fenced code block ... may be closed by the end of the document").
+query III
+SELECT c.language, replace(c.code, chr(10), '<LF>'), c.line_number
+FROM (SELECT UNNEST(md_extract_code_blocks('```sql' || chr(10) || 'SELECT 1')) c);
+----
+sql	SELECT 1<LF>	1
+
+# Same for a ~~~ fence, including the rest of the info string.
+query II
+SELECT c.language, c.info_string
+FROM (SELECT UNNEST(md_extract_code_blocks('~~~py extra' || chr(10) || 'x')) c);
+----
+py	py extra
+
+# A ``` fence nested inside a longer ```` fence is content, not a second block.
+query I
+SELECT len(md_extract_code_blocks(
+  '````' || chr(10) || '```' || chr(10) || 'x' || chr(10) || '```' || chr(10) || '````'));
+----
+1
+
+# KNOWN DIVERGENCE (#21 item 4): md_stats counts ``` occurrences and divides by
+# two, so it sees no code block at all in an unterminated fence, and does not
+# know ~~~ fences exist. cmark sees one in each case. Asserted as-is so the
+# divergence is visible and cannot widen unnoticed.
+query II
+SELECT (md_stats('```sql' || chr(10) || 'SELECT 1')).code_block_count,
+       (md_stats('~~~py' || chr(10) || 'x')).code_block_count;
+----
+0	0
+
+query II
+SELECT len(md_extract_code_blocks('```sql' || chr(10) || 'SELECT 1')),
+       len(md_extract_code_blocks('~~~py' || chr(10) || 'x'));
+----
+1	1
+
+# An unterminated frontmatter block is not frontmatter, and does not swallow
+# the document (this shape crashed the old std::regex scanner).
+query II
+SELECT md_extract_frontmatter('---' || chr(10) || repeat('a: b' || chr(10), 100)) IS NULL,
+       cardinality(md_extract_metadata('---' || chr(10) || repeat('a: b' || chr(10), 100)));
+----
+true	0
+
+#===================================================================
+# CRLF line endings
+#===================================================================
+
+# Headings, frontmatter and tables all survive CRLF, and no CR leaks into the
+# extracted values.
+query II
+SELECT s.title, s.level
+FROM (SELECT UNNEST(md_extract_sections(
+  '# A' || chr(13) || chr(10) || 'body' || chr(13) || chr(10) ||
+  '## B' || chr(13) || chr(10) || 'more')) s)
+ORDER BY s.start_line;
+----
+A	1
+B	2
+
+query I
+SELECT md_extract_metadata(
+  '---' || chr(13) || chr(10) || 'title: X' || chr(13) || chr(10) ||
+  '---' || chr(13) || chr(10) || 'body')['title'];
+----
+X
+
+query I
+SELECT r.cell_value
+FROM (SELECT UNNEST(md_extract_table_rows(
+  '| a |' || chr(13) || chr(10) || '|---|' || chr(13) || chr(10) ||
+  '| x |' || chr(13) || chr(10))) r)
+WHERE r.row_type = 'data';
+----
+x
+
+# Code block content is normalised to LF, so no bare CR survives.
+query I
+SELECT strpos((md_extract_code_blocks(
+  '```' || chr(10) || 'a' || chr(13) || chr(10) || 'b' || chr(10) || '```'))[1].code, chr(13));
+----
+0
+
+# A paragraph split by a CRLF blank line is two blocks with clean content.
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+  'para' || chr(13) || chr(10) || chr(13) || chr(10) || 'para2')) b)
+WHERE b.element_order = 1;
+----
+para
+
+#===================================================================
+# Byte order mark
+#
+# cmark strips a leading UTF-8 BOM, so every cmark-backed extractor is
+# unaffected. The remaining line scanners do not, so a BOM changes their
+# answer. Both halves are asserted; the second half is a KNOWN BUG, recorded
+# here rather than silently left untested.
+#===================================================================
+
+# cmark-backed: heading, section id, tables and HTML are all correct.
+query II
+SELECT s.title, s.section_id
+FROM (SELECT UNNEST(md_extract_sections(chr(65279) || '# Title' || chr(10) || 'body')) s);
+----
+Title	title
+
+query I
+SELECT len(md_extract_tables_json(
+  chr(65279) || '| a |' || chr(10) || '|---|' || chr(10) || '| x |'));
+----
+1
+
+query I
+SELECT replace(md_to_html(chr(65279) || '# Title'), chr(10), '<LF>');
+----
+<h1>Title</h1><LF>
+
+query I
+SELECT md_valid(chr(65279) || '# T');
+----
+true
+
+# KNOWN BUG (#21): the line scanners in md_stats, the frontmatter finder and
+# the tag scanner do not skip a leading BOM, so they disagree with cmark on
+# the very same document.
+query I
+SELECT (md_stats(chr(65279) || '# Title' || chr(10) || 'body')).heading_count;
+----
+0
+
+query I
+SELECT md_extract_frontmatter(
+  chr(65279) || '---' || chr(10) || 'a: 1' || chr(10) || '---') IS NULL;
+----
+true
+
+query I
+SELECT len(md_extract_tags(chr(65279) || '#tag'));
+----
+0
+
+# Without the BOM all three agree with cmark, which is what makes the above a
+# BOM bug rather than a difference of definition.
+query III
+SELECT (md_stats('# Title' || chr(10) || 'body')).heading_count,
+       md_extract_frontmatter('---' || chr(10) || 'a: 1' || chr(10) || '---'),
+       len(md_extract_tags('#tag'));
+----
+1	a: 1	1
+
+#===================================================================
+# Very long lines and very large documents
+#
+# These are the shapes that overflowed the stack in the old std::regex
+# extractors (GHSA-qv83-qqvf-72v9). They must resolve in bounded memory.
+#===================================================================
+
+# A 1 MB single line with no structure.
+query III
+SELECT (md_stats(repeat('a', 1000000))).char_count,
+       (md_stats(repeat('a', 1000000))).line_count,
+       len(md_extract_links(repeat('a', 1000000)));
+----
+1000000	1	0
+
+# A 200 K-token single line still renders.
+query I
+SELECT length(md_to_html(repeat('word ', 200000))) > 0;
+----
+true
+
+# An unterminated '[' 200 KB long: no link, no crash.
+query II
+SELECT len(md_extract_links('[' || repeat('b', 200000))),
+       len(md_extract_images('![' || repeat('b', 200000)));
+----
+0	0
+
+# An unterminated wikilink 100 KB long.
+query I
+SELECT len(md_extract_wikilinks('[[' || repeat('a', 100000)));
+----
+0
+
+# 10 000 consecutive pipes is not a table.
+query I
+SELECT len(md_extract_tables_json(repeat('|', 10000)));
+----
+0
+
+# 2 000 headings: every one is found, by both the section extractor and the
+# block parser.
+query II
+SELECT len(md_extract_sections(md)), len(parse_markdown_to_duck_blocks(md))
+FROM (SELECT string_agg('# H' || i, chr(10) ORDER BY i) AS md FROM range(0, 2000) t(i));
+----
+2000	2000
+
+#===================================================================
+# Deep nesting
+#===================================================================
+
+# 500 levels of blockquote around a heading: the heading is still found.
+query II
+SELECT s.title, s.level
+FROM (SELECT UNNEST(md_extract_sections(repeat('> ', 500) || '# H')) s);
+----
+H	1
+
+# 1 000 levels of blockquote still render.
+query I
+SELECT length(md_to_html(repeat('> ', 1000) || 'x')) > 0;
+----
+true
+
+# 500 levels of list nesting is one top-level list block, and round-trips
+# back to markdown without throwing.
+query II
+SELECT len(parse_markdown_to_duck_blocks(md)),
+       length(duck_blocks_to_md(parse_markdown_to_duck_blocks(md))) > 0
+FROM (SELECT string_agg(repeat('  ', i) || '- i', chr(10) ORDER BY i) AS md
+      FROM range(0, 500) t(i));
+----
+1	true
+
+# 200 nested emphasis delimiters on each side: GetInlineText walks this with a
+# depth guard (MAX_INLINE_DEPTH) rather than recursing without bound.
+query I
+SELECT len(parse_markdown_to_duck_blocks(repeat('*', 200) || 'x' || repeat('*', 200))) > 0;
+----
+true
+
+# 1 000 levels of blockquote through the block parser.
+query I
+SELECT len(parse_markdown_to_duck_blocks(repeat('> ', 1000) || 'deep')) > 0;
+----
+true
+
+#===================================================================
+# Mixed and invalid UTF-8
+#===================================================================
+
+# Mixed scripts, an emoji and a combining mark all survive extraction intact.
+query I
+SELECT s.title FROM (SELECT UNNEST(md_extract_sections('# héllo 世界 🎆' || chr(10) || 'x')) s);
+----
+héllo 世界 🎆
+
+# Section ids are ASCII slugs: every non-[a-z0-9_-] byte becomes '-', runs
+# collapse, and leading/trailing hyphens are trimmed -- so a heading that is
+# entirely non-ASCII after the first character slugs down hard. Pinned because
+# it is surprising, not because it is ideal.
+query I
+SELECT s.section_id FROM (SELECT UNNEST(md_extract_sections('# héllo 世界 🎆' || chr(10) || 'x')) s);
+----
+h-llo
+
+# A combining acute (U+0301) is not whitespace and must not be trimmed away.
+query II
+SELECT hex(r.cell_value), strlen(r.cell_value)
+FROM (SELECT UNNEST(md_extract_table_rows(
+  '| a |' || chr(10) || '|---|' || chr(10) || '| e' || chr(769) || ' |')) r)
+WHERE r.row_type = 'data';
+----
+65CC81	3
+
+# A file that is not valid UTF-8 is rejected with a catchable user error, not
+# an internal error and not a crash. test/md/invalid_utf8.md holds a lone
+# Latin-1 byte and a stray FF FE pair.
+statement error
+SELECT content FROM read_markdown('test/md/invalid_utf8.md');
+----
+Invalid unicode
+
+#===================================================================
+# Degenerate documents
+#===================================================================
+
+# Empty document: every extractor returns empty, nothing throws.
+query I
+SELECT len(md_extract_sections('')) + len(md_extract_links('')) + len(md_extract_images(''))
+     + len(md_extract_code_blocks('')) + len(md_extract_tables_json(''))
+     + len(md_extract_table_rows('')) + len(md_extract_tags(''))
+     + len(md_extract_wikilinks(''));
+----
+0
+
+# Whitespace-only document.
+query I
+SELECT len(md_extract_sections(repeat(' ', 100) || chr(10) || repeat(chr(9), 100)));
+----
+0
+
+# Asking for a section that does not exist yields empty strings, not an error.
+query II
+SELECT md_extract_section('# A' || chr(10) || 'x', 'nope'),
+       md_section_breadcrumb('# A', 'nope');
+----
+(empty)	(empty)

--- a/test/sql/markdown_malformed_inputs.test
+++ b/test/sql/markdown_malformed_inputs.test
@@ -111,10 +111,13 @@ para
 #===================================================================
 # Byte order mark
 #
-# cmark strips a leading UTF-8 BOM, so every cmark-backed extractor is
-# unaffected. The remaining line scanners do not, so a BOM changes their
-# answer. Both halves are asserted; the second half is a KNOWN BUG, recorded
-# here rather than silently left untested.
+# A BOM is an encoding marker, not content. cmark skips it, so every
+# cmark-backed extractor was always immune. The linear scanners in
+# markdown_utils.cpp did not, so md_stats.heading_count, md_extract_frontmatter,
+# md_extract_metadata and md_extract_tags all disagreed with cmark on the same
+# document -- a BOM-prefixed post silently got no frontmatter and no tags.
+# Fixed in #21; every scanner now skips it, and the counts below are asserted
+# against their BOM-less controls.
 #===================================================================
 
 # cmark-backed: heading, section id, tables and HTML are all correct.
@@ -140,33 +143,55 @@ SELECT md_valid(chr(65279) || '# T');
 ----
 true
 
-# KNOWN BUG (#21): the line scanners in md_stats, the frontmatter finder and
-# the tag scanner do not skip a leading BOM, so they disagree with cmark on
-# the very same document.
+# The line scanners now skip it too: heading counting, the frontmatter
+# finder (and so md_extract_metadata) and the tag scanner.
 query I
 SELECT (md_stats(chr(65279) || '# Title' || chr(10) || 'body')).heading_count;
 ----
-0
+1
 
 query I
 SELECT md_extract_frontmatter(
-  chr(65279) || '---' || chr(10) || 'a: 1' || chr(10) || '---') IS NULL;
+  chr(65279) || '---' || chr(10) || 'a: 1' || chr(10) || '---');
 ----
-true
+a: 1
+
+query I
+SELECT md_extract_metadata(
+  chr(65279) || '---' || chr(10) || 'title: X' || chr(10) || '---' || chr(10) || 'b')['title'];
+----
+X
 
 query I
 SELECT len(md_extract_tags(chr(65279) || '#tag'));
 ----
-0
+1
 
-# Without the BOM all three agree with cmark, which is what makes the above a
-# BOM bug rather than a difference of definition.
+# The BOM-less controls, which the above must now match exactly.
 query III
 SELECT (md_stats('# Title' || chr(10) || 'body')).heading_count,
        md_extract_frontmatter('---' || chr(10) || 'a: 1' || chr(10) || '---'),
        len(md_extract_tags('#tag'));
 ----
 1	a: 1	1
+
+# StripFrontmatter is reached through the same finder, so a BOM-prefixed
+# frontmatter block no longer leaks into the body.
+query I
+SELECT len(md_extract_sections(
+  chr(65279) || '---' || chr(10) || 'a: 1' || chr(10) || '---' || chr(10) || '# H'));
+----
+1
+
+# The BOM is not counted as document content either: three bytes of encoding
+# marker must not inflate char_count. Compare against the same text without it.
+query IIII
+SELECT (md_stats(chr(65279) || 'abc')).char_count,
+       (md_stats('abc')).char_count,
+       (md_stats(chr(65279) || 'abc')).word_count,
+       (md_stats('abc')).word_count;
+----
+3	3	1	1
 
 #===================================================================
 # Very long lines and very large documents

--- a/test/sql/markdown_security_regression.test
+++ b/test/sql/markdown_security_regression.test
@@ -42,16 +42,30 @@ SELECT len(md_extract_tables_json(repeat('|x', 30000) || '|'));
 0
 
 # Many table rows: tripped the (...)+ grouping. Resolves to one table.
+#
+# NOTE (#21): the fixture gained a delimiter row when table extraction moved
+# onto cmark-gfm's table extension. `|x|` repeated 30000 times has no
+# delimiter row, so it is not a GFM table at all and now yields 0 tables --
+# which would have quietly stopped exercising the large-input path this test
+# exists for. The delimiter row keeps a genuinely large table (30 K rows)
+# flowing through the extractor. The delimiter-less input is asserted just
+# below, so both shapes stay covered.
 query I
-SELECT len(md_extract_tables_json(repeat('|x|' || chr(10), 30000)));
+SELECT len(md_extract_tables_json('|x|' || chr(10) || '|-|' || chr(10) || repeat('|y|' || chr(10), 30000)));
 ----
 1
 
-# Same input via md_extract_table_rows -> all rows emitted, no crash.
+# Same input via md_extract_table_rows -> header cell + all row cells, no crash.
 query I
-SELECT len(md_extract_table_rows(repeat('|x|' || chr(10), 30000)));
+SELECT len(md_extract_table_rows('|x|' || chr(10) || '|-|' || chr(10) || repeat('|y|' || chr(10), 30000)));
 ----
-30000
+30001
+
+# 30 K pipe lines with no delimiter row: not a GFM table, still O(n), no crash.
+query I
+SELECT len(md_extract_tables_json(repeat('|x|' || chr(10), 30000)));
+----
+0
 
 #===================================================================
 # md_stats scanners: link / heading regex over long input

--- a/test/sql/markdown_tables_edge_cases.test
+++ b/test/sql/markdown_tables_edge_cases.test
@@ -153,14 +153,16 @@ FROM (SELECT UNNEST(md_extract_tables_json(
 1	[['', '']]
 
 # Inline markup in a cell is flattened to text, matching the duck_blocks table
-# JSON exactly. NOTE: this loses a link's URL -- see the report on #21.
+# JSON exactly -- except for URL-bearing nodes, which are written back out in
+# markdown so the URL is not lost. See the dedicated section at the end of
+# this file.
 query I
 SELECT t.table_data
 FROM (SELECT UNNEST(md_extract_tables_json(
         '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
         '| **bold** | [text](http://example.com) |')) t);
 ----
-[[bold, text]]
+[[bold, '[text](http://example.com)']]
 
 query I
 SELECT b.content
@@ -169,7 +171,7 @@ FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
         '| **bold** | [text](http://example.com) |')) b)
 WHERE b.element_type = 'table';
 ----
-{"headers": ["a", "b"], "rows": [["bold", "text"]]}
+{"headers": ["a", "b"], "rows": [["bold", "[text](http://example.com)"]]}
 
 # Entities and backslash escapes are resolved, as cmark resolves them
 # everywhere else in this extension.
@@ -220,3 +222,139 @@ FROM (SELECT UNNEST(md_extract_tables_json(
         '| naïve | 🎆 |' || chr(10) || '|---|---|' || chr(10) || '| café | é |')) t);
 ----
 [naïve, 🎆]	[[café, é]]
+
+# =============================================================================
+# URL-bearing inline nodes must survive cell extraction (#21 follow-up).
+#
+# Consolidating onto cmark initially flattened a cell to its plain text, so
+# `| [DuckDB](https://duckdb.org) |` came out as `DuckDB` and the URL was
+# gone -- a silent data loss, and a net regression against v1.5.2 for anyone
+# pulling links out of tables. The inline serialiser now reconstructs markdown
+# for the node types that carry information plain text does not: links and
+# images. Emphasis, code spans and escaped pipes keep whatever cmark gives
+# them.
+#
+# The compatibility bar is the v1.5.2 output for a plain link, reproduced
+# exactly.
+# =============================================================================
+
+# v1.5.2 compatibility: a plain link cell comes back byte for byte.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x | [DuckDB](https://duckdb.org) |')) t);
+----
+[[x, '[DuckDB](https://duckdb.org)']]
+
+# The URL is recoverable from the extracted cell, which is the actual point.
+query I
+SELECT t.table_data[1][2] LIKE '%https://duckdb.org%'
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x | [DuckDB](https://duckdb.org) |')) t);
+----
+true
+
+# A titled link keeps its title.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a |' || chr(10) || '|---|' || chr(10) ||
+        '| [D](https://duckdb.org "The Duck") |')) t);
+----
+[['[D](https://duckdb.org "The Duck")']]
+
+# An image cell keeps its src -- same argument as links.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a |' || chr(10) || '|---|' || chr(10) ||
+        '| ![logo](https://duckdb.org/logo.png) |')) t);
+----
+[['![logo](https://duckdb.org/logo.png)']]
+
+# A titled image keeps both.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a |' || chr(10) || '|---|' || chr(10) ||
+        '| ![logo](/l.png "Logo") |')) t);
+----
+[['![logo](/l.png "Logo")']]
+
+# An autolink round trips as an autolink. cmark represents <https://x> as a
+# link whose text equals its URL, which is ambiguous with an explicit
+# [https://x](https://x); the serialiser emits the <url> form for that shape,
+# which is lossless either way and matches how the source is usually written.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a |' || chr(10) || '|---|' || chr(10) ||
+        '| <https://duckdb.org> |')) t);
+----
+[['<https://duckdb.org>']]
+
+# A link nested inside emphasis keeps the URL; the emphasis markers are still
+# dropped (cmark's plain text), as specified.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a |' || chr(10) || '|---|' || chr(10) ||
+        '| **[D](https://duckdb.org)** |')) t);
+----
+[['[D](https://duckdb.org)']]
+
+# Emphasis and code spans without URLs are unchanged: still flattened.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| **bold** | `code` |')) t);
+----
+[[bold, code]]
+
+# An escaped pipe inside a link label still yields one cell, with the URL.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a |' || chr(10) || '|---|' || chr(10) ||
+        '| [a ' || chr(92) || '| b](https://x) |')) t);
+----
+[['[a | b](https://x)']]
+
+# A relative link, the common case in documentation tables.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| doc |' || chr(10) || '|---|' || chr(10) || '| [spec](./spec.md) |')) t);
+----
+[['[spec](./spec.md)']]
+
+# md_extract_table_rows exposes the same cell value.
+query I
+SELECT r.cell_value
+FROM (SELECT UNNEST(md_extract_table_rows(
+        '| a |' || chr(10) || '|---|' || chr(10) || '| [D](https://duckdb.org) |')) r)
+WHERE r.row_type = 'data';
+----
+[D](https://duckdb.org)
+
+# ... and the duck_blocks table JSON still agrees cell for cell, which is the
+# invariant the consolidation exists to establish.
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+        '| a |' || chr(10) || '|---|' || chr(10) || '| [D](https://duckdb.org) |')) b)
+WHERE b.element_type = 'table';
+----
+{"headers": ["a"], "rows": [["[D](https://duckdb.org)"]]}
+
+# A link in a list item is serialised the same way (the list path shares the
+# inline serialiser).
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks('- see [D](https://duckdb.org)')) b)
+WHERE b.element_type = 'list';
+----
+["see [D](https://duckdb.org)"]

--- a/test/sql/markdown_tables_edge_cases.test
+++ b/test/sql/markdown_tables_edge_cases.test
@@ -53,3 +53,170 @@ query I
 SELECT len(md_extract_tables_json('||' || chr(10) || '|-|')) >= 0;
 ----
 true
+
+# =============================================================================
+# One parser (#21). md_extract_tables_json / md_extract_table_rows used to go
+# through a hand-rolled pipe-table line scanner while read_markdown_blocks /
+# parse_markdown_to_duck_blocks used cmark-gfm's GFM table extension, so the
+# same document could yield different tables depending on which function was
+# called. Both now use cmark. The assertions below pin the cases where that
+# actually changes the answer.
+# =============================================================================
+
+# An escaped pipe is one cell, not two. The old scanner split on every '|'.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x ' || chr(92) || '| z | y |')) t);
+----
+[[x | z, y]]
+
+# ... and the two surfaces now agree on that cell.
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x ' || chr(92) || '| z | y |')) b)
+WHERE b.element_type = 'table';
+----
+{"headers": ["a", "b"], "rows": [["x | z", "y"]]}
+
+# A table inside a fenced code block is code, not a table.
+query I
+SELECT len(md_extract_tables_json(
+        '```' || chr(10) || '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| x | y |' || chr(10) || '```'));
+----
+0
+
+# A table inside a blockquote IS a table (the old scanner required the line to
+# start with '|', so a '>' prefix hid it entirely).
+query II
+SELECT t.headers, t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '> | a | b |' || chr(10) || '> |---|---|' || chr(10) || '> | x | y |')) t);
+----
+[a, b]	[[x, y]]
+
+# A table indented up to three spaces is still a table.
+query I
+SELECT len(md_extract_tables_json(
+        '   | a | b |' || chr(10) || '   |---|---|' || chr(10) || '   | x | y |'));
+----
+1
+
+# GFM allows a table without leading/trailing pipes.
+query II
+SELECT t.headers, t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        'a | b' || chr(10) || '--- | ---' || chr(10) || 'x | y')) t);
+----
+[a, b]	[[x, y]]
+
+# No delimiter row -> not a table.
+query I
+SELECT len(md_extract_tables_json('| a | b |' || chr(10) || '| x | y |'));
+----
+0
+
+# Delimiter row cell count must match the header row.
+query I
+SELECT len(md_extract_tables_json(
+        '| a | b | c |' || chr(10) || '|---|---|' || chr(10) || '| x | y | z |'));
+----
+0
+
+# A row with more cells than the header is truncated to the column count
+# (GFM: "excess cells are ignored"). The old scanner emitted the extra cell.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) || '| x | y | z |')) t);
+----
+[[x, y]]
+
+# A row with fewer cells is padded with empty strings.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b | c |' || chr(10) || '|---|---|---|' || chr(10) || '| x |')) t);
+----
+[[x, '', '']]
+
+# An all-empty data row is a data row, not an alignment row.
+query II
+SELECT t.num_rows, t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) || '|  |  |')) t);
+----
+1	[['', '']]
+
+# Inline markup in a cell is flattened to text, matching the duck_blocks table
+# JSON exactly. NOTE: this loses a link's URL -- see the report on #21.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| **bold** | [text](http://example.com) |')) t);
+----
+[[bold, text]]
+
+query I
+SELECT b.content
+FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| **bold** | [text](http://example.com) |')) b)
+WHERE b.element_type = 'table';
+----
+{"headers": ["a", "b"], "rows": [["bold", "text"]]}
+
+# Entities and backslash escapes are resolved, as cmark resolves them
+# everywhere else in this extension.
+query I
+SELECT t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) ||
+        '| &amp; | ' || chr(92) || '* |')) t);
+----
+[[&, *]]
+
+# line_number comes from cmark's native line tracking, so a table further down
+# the document reports its real line (the old scanner reported 1 for the first
+# table in a document regardless of where it started).
+query I
+SELECT t.line_number
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '# Heading' || chr(10) || chr(10) || 'Some text.' || chr(10) || chr(10) ||
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) || '| x | y |')) t);
+----
+5
+
+# Two tables keep distinct line numbers.
+query I
+SELECT list(t.line_number ORDER BY t.table_index)
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a |' || chr(10) || '|---|' || chr(10) || '| 1 |' || chr(10) || chr(10) ||
+        '| b |' || chr(10) || '|---|' || chr(10) || '| 2 |')) t);
+----
+[1, 5]
+
+# Column alignments from the delimiter row are parsed (internal today -- the
+# public structs do not expose alignment -- but a table with an alignment row
+# must still extract cleanly).
+query II
+SELECT t.headers, t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b | c |' || chr(10) || '|:--|:-:|--:|' || chr(10) || '| x | y | z |')) t);
+----
+[a, b, c]	[[x, y, z]]
+
+# UTF-8 cells survive intact (#32 regression: trailing multi-byte characters
+# were eaten by StringUtil::Trim). Now asserted through the cmark path, which
+# is the one serving tables.
+query II
+SELECT t.headers, t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| naïve | 🎆 |' || chr(10) || '|---|---|' || chr(10) || '| café | é |')) t);
+----
+[naïve, 🎆]	[[café, é]]

--- a/test/sql/markdown_tables_edge_cases.test
+++ b/test/sql/markdown_tables_edge_cases.test
@@ -1,0 +1,55 @@
+# name: test/sql/markdown_tables_edge_cases.test
+# description: Table extraction edge cases (#21) -- degenerate tables must not crash
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# A table with a header but no data rows made md_extract_tables_json build its
+# `table_data` list with the single-argument Value::LIST overload on an empty
+# vector, which is an assertion failure inside DuckDB:
+#
+#   INTERNAL Error: Value::LIST(values) cannot be used to make an empty list
+#
+# An INTERNAL error is not a catchable user error -- it aborts the query and
+# tells the user to file a DuckDB bug. There was no test for a table with zero
+# data rows, so this shipped.
+# =============================================================================
+
+# Header row only.
+query III
+SELECT t.num_columns, t.num_rows, t.table_data
+FROM (SELECT UNNEST(md_extract_tables_json('| a | b |' || chr(10) || '|---|---|')) t);
+----
+2	0	[]
+
+# Header row only, single column.
+query II
+SELECT t.num_columns, t.num_rows
+FROM (SELECT UNNEST(md_extract_tables_json('| only |' || chr(10) || '|------|')) t);
+----
+1	0
+
+# md_extract_table_rows on the same input still yields just the header cells.
+query I
+SELECT len(md_extract_table_rows('| a | b |' || chr(10) || '|---|---|'));
+----
+2
+
+# A data row whose cells are all empty reaches the same empty-list assertion by
+# a different route: the line-scanning parser classifies it as an alignment
+# row (it contains only '|' and spaces), so the table ends up with zero data
+# rows. Whether that row *should* count as data is a separate question -- this
+# assertion is only that the query completes.
+query II
+SELECT t.num_columns, t.num_rows >= 0
+FROM (SELECT UNNEST(md_extract_tables_json(
+        '| a | b |' || chr(10) || '|---|---|' || chr(10) || '|  |  |')) t);
+----
+2	true
+
+# A table with no columns at all is still not a crash.
+query I
+SELECT len(md_extract_tables_json('||' || chr(10) || '|-|')) >= 0;
+----
+true

--- a/test/sql/markdown_utf8_trim.test
+++ b/test/sql/markdown_utf8_trim.test
@@ -11,6 +11,14 @@ require markdown
 # on a signed `char`, so every trailing byte >= 0x80 tests as "keep trimming".
 # Any cell ending in a non-ASCII character silently lost it; a cell holding
 # only an emoji was erased entirely.
+#
+# NOTE (#21): table extraction has since moved onto cmark-gfm's table
+# extension, which strips cell padding itself and never calls TrimWhitespace.
+# These assertions are kept unchanged and deliberately still run through
+# md_extract_table_rows / md_extract_tables_json, so the #32 coverage follows
+# whichever parser serves tables rather than evaporating with the old scanner.
+# The frontmatter and wikilink cases at the bottom still exercise
+# TrimWhitespace directly.
 #===================================================================
 
 # The exact reproducer from the issue.


### PR DESCRIPTION
Works through #21. Four of the five findings are fixed; one is assessed and deliberately not
changed. Seven commits, one per item, so any single change can be reverted.

## One table parser instead of two

`ParseBlocks` used cmark's GFM table extension while `md_extract_tables_json` /
`md_extract_table_rows` used a hand-rolled regex, so the same document could yield different
tables depending on which function you called. Both now use cmark.

**A 27-input before/after comparison is in the branch report.** 10 cases are strictly better,
2 pre-existing crashes are gone, and 2 existing expectations changed because the old answer
contradicted the GFM spec.

The clearest example — an escaped pipe inside a cell:

| cell in document | v1.5.2 | now |
|---|---|---|
| `a \| b` | **`a \`** (truncated) | `a \| b` |

### Link URLs are preserved, deliberately

Consolidating onto cmark initially made a link cell render as display text, dropping its URL —
the one place cmark was *worse*. Rather than accept that, `GetInlineText` now reconstructs
markdown for the inline nodes that carry information the plain text does not: links, titled
links, images and titled images. Autolinks emit the `<url>` form.

Verified byte-for-byte against v1.5.2:

| cell | v1.5.2 | now |
|---|---|---|
| `[DuckDB](https://duckdb.org)` | `[DuckDB](https://duckdb.org)` | identical |
| `[D](https://d.org "T")` | `[D](https://d.org "T")` | identical |
| `![alt](https://i.png)` | `![alt](https://i.png)` | identical |
| `<https://auto.org>` | `<https://auto.org>` | identical |

Re-running the 27-case probe after this change moved **exactly one row** (the link cell, back
to its v1.5.2 value) and left the 10 improvements intact.

**One intentional change to be aware of:** presentational markup is now flattened —
`**b** and \`c\`` yields `b and c` rather than the raw markdown v1.5.2 emitted. The line is
information vs. presentation: a URL is data and is reconstructed; emphasis is styling and the
text survives without it.

## JSON round-tripping — the issue's finding was stale, the mirror one was real

#21 reports the table-cell *escaper* under-escaping. That was already unified in v1.5.0 and is
correct. The **de**-escaper had the mirror-image gap: `ParseJsonTable` decoded nothing, so a
tab written as `\t` came back as a literal `t`. Fixed with one shared decoder.

## Frontmatter documentation

Per the decision recorded on the issue, the parser is unchanged — flat `key: value` parsing is
intentional and is what keeps frontmatter from ever reaching a YAML library. The README now has
a **Frontmatter Handling** section with a verified behaviour table, and points users who need
real YAML at the `yaml` extension's `read_yaml_frontmatter`, which is the actual answer rather
than a caveat.

## Malformed-input tests

57 new assertions: unterminated fences, ragged tables, 1000-deep nesting, 1 MB lines, CRLF,
BOM, invalid UTF-8, degenerate inputs. This is what the issue asked for, and it immediately
found a real defect — `md_extract_tables_json` aborted with an INTERNAL error on a header-only
table (fixed in `b45b7df`).

## BOM handling

A leading BOM broke `md_extract_frontmatter`, `md_extract_metadata`, `md_extract_tags` and
`md_stats.heading_count`, while every cmark path handled it. Fixed in `FindFrontmatter`,
`CalculateStats` and `ExtractTags` after confirming wikilinks and the reference-definition scan
were already immune. Note `md_stats(BOM || 'abc').char_count` goes 6 → 3 — deliberate, and
asserted.

## `md_stats` — assessed, **not** changed

`link_count` diverges from cmark by up to **7×** on real documents: it counts images, code-span
and fenced-code examples, and misses reference and auto links. cmark is more correct in every
case.

It is still not changed, because switching would silently delete image counts and redefine
`code_block_count` — quietly changing what an existing column means is its own regression. The
recommendation is to *add* fields or an `exact :=` option. The divergences are now asserted in
the suite so this does not get re-litigated from memory.

## Testing

**1308 → 1430 assertions**, 26 → 29 test cases.

## Findings recorded, not fixed here

- `md_stats` should gain fields rather than have existing ones redefined (above).
- `ParseJsonTable` splits the rows array on raw `[` / `]` without respecting string boundaries,
  so a cell containing `]` truncates the row. Pre-existing and structural.
- cmark reports a paragraph-interrupting table's `line_number` as the paragraph's start line.
  Far better than the old always-`1`, but not exact.
- **CI does not load the `json` extension**, so `frontmatter_raw_and_json_escape.test` never
  runs — and because `require json` is file-level, all five of its assertions are dark,
  including four `md_extract_frontmatter` ones that have nothing to do with json. The escaper is
  now covered by the extension-free `markdown_json_escape.test`; those four remain uncovered.
  Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjgU52vGS3mpSAwwgJD5C4
