### PR TITLE
chore: apply formatter drift and ignore .cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test_*.sql
 test_*.md
 *.cpp.tmp
 SELECT*
+
+# clangd index
+.cache/

--- a/src/include/markdown_utils.hpp
+++ b/src/include/markdown_utils.hpp
@@ -169,15 +169,15 @@ struct MarkdownImage {
 // Obsidian / wiki-style inline elements (not part of CommonMark, so cmark-gfm does
 // not see them — extracted with a line-by-line regex pass, like the reference-link scan).
 struct MarkdownWikilink {
-	std::string target;   // [[target]] — the page/note name (before #, ^, |)
-	std::string alias;    // [[target|alias]] — display text, "" if none
-	std::string anchor;   // [[target#heading]] -> "#heading", [[target^block]] -> "^block", "" if none
-	bool is_embed;        // ![[...]] transclusion
+	std::string target; // [[target]] — the page/note name (before #, ^, |)
+	std::string alias;  // [[target|alias]] — display text, "" if none
+	std::string anchor; // [[target#heading]] -> "#heading", [[target^block]] -> "^block", "" if none
+	bool is_embed;      // ![[...]] transclusion
 	idx_t line_number;
 };
 
 struct MarkdownTag {
-	std::string tag;      // #tag / #nested/tag — without the leading '#'
+	std::string tag; // #tag / #nested/tag — without the leading '#'
 	idx_t line_number;
 };
 

--- a/src/markdown_scalar_functions.cpp
+++ b/src/markdown_scalar_functions.cpp
@@ -354,32 +354,33 @@ void MarkdownFunctions::RegisterMetadataFunctions(ExtensionLoader &loader) {
 	// NULL when there is no frontmatter. This is the lightweight-markdown / real-YAML seam: pair it
 	// with duckdb_yaml (yaml(...) / read_yaml_frontmatter) when you need full YAML fidelity, without
 	// markdown itself carrying a YAML parser.
-	ScalarFunction md_extract_frontmatter_fun(
-	    "md_extract_frontmatter", {markdown_type}, LogicalType::VARCHAR,
-	    [](DataChunk &args, ExpressionState &state, Vector &result) {
-		    auto &input = args.data[0];
-		    auto count = args.size();
+	ScalarFunction md_extract_frontmatter_fun("md_extract_frontmatter", {markdown_type}, LogicalType::VARCHAR,
+	                                          [](DataChunk &args, ExpressionState &state, Vector &result) {
+		                                          auto &input = args.data[0];
+		                                          auto count = args.size();
 
-		    for (idx_t i = 0; i < count; i++) {
-			    auto md_value = input.GetValue(i);
-			    if (md_value.IsNull()) {
-				    result.SetValue(i, Value(LogicalType::VARCHAR));
-				    continue;
-			    }
+		                                          for (idx_t i = 0; i < count; i++) {
+			                                          auto md_value = input.GetValue(i);
+			                                          if (md_value.IsNull()) {
+				                                          result.SetValue(i, Value(LogicalType::VARCHAR));
+				                                          continue;
+			                                          }
 
-			    try {
-				    auto raw = markdown_utils::ExtractRawFrontmatter(md_value.ToString());
-				    if (raw.empty()) {
-					    // No frontmatter block (ExtractRawFrontmatter returns "" when absent).
-					    result.SetValue(i, Value(LogicalType::VARCHAR));
-				    } else {
-					    result.SetValue(i, Value(raw));
-				    }
-			    } catch (const std::exception &e) {
-				    result.SetValue(i, Value(LogicalType::VARCHAR));
-			    }
-		    }
-	    });
+			                                          try {
+				                                          auto raw = markdown_utils::ExtractRawFrontmatter(
+				                                              md_value.ToString());
+				                                          if (raw.empty()) {
+					                                          // No frontmatter block (ExtractRawFrontmatter returns ""
+					                                          // when absent).
+					                                          result.SetValue(i, Value(LogicalType::VARCHAR));
+				                                          } else {
+					                                          result.SetValue(i, Value(raw));
+				                                          }
+			                                          } catch (const std::exception &e) {
+				                                          result.SetValue(i, Value(LogicalType::VARCHAR));
+			                                          }
+		                                          }
+	                                          });
 
 	loader.RegisterFunction(md_extract_frontmatter_fun);
 }

--- a/src/markdown_types.cpp
+++ b/src/markdown_types.cpp
@@ -79,17 +79,15 @@ static bool MarkdownToTextCast(Vector &source, Vector &result, idx_t count, Cast
 }
 
 static bool VarcharToMarkdownCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-	UnaryExecutor::Execute<string_t, string_t>(source, result, count, [&](string_t str) -> string_t {
-		return StringVector::AddString(result, str);
-	});
+	UnaryExecutor::Execute<string_t, string_t>(
+	    source, result, count, [&](string_t str) -> string_t { return StringVector::AddString(result, str); });
 
 	return true;
 }
 
 static bool MarkdownToVarcharCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-	UnaryExecutor::Execute<string_t, string_t>(source, result, count, [&](string_t md_str) -> string_t {
-		return StringVector::AddString(result, md_str);
-	});
+	UnaryExecutor::Execute<string_t, string_t>(
+	    source, result, count, [&](string_t md_str) -> string_t { return StringVector::AddString(result, md_str); });
 
 	return true;
 }

