### PR TITLE
ci: run the DuckDB-main canary only on main

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -18,17 +18,19 @@ jobs:
   # outstanding breaks are tracked as a checklist in the "DuckDB main API breaks"
   # issue.
   #
-  # It is skipped on pull_request so it cannot make a PR look broken. `if` is used
-  # rather than `continue-on-error` because a job that calls a REUSABLE WORKFLOW
-  # accepts only name/needs/if/permissions/uses/with/secrets/strategy/concurrency --
-  # `continue-on-error` is not among them, and adding it makes the whole workflow
-  # fail to parse (zero jobs scheduled, run marked failed).
+  # It runs ONLY on pushes to main (and on demand). Skipping `pull_request` alone was
+  # not enough: pushing to a branch fires a push run AND a pull_request run against the
+  # same commit, and a PR's check rollup includes both -- so the canary still showed as
+  # a red check on every PR. Upstream drift is a property of main, not of a branch, so
+  # main is where it belongs.
   #
-  # The canary therefore still runs on every push to a branch and on main, which is
-  # where the warning is actually wanted.
+  # `if` is used rather than `continue-on-error` because a job calling a REUSABLE
+  # WORKFLOW accepts only name/needs/if/permissions/uses/with/secrets/strategy/
+  # concurrency -- `continue-on-error` is not among them, and adding it makes the whole
+  # workflow fail to PARSE (zero jobs scheduled, run marked failed).
   duckdb-next-build:
     name: Canary — build against DuckDB main (advisory)
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       duckdb_version: main


### PR DESCRIPTION
Follow-up to #37, which did not fully land the intent.

Skipping `pull_request` alone was not enough. Pushing to a branch fires **both** a `push` run and a `pull_request` run against the same commit, and a PR's check rollup includes every check on its head SHA — so the canary, correctly skipped in the PR run, still surfaced as a red check on the PR via the push run. Both #34 and #35 showed exactly one red check for this reason after #37 merged.

Upstream API drift is a property of DuckDB `main`, not of any particular branch, so running the canary on every branch push bought nothing and cost a red check on every PR. It now runs on pushes to `main` and on `workflow_dispatch`.

Still `if` rather than `continue-on-error`: a job calling a reusable workflow does not accept that key, and adding it makes the workflow fail to **parse** — zero jobs scheduled, run marked failed. That is recorded in the comment so it is not retried.

CI configuration only. YAML validated before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjgU52vGS3mpSAwwgJD5C4