### PR TITLE
Finish the remaining review findings: dark tests, JSON bracket parsing, md_stats exact (#36, #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,13 @@ Available tokens: `wikilinks`, `tags`, and the `obsidian` flavor (= both). Unkno
 - **`md_to_html(markdown)`** - Convert markdown content to HTML
 - **`md_to_text(markdown)`** - Convert markdown to plain text (useful for full-text search)
 - **`md_valid(markdown)`** - Validate markdown content and return boolean
-- **`md_stats(markdown)`** - Get document statistics (word count, reading time, etc.)
+- **`md_stats(markdown, [exact])`** - Get document statistics (word count, reading time, etc.). By default `heading_count`, `code_block_count` and `link_count` come from line/character scanners, which count a `[text](target)` match anywhere — including images, code spans and fenced code — and miss reference links, autolinks, setext headings, indented code blocks and `~~~` fences. Pass `exact := true` to take those three counts from cmark's AST instead, so they agree with `md_extract_links` and `md_extract_code_blocks`. The default is unchanged for compatibility; `word_count`, `char_count`, `line_count` and `reading_time_minutes` are textual and identical either way.
+
+  ```sql
+  SELECT (md_stats(content)).link_count,                 -- scanner: counts images and code samples
+         (md_stats(content, exact := true)).link_count   -- cmark: real links only, references and autolinks included
+  FROM read_markdown('docs/*.md');
+  ```
 - **`md_extract_metadata(markdown)`** - Extract frontmatter as `MAP(VARCHAR, VARCHAR)`. This is a lightweight **line-split key/value** reader (each line split on the first `:`), *not* a full YAML parser — nested maps, lists, and multiline scalars are not interpreted. For real YAML — nested maps, lists, `|`/`>` blocks — use the `yaml` extension's `read_yaml_frontmatter`; see [Frontmatter Handling](#frontmatter-handling).
 - **`md_extract_frontmatter(markdown)`** - Extract the **raw** frontmatter block (the text between the `---` fences) as `VARCHAR`, or `NULL` when there is no frontmatter. Composes with `duckdb_yaml` for real YAML parsing without this extension carrying a YAML parser: e.g. `SELECT yaml(md_extract_frontmatter(content))`.
 - **`md_extract_section(markdown, section_id, [include_subsections])`** - Extract specific section by ID. With `include_subsections := true`, includes all nested content (full mode); default is minimal mode.

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -11,5 +11,7 @@ duckdb_extension_load(markdown
     LINKED_LIBS "$<TARGET_FILE:libcmark-gfm-extensions_static>;$<TARGET_FILE:libcmark-gfm_static>"
 )
 
-# Any extra extensions that should be built
-# e.g.: duckdb_extension_load(json)
+# Any extra extensions that should be built.
+# json: test/sql/table_cell_json_valid.test uses json_valid() behind a file-level
+# `require json`. Without this line that whole file is silently skipped (issue #36).
+duckdb_extension_load(json)

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -159,6 +159,90 @@ static void ParseJSONStringArrayBody(const string &body, vector<string> &out) {
 }
 
 //===--------------------------------------------------------------------===//
+// JSON array structure
+//
+// The table JSON produced by markdown_utils is {"headers": [...], "rows":
+// [[...], ...]}, but the cells inside it are arbitrary user text. Locating the
+// arrays with plain find('[') / find(']') treats a bracket inside a cell string
+// as structure: a ']' truncated its row (or, in a header, emptied the headers
+// array and killed the table), and a stray '[' could be read as the start of a
+// phantom row. Brackets and braces inside a JSON string are text, so every scan
+// below steps over strings rather than through them.
+//===--------------------------------------------------------------------===//
+
+// `open_quote` indexes the opening quote of a JSON string; returns the index of
+// its closing quote, or npos if the string is unterminated. Backslash escapes
+// are honoured, so \" does not end the string and \\ does not escape the quote
+// after it.
+static size_t FindJSONStringEnd(const string &src, size_t open_quote) {
+	for (size_t i = open_quote + 1; i < src.size(); i++) {
+		if (src[i] == '\\') {
+			i++; // skip whatever the backslash escapes, including another backslash
+		} else if (src[i] == '"') {
+			return i;
+		}
+	}
+	return string::npos;
+}
+
+// `open` indexes a '['; returns the index of the matching ']', or npos if the
+// array is unbalanced (or contains an unterminated string).
+static size_t FindMatchingBracket(const string &src, size_t open) {
+	int depth = 0;
+	for (size_t i = open; i < src.size(); i++) {
+		char c = src[i];
+		if (c == '"') {
+			size_t end = FindJSONStringEnd(src, i);
+			if (end == string::npos) {
+				return string::npos;
+			}
+			i = end;
+		} else if (c == '[') {
+			depth++;
+		} else if (c == ']') {
+			if (--depth == 0) {
+				return i;
+			}
+		}
+	}
+	return string::npos;
+}
+
+// Find the array that is the value of key `key`, returning the index of its
+// '[' or npos. Only a real key position matches: the scan skips over string
+// contents, so a cell whose text happens to read `"rows": [` is not mistaken
+// for the key, and the name must actually be followed by ':' and '['.
+static size_t FindJSONArrayValue(const string &src, const string &key) {
+	const string quoted = "\"" + key + "\"";
+	for (size_t i = 0; i < src.size(); i++) {
+		if (src[i] != '"') {
+			continue;
+		}
+		size_t end = FindJSONStringEnd(src, i);
+		if (end == string::npos) {
+			return string::npos;
+		}
+		if (end == i + quoted.size() - 1 && src.compare(i, quoted.size(), quoted) == 0) {
+			size_t j = end + 1;
+			while (j < src.size() && StringUtil::CharacterIsSpace(src[j])) {
+				j++;
+			}
+			if (j < src.size() && src[j] == ':') {
+				j++;
+				while (j < src.size() && StringUtil::CharacterIsSpace(src[j])) {
+					j++;
+				}
+				if (j < src.size() && src[j] == '[') {
+					return j;
+				}
+			}
+		}
+		i = end;
+	}
+	return string::npos;
+}
+
+//===--------------------------------------------------------------------===//
 // Helper Functions
 //===--------------------------------------------------------------------===//
 
@@ -211,40 +295,50 @@ vector<string> DuckBlockFunctions::ParseJsonListItems(const string &content) {
 }
 
 void DuckBlockFunctions::ParseJsonTable(const string &content, vector<string> &headers, vector<vector<string>> &rows) {
-	// Find headers array
-	size_t headers_start = content.find("\"headers\":");
-	if (headers_start != string::npos) {
-		size_t arr_start = content.find('[', headers_start);
-		size_t arr_end = content.find(']', arr_start);
-		if (arr_start != string::npos && arr_end != string::npos) {
-			string headers_str = content.substr(arr_start + 1, arr_end - arr_start - 1);
-			ParseJSONStringArrayBody(headers_str, headers);
+	// Headers: a flat array of strings.
+	size_t headers_open = FindJSONArrayValue(content, "headers");
+	if (headers_open != string::npos) {
+		size_t headers_close = FindMatchingBracket(content, headers_open);
+		if (headers_close != string::npos) {
+			ParseJSONStringArrayBody(content.substr(headers_open + 1, headers_close - headers_open - 1), headers);
 		}
 	}
 
-	// Find rows array
-	size_t rows_start = content.find("\"rows\":");
-	if (rows_start != string::npos) {
-		size_t outer_start = content.find('[', rows_start);
-		if (outer_start != string::npos) {
-			size_t pos = outer_start + 1;
-			while (pos < content.size()) {
-				size_t row_start = content.find('[', pos);
-				if (row_start == string::npos)
-					break;
-				size_t row_end = content.find(']', row_start);
-				if (row_end == string::npos)
-					break;
-
-				string row_str = content.substr(row_start + 1, row_end - row_start - 1);
-				vector<string> row;
-				ParseJSONStringArrayBody(row_str, row);
-				if (!row.empty()) {
-					rows.push_back(row);
-				}
-				pos = row_end + 1;
+	// Rows: an array of arrays. Walk the outer array's body, stepping over any
+	// string so that brackets inside cells stay text.
+	size_t rows_open = FindJSONArrayValue(content, "rows");
+	if (rows_open == string::npos) {
+		return;
+	}
+	size_t rows_close = FindMatchingBracket(content, rows_open);
+	if (rows_close == string::npos) {
+		return;
+	}
+	size_t pos = rows_open + 1;
+	while (pos < rows_close) {
+		char c = content[pos];
+		if (c == '"') {
+			size_t str_end = FindJSONStringEnd(content, pos);
+			if (str_end == string::npos) {
+				break;
 			}
+			pos = str_end + 1;
+			continue;
 		}
+		if (c != '[') {
+			pos++;
+			continue;
+		}
+		size_t row_close = FindMatchingBracket(content, pos);
+		if (row_close == string::npos || row_close > rows_close) {
+			break;
+		}
+		vector<string> row;
+		ParseJSONStringArrayBody(content.substr(pos + 1, row_close - pos - 1), row);
+		if (!row.empty()) {
+			rows.push_back(row);
+		}
+		pos = row_close + 1;
 	}
 }
 

--- a/src/include/markdown_utils.hpp
+++ b/src/include/markdown_utils.hpp
@@ -76,8 +76,25 @@ std::string StripFrontmatter(const std::string &markdown_str);
 // Convert metadata to DuckDB MAP value
 Value MetadataToMap(const MarkdownMetadata &metadata);
 
-// Calculate document statistics
-MarkdownStats CalculateStats(const std::string &markdown_str);
+// Calculate document statistics.
+//
+// `exact` selects how the three *structural* counts -- heading_count,
+// code_block_count and link_count -- are obtained (#21):
+//
+//   false (default): the historical line/character scanners. Kept bit-for-bit
+//     so md_stats(doc) never changes under existing callers. They count '```'
+//     fences in pairs and match a literal "[text](target)" anywhere in the
+//     document, so they see links inside code, count images as links, and miss
+//     reference links, autolinks, setext headings, indented code and ~~~ fences.
+//
+//   true: counted from cmark's AST, so they agree with what this extension's
+//     own extraction functions already report -- link_count equals
+//     len(md_extract_links(doc)) and code_block_count equals
+//     len(md_extract_code_blocks(doc)).
+//
+// word_count, char_count, line_count and reading_time_minutes are textual
+// measures with no AST counterpart and are identical under both.
+MarkdownStats CalculateStats(const std::string &markdown_str, bool exact = false);
 
 //===--------------------------------------------------------------------===//
 // Section Parsing

--- a/src/markdown_scalar_functions.cpp
+++ b/src/markdown_scalar_functions.cpp
@@ -120,6 +120,72 @@ void MarkdownFunctions::RegisterMarkdownTypeFunctions(ExtensionLoader &loader) {
 	loader.RegisterFunction(value_to_md_fun);
 }
 
+namespace {
+
+// The all-zero stats struct returned for empty input and for any input that
+// throws, shared by both md_stats overloads.
+Value EmptyStatsValue() {
+	child_list_t<Value> struct_values;
+	struct_values.push_back(std::make_pair("word_count", Value::BIGINT(0)));
+	struct_values.push_back(std::make_pair("char_count", Value::BIGINT(0)));
+	struct_values.push_back(std::make_pair("line_count", Value::BIGINT(0)));
+	struct_values.push_back(std::make_pair("heading_count", Value::BIGINT(0)));
+	struct_values.push_back(std::make_pair("code_block_count", Value::BIGINT(0)));
+	struct_values.push_back(std::make_pair("link_count", Value::BIGINT(0)));
+	struct_values.push_back(std::make_pair("reading_time_minutes", Value::DOUBLE(0.0)));
+	return Value::STRUCT(std::move(struct_values));
+}
+
+Value StatsValue(const markdown_utils::MarkdownStats &stats) {
+	child_list_t<Value> struct_values;
+	struct_values.push_back(std::make_pair("word_count", Value::BIGINT(stats.word_count)));
+	struct_values.push_back(std::make_pair("char_count", Value::BIGINT(stats.char_count)));
+	struct_values.push_back(std::make_pair("line_count", Value::BIGINT(stats.line_count)));
+	struct_values.push_back(std::make_pair("heading_count", Value::BIGINT(stats.heading_count)));
+	struct_values.push_back(std::make_pair("code_block_count", Value::BIGINT(stats.code_block_count)));
+	struct_values.push_back(std::make_pair("link_count", Value::BIGINT(stats.link_count)));
+	struct_values.push_back(std::make_pair("reading_time_minutes", Value::DOUBLE(stats.reading_time_minutes)));
+	return Value::STRUCT(std::move(struct_values));
+}
+
+// `has_exact_arg` says whether this is the two-argument overload. The flag is
+// read per row, so a non-constant expression works. Both overloads use DuckDB's
+// default null handling, so a NULL in either argument yields a NULL struct
+// without the function running at all; the IsNull guard below is belt and
+// braces for the paths that do not fold.
+void ExecuteStats(DataChunk &args, Vector &result, bool has_exact_arg) {
+	auto &markdown_vector = args.data[0];
+
+	for (idx_t row_idx = 0; row_idx < args.size(); row_idx++) {
+		try {
+			Value md_value = markdown_vector.GetValue(row_idx);
+
+			if (md_value.IsNull()) {
+				result.SetValue(row_idx, Value());
+				continue;
+			}
+
+			bool exact = false;
+			if (has_exact_arg) {
+				Value exact_value = args.data[1].GetValue(row_idx);
+				exact = !exact_value.IsNull() && BooleanValue::Get(exact_value);
+			}
+
+			string md_str = StringValue::Get(md_value);
+			if (md_str.empty()) {
+				result.SetValue(row_idx, EmptyStatsValue());
+				continue;
+			}
+
+			result.SetValue(row_idx, StatsValue(markdown_utils::CalculateStats(md_str, exact)));
+		} catch (const std::exception &e) {
+			result.SetValue(row_idx, EmptyStatsValue());
+		}
+	}
+}
+
+} // namespace
+
 void MarkdownFunctions::RegisterStatsFunctions(ExtensionLoader &loader) {
 	auto markdown_type = MarkdownTypes::MarkdownType();
 
@@ -136,67 +202,27 @@ void MarkdownFunctions::RegisterStatsFunctions(ExtensionLoader &loader) {
 	auto stats_struct_type = LogicalType::STRUCT(stats_struct_types);
 
 	ScalarFunction md_stats_fun(
-	    "md_stats", {markdown_type}, stats_struct_type, [](DataChunk &args, ExpressionState &state, Vector &result) {
-		    auto &markdown_vector = args.data[0];
-
-		    for (idx_t row_idx = 0; row_idx < args.size(); row_idx++) {
-			    try {
-				    Value md_value = markdown_vector.GetValue(row_idx);
-
-				    if (md_value.IsNull()) {
-					    result.SetValue(row_idx, Value());
-					    continue;
-				    }
-
-				    string md_str = StringValue::Get(md_value);
-
-				    if (md_str.empty()) {
-					    // Return empty stats struct
-					    child_list_t<Value> struct_values;
-					    struct_values.push_back(std::make_pair("word_count", Value::BIGINT(0)));
-					    struct_values.push_back(std::make_pair("char_count", Value::BIGINT(0)));
-					    struct_values.push_back(std::make_pair("line_count", Value::BIGINT(0)));
-					    struct_values.push_back(std::make_pair("heading_count", Value::BIGINT(0)));
-					    struct_values.push_back(std::make_pair("code_block_count", Value::BIGINT(0)));
-					    struct_values.push_back(std::make_pair("link_count", Value::BIGINT(0)));
-					    struct_values.push_back(std::make_pair("reading_time_minutes", Value::DOUBLE(0.0)));
-
-					    result.SetValue(row_idx, Value::STRUCT(struct_values));
-					    continue;
-				    }
-
-				    auto stats = markdown_utils::CalculateStats(md_str);
-
-				    // Create struct value
-				    child_list_t<Value> struct_values;
-				    struct_values.push_back(std::make_pair("word_count", Value::BIGINT(stats.word_count)));
-				    struct_values.push_back(std::make_pair("char_count", Value::BIGINT(stats.char_count)));
-				    struct_values.push_back(std::make_pair("line_count", Value::BIGINT(stats.line_count)));
-				    struct_values.push_back(std::make_pair("heading_count", Value::BIGINT(stats.heading_count)));
-				    struct_values.push_back(std::make_pair("code_block_count", Value::BIGINT(stats.code_block_count)));
-				    struct_values.push_back(std::make_pair("link_count", Value::BIGINT(stats.link_count)));
-				    struct_values.push_back(
-				        std::make_pair("reading_time_minutes", Value::DOUBLE(stats.reading_time_minutes)));
-
-				    result.SetValue(row_idx, Value::STRUCT(struct_values));
-
-			    } catch (const std::exception &e) {
-				    // Return empty stats on error
-				    child_list_t<Value> struct_values;
-				    struct_values.push_back(std::make_pair("word_count", Value::BIGINT(0)));
-				    struct_values.push_back(std::make_pair("char_count", Value::BIGINT(0)));
-				    struct_values.push_back(std::make_pair("line_count", Value::BIGINT(0)));
-				    struct_values.push_back(std::make_pair("heading_count", Value::BIGINT(0)));
-				    struct_values.push_back(std::make_pair("code_block_count", Value::BIGINT(0)));
-				    struct_values.push_back(std::make_pair("link_count", Value::BIGINT(0)));
-				    struct_values.push_back(std::make_pair("reading_time_minutes", Value::DOUBLE(0.0)));
-
-				    result.SetValue(row_idx, Value::STRUCT(struct_values));
-			    }
-		    }
-	    });
-
+	    "md_stats", {markdown_type}, stats_struct_type,
+	    [](DataChunk &args, ExpressionState &state, Vector &result) { ExecuteStats(args, result, false); });
 	loader.RegisterFunction(md_stats_fun);
+
+	// md_stats(doc, exact) -- opt-in accurate structural counts (#21).
+	//
+	// A second overload rather than extra struct fields: adding fields would
+	// change the return TYPE of md_stats(doc) for every existing caller (views,
+	// CTAS, struct comparisons), which is a shape change forced on people who
+	// asked for nothing. This way md_stats(doc) is untouched -- same type, same
+	// values -- and the accurate counts are one explicit argument away, in the
+	// same columns, so nothing downstream has to be renamed.
+	//
+	// Note on spelling: DuckDB accepts `md_stats(doc, exact := true)` and it
+	// reads well, but scalar functions have no named-parameter map, so the label
+	// is not validated -- it binds positionally either way. Documented as a
+	// positional BOOLEAN for that reason.
+	ScalarFunction md_stats_exact_fun(
+	    "md_stats", {markdown_type, LogicalType::BOOLEAN}, stats_struct_type,
+	    [](DataChunk &args, ExpressionState &state, Vector &result) { ExecuteStats(args, result, true); });
+	loader.RegisterFunction(md_stats_exact_fun);
 
 	// Register md_extract_section function (2-arg version: uses minimal mode)
 	ScalarFunction md_extract_section(

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1596,6 +1596,13 @@ std::vector<MarkdownTable> ExtractTables(const std::string &markdown_str) {
 		}
 
 		MarkdownTable table;
+		// Exact except when the table interrupts a paragraph, where cmark reports
+		// the paragraph's first line instead of the header row's (#21 item 4).
+		// Not fixable cleanly: the table_header child carries the same wrong
+		// start_line, the interrupting paragraph node's own line numbers come back
+		// as 0, and deriving the header line from the first body row is a
+		// heuristic with no answer for a header-only table. Pinned in
+		// test/sql/markdown_tables_edge_cases.test.
 		table.line_number = static_cast<idx_t>(cmark_node_get_start_line(node));
 
 		uint16_t n_columns = cmark_gfm_extensions_get_table_columns(node);

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -299,7 +299,52 @@ Value MetadataToMap(const MarkdownMetadata &metadata) {
 	return Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(keys), std::move(values));
 }
 
-MarkdownStats CalculateStats(const std::string &markdown_str_in) {
+// Structural counts taken from cmark's AST, for CalculateStats(..., exact=true).
+// Parsed with CMARK_OPT_DEFAULT and no extensions registered, which is exactly
+// what ExtractLinks and ExtractCodeBlocks do -- that is the point: in exact mode
+// md_stats must agree with md_extract_links / md_extract_code_blocks rather than
+// give a second opinion on the same document.
+static void CountStructuralNodes(const std::string &markdown_str, MarkdownStats &stats) {
+	stats.heading_count = 0;
+	stats.code_block_count = 0;
+	stats.link_count = 0;
+	if (markdown_str.empty()) {
+		return;
+	}
+
+	cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
+	cmark_parser_feed(parser, markdown_str.c_str(), markdown_str.length());
+	cmark_node *doc = cmark_parser_finish(parser);
+	cmark_iter *iter = cmark_iter_new(doc);
+
+	cmark_event_type ev_type;
+	while ((ev_type = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
+		if (ev_type != CMARK_EVENT_ENTER) {
+			continue;
+		}
+		switch (cmark_node_get_type(cmark_iter_get_node(iter))) {
+		case CMARK_NODE_HEADING:
+			stats.heading_count++;
+			break;
+		case CMARK_NODE_CODE_BLOCK:
+			stats.code_block_count++;
+			break;
+		case CMARK_NODE_LINK:
+			// Deliberately not CMARK_NODE_IMAGE: an image is not a link. The
+			// scanner counting them was one of the divergences in #21.
+			stats.link_count++;
+			break;
+		default:
+			break;
+		}
+	}
+
+	cmark_iter_free(iter);
+	cmark_node_free(doc);
+	cmark_parser_free(parser);
+}
+
+MarkdownStats CalculateStats(const std::string &markdown_str_in, bool exact) {
 	MarkdownStats stats = {};
 
 	// Skip a leading BOM before counting anything: it is an encoding marker,
@@ -318,6 +363,16 @@ MarkdownStats CalculateStats(const std::string &markdown_str_in) {
 
 	stats.char_count = markdown_str.length();
 	stats.line_count = static_cast<idx_t>(std::count(markdown_str.begin(), markdown_str.end(), '\n')) + 1;
+
+	// Exact mode: the three structural counts come from cmark's AST instead of
+	// the scanners below. Everything above (word/char/line) is textual and the
+	// same either way; reading_time_minutes is derived from word_count at the
+	// end, so it is unaffected too.
+	if (exact) {
+		CountStructuralNodes(markdown_str, stats);
+		stats.reading_time_minutes = static_cast<double>(stats.word_count) / 200.0;
+		return stats;
+	}
 
 	// Count headings (#17: this previously returned 0 unless the document *opened* with a
 	// heading — a single-pass `^#{1,6}` only anchors at string start). Scan line-by-line,

--- a/test/sql/duck_block_table_json_brackets.test
+++ b/test/sql/duck_block_table_json_brackets.test
@@ -1,0 +1,130 @@
+# name: test/sql/duck_block_table_json_brackets.test
+# description: duck_block_to_md must not split the JSON rows array on brackets inside cells (#21)
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# ParseJsonTable used to locate the headers/rows arrays with plain
+# content.find('[') / content.find(']'), which treats a bracket inside a cell
+# string as structure. A cell containing ']' truncated (or deleted) its row, a
+# stray '[' could start a phantom row, and a ']' in a header killed the whole
+# table -- headers came back empty, so the renderer fell through and emitted the
+# raw JSON. Brackets inside JSON strings are text; the parser must say so.
+# =============================================================================
+
+# A ']' in a body cell: the row keeps both cells, and the following row survives.
+query I
+SELECT duck_block_to_md({
+    kind: 'block',
+    element_type: 'table',
+    content: '{"headers": ["A", "B"], "rows": [["a]b", "c"], ["d", "e"]]}',
+    level: NULL,
+    encoding: 'json',
+    attributes: MAP{},
+    element_order: 0
+}) LIKE '%| A | B |%| a]b | c |%| d | e |%';
+----
+true
+
+# A '[' in a body cell.
+query I
+SELECT duck_block_to_md({
+    kind: 'block',
+    element_type: 'table',
+    content: '{"headers": ["A", "B"], "rows": [["a[b", "c"], ["d", "e"]]}',
+    level: NULL,
+    encoding: 'json',
+    attributes: MAP{},
+    element_order: 0
+}) LIKE '%| a[b | c |%| d | e |%';
+----
+true
+
+# ']' in one cell and '[' in the next: the ']' used to end the row early and the
+# '[' was then read as the start of a phantom row, losing a real row entirely.
+query I
+SELECT duck_block_to_md({
+    kind: 'block',
+    element_type: 'table',
+    content: '{"headers": ["A", "B"], "rows": [["a]b", "c[d"], ["e", "f"]]}',
+    level: NULL,
+    encoding: 'json',
+    attributes: MAP{},
+    element_order: 0
+}) LIKE '%| a]b | c[d |%| e | f |%';
+----
+true
+
+# A ']' in a HEADER cell: headers came back empty, so nothing was rendered as a
+# table at all and the raw JSON was emitted verbatim.
+query I
+SELECT duck_block_to_md({
+    kind: 'block',
+    element_type: 'table',
+    content: '{"headers": ["a]b", "Age"], "rows": [["Alice", "30"]]}',
+    level: NULL,
+    encoding: 'json',
+    attributes: MAP{},
+    element_order: 0
+}) LIKE '%| a]b | Age |%| Alice | 30 |%';
+----
+true
+
+# Both brackets plus an escaped quote in the same cell.
+query I
+SELECT duck_block_to_md({
+    kind: 'block',
+    element_type: 'table',
+    content: '{"headers": ["A", "B"], "rows": [["x", "arr[0] = \"y\""], ["p", "q"]]}',
+    level: NULL,
+    encoding: 'json',
+    attributes: MAP{},
+    element_order: 0
+}) LIKE '%| x | arr[0] = "y" |%| p | q |%';
+----
+true
+
+# A cell whose text imitates the surrounding JSON. Locating "rows" with a plain
+# substring search would find the one inside the cell; the key lookup has to
+# honour string boundaries too.
+query I
+SELECT duck_block_to_md({
+    kind: 'block',
+    element_type: 'table',
+    content: '{"headers": ["A", "B"], "rows": [["x", "], \"rows\": [[\"phantom\""], ["p", "q"]]}',
+    level: NULL,
+    encoding: 'json',
+    attributes: MAP{},
+    element_order: 0
+}) LIKE '%| p | q |%';
+----
+true
+
+# ...and the phantom cell must not appear as a row of its own.
+query I
+SELECT duck_block_to_md({
+    kind: 'block',
+    element_type: 'table',
+    content: '{"headers": ["A", "B"], "rows": [["x", "], \"rows\": [[\"phantom\""], ["p", "q"]]}',
+    level: NULL,
+    encoding: 'json',
+    attributes: MAP{},
+    element_order: 0
+}) NOT LIKE '%| phantom |%';
+----
+true
+
+# Escaped backslash before a quote must not be read as escaping the quote.
+query I
+SELECT duck_block_to_md({
+    kind: 'block',
+    element_type: 'table',
+    content: '{"headers": ["A", "B"], "rows": [["back\\slash", "c]d"], ["e", "f"]]}',
+    level: NULL,
+    encoding: 'json',
+    attributes: MAP{},
+    element_order: 0
+}) LIKE '%| c]d |%| e | f |%';
+----
+true

--- a/test/sql/frontmatter_raw.test
+++ b/test/sql/frontmatter_raw.test
@@ -1,17 +1,19 @@
-# name: test/sql/frontmatter_raw_and_json_escape.test
-# description: md_extract_frontmatter raw block (#17) + table-cell JSON escaping (#21)
+# name: test/sql/frontmatter_raw.test
+# description: md_extract_frontmatter raw block (#17)
 # group: [sql]
 
 require markdown
-
-# json_valid (below) lives in the json extension.
-require json
 
 # =============================================================================
 # md_extract_frontmatter: the RAW frontmatter block between the --- fences, for
 # callers who want to hand it to duckdb_yaml rather than the line-split MAP.
 # Newlines are built with chr(10) — sqllogictest does not allow literal newlines
 # inside a SQL string literal.
+#
+# These assertions need nothing beyond the markdown extension itself. They used
+# to live in frontmatter_raw_and_json_escape.test, behind that file's
+# `require json`, which is file-level — so they never ran anywhere json was not
+# loaded (issue #36).
 # =============================================================================
 
 # Single-line body compared directly.
@@ -35,18 +37,5 @@ true
 # NULL input -> NULL.
 query I
 SELECT md_extract_frontmatter(NULL::VARCHAR) IS NULL;
-----
-true
-
-# =============================================================================
-# Table-cell JSON escaping (#21): a literal tab in a cell must still produce
-# VALID JSON in the `encoding='json'` block content. Pre-fix the table path
-# escaped only " \ \n, so a tab emitted a raw byte and broke the JSON.
-# =============================================================================
-
-query I
-SELECT bool_and(json_valid(content))
-FROM read_markdown_blocks('test/md/tab_in_cell.md')
-WHERE encoding = 'json';
 ----
 true

--- a/test/sql/markdown_tables_edge_cases.test
+++ b/test/sql/markdown_tables_edge_cases.test
@@ -203,6 +203,48 @@ FROM (SELECT UNNEST(md_extract_tables_json(
 ----
 [1, 5]
 
+# KNOWN DIVERGENCE (#21 item 4): a GFM table may interrupt a paragraph, and when
+# it does cmark reports the table's start_line as the paragraph's FIRST line
+# rather than the header row's. The error is as large as the paragraph is long:
+# below the header row is line 4 and cmark says 1.
+#
+# Investigated and deliberately not fixed. cmark does not expose the header
+# row's line anywhere: the table_header child node carries the same wrong
+# start_line as the table itself, and in this case the interrupting paragraph
+# node's own start_line/end_line come back as 0, so there is nothing correct to
+# add to. The only derivation available is arithmetic off the first body row
+# (header = first body row - 2, the delimiter being between them), which is a
+# heuristic on a sibling node and has no answer at all for a header-only table
+# -- see the second case below, which has no body row. Re-scanning the source
+# for the header line was ruled out. Asserted as-is so the divergence is visible
+# and cannot widen unnoticed.
+query I
+SELECT t.line_number
+FROM (SELECT UNNEST(md_extract_tables_json(
+        'line one' || chr(10) || 'line two' || chr(10) || 'line three' || chr(10) ||
+        '| A | B |' || chr(10) || '|---|---|' || chr(10) || '| 1 | 2 |')) t);
+----
+1
+
+# Header-only interrupting table: no body row exists, so even the arithmetic
+# workaround has nothing to work from. Header row is line 2; cmark says 1.
+query I
+SELECT t.line_number
+FROM (SELECT UNNEST(md_extract_tables_json(
+        'Some paragraph text' || chr(10) || '| A | B |' || chr(10) || '|---|---|')) t);
+----
+1
+
+# A table that does NOT interrupt a paragraph is exact -- the divergence is
+# specific to the interrupting case.
+query I
+SELECT t.line_number
+FROM (SELECT UNNEST(md_extract_tables_json(
+        'Some paragraph text' || chr(10) || chr(10) ||
+        '| A | B |' || chr(10) || '|---|---|' || chr(10) || '| 1 | 2 |')) t);
+----
+3
+
 # Column alignments from the delimiter row are parsed (internal today -- the
 # public structs do not expose alignment -- but a table with an alignment row
 # must still extract cleanly).

--- a/test/sql/md_stats_exact.test
+++ b/test/sql/md_stats_exact.test
@@ -1,0 +1,144 @@
+# name: test/sql/md_stats_exact.test
+# description: md_stats(doc, exact) — opt-in cmark-derived structural counts (#21)
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# md_stats(doc) counts headings, code blocks and links with line/character
+# scanners. They diverge from cmark: they see links inside code spans and fenced
+# code, count images as links, and miss reference links, autolinks, setext
+# headings, indented code blocks and ~~~ fences.
+#
+# md_stats(doc) is NOT changed — same return type, same values. The second
+# argument opts into counts taken from cmark's AST, which by construction agree
+# with this extension's own extractors (md_extract_links,
+# md_extract_code_blocks) instead of giving a second opinion on the same doc.
+#
+# Every assertion below that uses one argument is the pre-existing behaviour and
+# must keep its value.
+# =============================================================================
+
+statement ok
+CREATE TEMPORARY MACRO doc() AS (E'# Title\nInline [a](http://a) and image ![i](http://i.png).\nRef [b][ref] and auto <http://c>.\nCode span `[x](http://x)`.\n\n```md\n[y](http://y)\n[z](http://z)\n```\n\n[ref]: http://b\n');
+
+# The headline divergence. The scanner finds five "[text](target)" matches: the
+# real link, the image, the one in a code span and the two inside the fence. It
+# finds neither the reference link nor the autolink. cmark sees three links.
+query II
+SELECT (md_stats(doc())).link_count, (md_stats(doc(), true)).link_count;
+----
+5	3
+
+# Exact mode agrees with the extractors — that is the contract, not a
+# coincidence of this document.
+query II
+SELECT (md_stats(doc(), true)).link_count = len(md_extract_links(doc())),
+       (md_stats(doc(), true)).code_block_count = len(md_extract_code_blocks(doc()));
+----
+true	true
+
+# An image is not a link. It is counted by the scanner and not by exact mode,
+# and md_extract_images finds exactly the one the scanner over-counted.
+query I
+SELECT (md_stats(doc())).link_count - (md_stats(doc(), true)).link_count
+       >= len(md_extract_images(doc()));
+----
+true
+
+# The `exact :=` spelling binds to the same overload. DuckDB does not validate
+# named-argument labels for scalar functions, so this is sugar, not a contract;
+# asserted so the documented call form is known to work.
+query I
+SELECT (md_stats(doc(), exact := true)).link_count;
+----
+3
+
+# =============================================================================
+# The divergences already asserted elsewhere in the suite, now with the exact
+# column beside them. Left value = existing behaviour, unchanged.
+# =============================================================================
+
+# markdown_malformed_inputs.test: an unterminated ``` fence, and a ~~~ fence.
+# The scanner counts ``` in pairs and does not know ~~~ exists, so it sees no
+# code block in either; cmark sees one in each.
+query IIII
+SELECT (md_stats('```sql' || chr(10) || 'SELECT 1')).code_block_count,
+       (md_stats('```sql' || chr(10) || 'SELECT 1', true)).code_block_count,
+       (md_stats('~~~py' || chr(10) || 'x')).code_block_count,
+       (md_stats('~~~py' || chr(10) || 'x', true)).code_block_count;
+----
+0	1	0	1
+
+# A setext heading is a heading to cmark; the ATX line scanner cannot see one.
+query II
+SELECT (md_stats(E'Setext\n======\ntext')).heading_count,
+       (md_stats(E'Setext\n======\ntext', true)).heading_count;
+----
+0	1
+
+# An indented code block is a code block to cmark; the fence counter cannot see one.
+query II
+SELECT (md_stats(E'    indented code')).code_block_count,
+       (md_stats(E'    indented code', true)).code_block_count;
+----
+0	1
+
+# markdown_security_regression.test: a document where the two agree. Exact mode
+# is not a general shift in the numbers — it only moves where the scanners were
+# wrong.
+query III
+SELECT (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```', true)).heading_count,
+       (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```', true)).link_count,
+       (md_stats(E'# H1\n## H2\ntext [a](b) and [c](d)\n```\ncode\n```', true)).code_block_count;
+----
+2	2	1
+
+# markdown_security_regression.test: the long unterminated "[" that used to trip
+# the old regex still costs nothing in exact mode.
+query I
+SELECT (md_stats(repeat('a', 5) || '[' || repeat('b', 300000), true)).link_count;
+----
+0
+
+# =============================================================================
+# The textual fields are the same under both modes — "exact" is scoped to the
+# three structural counts and claims nothing about word or character counting.
+# =============================================================================
+
+query I
+SELECT (md_stats(doc())).word_count = (md_stats(doc(), true)).word_count
+   AND (md_stats(doc())).char_count = (md_stats(doc(), true)).char_count
+   AND (md_stats(doc())).line_count = (md_stats(doc(), true)).line_count
+   AND (md_stats(doc())).reading_time_minutes = (md_stats(doc(), true)).reading_time_minutes;
+----
+true
+
+# exact := false is exactly the one-argument function.
+query I
+SELECT md_stats(doc(), false) = md_stats(doc());
+----
+true
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+# NULL document -> NULL struct, as with one argument.
+query II
+SELECT md_stats(NULL::VARCHAR, true) IS NULL, md_stats(NULL::VARCHAR) IS NULL;
+----
+true	true
+
+# Empty document -> all zeros.
+query II
+SELECT (md_stats('', true)).link_count, (md_stats('', true)).code_block_count;
+----
+0	0
+
+# The flag does not have to be a constant: it is read per row.
+query II
+SELECT f, (md_stats(doc(), f)).link_count FROM (VALUES (false), (true)) t(f) ORDER BY f;
+----
+false	5
+true	3

--- a/test/sql/table_cell_json_valid.test
+++ b/test/sql/table_cell_json_valid.test
@@ -1,0 +1,25 @@
+# name: test/sql/table_cell_json_valid.test
+# description: table-cell JSON escaping (#21) validated with the json extension
+# group: [sql]
+
+require markdown
+
+# json_valid (below) lives in the json extension. This `require` is file-level,
+# so everything in this file is skipped where json is not loaded — keep only
+# genuinely json-dependent assertions here (issue #36). The escaper itself is
+# also covered, without json, by markdown_json_escape.test; this file is the
+# independent check that what we emit really parses as JSON.
+require json
+
+# =============================================================================
+# Table-cell JSON escaping (#21): a literal tab in a cell must still produce
+# VALID JSON in the `encoding='json'` block content. Pre-fix the table path
+# escaped only " \ \n, so a tab emitted a raw byte and broke the JSON.
+# =============================================================================
+
+query I
+SELECT bool_and(json_valid(content))
+FROM read_markdown_blocks('test/md/tab_in_cell.md')
+WHERE encoding = 'json';
+----
+true


### PR DESCRIPTION
Closes #36. Finishes the remaining items from #21.

## Dark tests (#36)

`frontmatter_raw_and_json_escape.test` was skipped in CI because it opens with `require json`
and CI never loaded that extension — and `require` is file-level, so **five assertions had
never run**, four of them `md_extract_frontmatter` tests unrelated to json.

Both halves fixed: the frontmatter assertions move to `frontmatter_raw.test` with no guard
(correct regardless of CI configuration), and `duckdb_extension_load(json)` is enabled so the
json-dependent half actually runs.

**Swept the rest of the suite** rather than fixing this one file and moving on: `require json`
was the only dark guard. `require notwindows` is deliberate and still runs on Linux and macOS.
No `require-env`, `skipif` or `onlyif` anywhere.

## `ParseJsonTable` bracket splitting (#21) — worse than reported

The issue said a cell containing `]` truncates the row. It is worse: a `]` in a **header**
emptied the headers array entirely and dumped raw JSON instead of a table. A cell that
imitates the surrounding JSON could also hijack the key lookup.

Fixed with real string-aware scanning rather than patching the split heuristic. Verified:

```
| a] b | c |        ->  header: [a] b] [c]
| x]y  | z |        ->  data:   [x]y]  [z]
```

8 new assertions, red first.

## `md_stats` accuracy (#21) — added, not redefined

`link_count` diverges from cmark by up to 7× (it counts images, code-span and fenced-code
examples, and misses reference and auto links). The recorded decision was to add accurate
counts rather than redefine existing fields.

Implemented as an **`md_stats(doc, exact BOOLEAN)` overload**, chosen over extra struct
fields for a specific reason: extra fields would change `md_stats`'s **return type** for every
existing caller — the same class of quiet regression the decision was avoiding. An overload
leaves the one-argument form byte-for-byte identical.

`exact` is defined by an invariant rather than by "whatever cmark says": it equals
`len(md_extract_links(doc))` and `len(md_extract_code_blocks(doc))`, so `md_stats` stops
contradicting its own extractors. Verified on a document with one link and one image:

| | `link_count` |
|---|---|
| `md_stats(doc)` | 2 (unchanged) |
| `md_stats(doc, true)` | 1 |
| `len(md_extract_links(doc))` | 1 |

## Table `line_number` (#21) — **not** fixed, deliberately

Investigated and rejected, with evidence:

- `table_header` carries the same wrong `start_line` as the table itself.
- The interrupting paragraph's own line numbers come back as `0`.
- A cell reports `start_col = 31` on a 9-character line — cmark's coordinates here are
  **buffer-relative, not source-relative**.

The only workaround is sibling arithmetic, which has no answer for a header-only table.
Pinned as a documented KNOWN DIVERGENCE instead of papered over with a heuristic.

## Testing

**1454 → 1499 assertions**, 32 → 36 test cases, and the skip count goes **1 → 0**. No existing
assertion changed.

## Notes

- `md_stats(doc, exact := true)` reads well, but DuckDB does **not** validate named-argument
  labels on scalar functions — `md_extract_section('x', banana := 'A')` binds silently — so
  the label is sugar. Documented as positional.
- A formatting-only commit is still owed: `make format` produces drift on ~9 files that
  predates this branch. Those hunks were reverted here so each commit stays on-topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjgU52vGS3mpSAwwgJD5C4