--- a/test/sql/markdown_sections_varchar.test
+++ b/test/sql/markdown_sections_varchar.test
@@ -1,6 +1,6 @@
 # name: test/sql/markdown_sections_varchar.test
 # description: md_extract_sections resolves on VARCHAR / md inputs (Issue: binder ambiguity)
-# group: [markdown]
+# group: [sql]
 
 require markdown
 

--- a/test/sql/markdown_security_regression.test
+++ b/test/sql/markdown_security_regression.test
@@ -1,5 +1,7 @@
 # name: test/sql/markdown_security_regression.test
 # description: Regression tests for the linear-scanning extractors (GHSA-qv83-qqvf-72v9).
+# group: [sql]
+
 #              The previous hand-rolled std::regex extractors recursed while
 #              matching greedy quantifiers over untrusted input; an unclosed
 #              frontmatter block, a many-cell table, or a long unterminated "["
@@ -8,7 +10,6 @@
 #              inputs took down the base binary (verified out-of-process). The
 #              cases below all use BOUNDED inputs that tripped the old regexes
 #              and must now resolve cleanly in O(n).
-# group: [sql]
 
 require markdown
 

--- a/test/sql/md_stats_heading_count.test
+++ b/test/sql/md_stats_heading_count.test
@@ -1,6 +1,6 @@
 # name: test/sql/md_stats_heading_count.test
 # description: md_stats().heading_count counts every ATX heading line (issue #17)
-# group: [markdown]
+# group: [sql]
 
 require markdown
 

--- a/test/sql/wikilinks_tags.test
+++ b/test/sql/wikilinks_tags.test
@@ -1,8 +1,9 @@
 # name: test/sql/wikilinks_tags.test
 # description: Obsidian/wiki extraction via the `extract_extensions` add-on parameter on
+# group: [sql]
+
 #              read_markdown / read_markdown_sections / read_markdown_blocks, plus the
 #              md_stats heading_count fix and the un-gated scalar primitives.
-# group: [sql]
 
 require markdown
 


### PR DESCRIPTION
`make format` had been producing changes on ~9 files that no feature branch introduced. Every branch therefore either carried unrelated formatting hunks or reverted them by hand — three branches this week did the latter, which is wasted effort and makes each diff slightly dishonest about what it touched.

Applying it once, on its own, so the next branch starts from a clean `format-check`.

No behaviour change: **1499 assertions in 36 test cases** pass unchanged, and `format-check` is green.

Also adds `.cache/` (clangd's index) to `.gitignore` — it was showing as untracked in every `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjgU52vGS3mpSAwwgJD5C4