### PR TITLE
duck_block: align to spec 6.2, fix ten content-losing defects, add four checks

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -50,6 +50,19 @@ jobs:
       vcpkg_commit: bffcbb75f71553824aa948a7e7b4f798662a6fa7
       vcpkg_url: https://github.com/Microsoft/vcpkg.git
 
+  # src/include/duck_block_vocabulary.hpp is a VENDORED copy of the published
+  # duck_block vocabulary, so nothing notices when upstream moves. Renames are a
+  # compile error once the constants are in use; a changed VALUE is not -- it
+  # compiles clean and silently stops matching. This is what catches that.
+  # No submodules: the point of vendoring is that this needs none.
+  vocabulary-drift:
+    name: duck_block Vocabulary Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check vendored vocabulary against upstream duck_block_utils
+        run: python3 scripts/check_duck_block_vocabulary.py
+
   code-quality-check:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -61,6 +61,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check vendored vocabulary against upstream duck_block_utils
+        # The check resolves upstream's branch to a commit sha through the API
+        # before fetching, because the raw endpoint serves branch urls from a
+        # lagging cache. Unauthenticated that API is rate limited per IP, which
+        # runners share -- without a token the check would usually fall back to
+        # the cached branch url and report UNVERIFIED rather than a real answer.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/check_duck_block_vocabulary.py
 
   code-quality-check:

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -60,11 +60,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check this reader against the canonical conformance rules
-        # Pure SQL, no extension, no network -- so it cannot skip and needs no
-        # token. duck_blocks_validate() lives in an extension this repo cannot
-        # load, so this is the only conformance available to it.
-        run: python3 scripts/check_conformance.py
       - name: Check vendored vocabulary against upstream duck_block_utils
         # The check resolves upstream's branch to a commit sha through the API
         # before fetching, because the raw endpoint serves branch urls from a
@@ -74,6 +69,52 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/check_duck_block_vocabulary.py --strict
+
+  conformance:
+    name: duck_block Conformance
+    # NEEDS THE BUILT EXTENSION. This step first lived in vocabulary-drift, which
+    # checks out and runs python with no build at all, so it failed four runs in
+    # a row on "missing this extension's build" -- the check refusing to skip,
+    # correctly, in a job that could never satisfy it. The comment there claimed
+    # it was "pure SQL, no extension": the RULES are pure SQL, but the reader
+    # under test is this extension and the script loads it.
+    #
+    # The artifacts target released v1.5.4, so a stock duckdb of the same version
+    # can load them. That is only true of the CI build -- a local dev build
+    # reports a submodule hash and no released CLI will touch it.
+    #
+    # VERSION COUPLING: the artifact name and the CLI url below both hardcode
+    # v1.5.4, matching duckdb-stable-build's duckdb_version above. A reusable
+    # workflow's `with:` cannot read `env`, so this cannot be a single variable.
+    # Bumping the build's version without bumping these two fails LOUDLY here
+    # (artifact not found, or the CLI refuses the extension's ABI) rather than
+    # quietly checking nothing -- but it does need bumping in both places.
+    needs: duckdb-stable-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download the built extension
+        uses: actions/download-artifact@v4
+        with:
+          name: markdown-v1.5.4-extension-linux_amd64
+          path: ci-ext
+      - name: Install a matching DuckDB CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL -o duckdb.zip https://github.com/duckdb/duckdb/releases/download/v1.5.4/duckdb_cli-linux-amd64.zip
+          unzip -o duckdb.zip -d ci-bin
+          chmod +x ci-bin/duckdb
+          ci-bin/duckdb -c "SELECT 'cli ok';"
+      - name: Check this reader against the canonical conformance rules
+        # No skip path by design: if the artifact or the CLI is missing this
+        # FAILS rather than reporting a green nothing.
+        env:
+          DUCKDB_BIN: ci-bin/duckdb
+        run: |
+          set -euo pipefail
+          ext=$(find ci-ext -name 'markdown.duckdb_extension' | head -1)
+          test -n "$ext" || { echo "no extension in the artifact"; exit 1; }
+          MARKDOWN_EXTENSION="$ext" python3 scripts/check_conformance.py
 
   code-quality-check:
     name: Code Quality Check

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -60,6 +60,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check this reader against the canonical conformance rules
+        # Pure SQL, no extension, no network -- so it cannot skip and needs no
+        # token. duck_blocks_validate() lives in an extension this repo cannot
+        # load, so this is the only conformance available to it.
+        run: python3 scripts/check_conformance.py
       - name: Check vendored vocabulary against upstream duck_block_utils
         # The check resolves upstream's branch to a commit sha through the API
         # before fetching, because the raw endpoint serves branch urls from a

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -68,7 +68,7 @@ jobs:
         # the cached branch url and report UNVERIFIED rather than a real answer.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/check_duck_block_vocabulary.py
+        run: python3 scripts/check_duck_block_vocabulary.py --strict
 
   code-quality-check:
     name: Code Quality Check

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ duckdb_unittest_tempdir/
 .DS_Store
 testext
 test/python/__pycache__/
+# The WATCHED notes in scripts/ invite importing those checks as modules to
+# fire a branch by hand, which regenerates this next to them.
+__pycache__/
+*.pyc
 .Rhistory
 make.out
 test_output/

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,11 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+# Check the vendored duck_block vocabulary against upstream duck_block_utils.
+# A vendored copy does not notice when upstream moves, and a changed VALUE
+# (rather than a renamed constant) is invisible to the compiler regardless.
+# Pass --upstream PATH to compare against a local clone instead of the network.
+.PHONY: check-vocabulary
+check-vocabulary:
+	python3 scripts/check_duck_block_vocabulary.py

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,37 @@ check-producer:
 	python3 scripts/check_against_producer.py
 
 # Check this reader's output against the canonical duck_block conformance rules.
-# Unlike check-producer this has NO external dependency: the rules are pure SQL,
-# so it cannot skip. duck_blocks_validate() lives in an extension this repo
-# cannot load at all, so before these macros existed nothing had ever checked
-# this reader's output against the canonical rules.
+# Unlike check-producer it has no NETWORK dependency and cannot skip. It does
+# need a BUILD: the rules are pure SQL, but the reader under test is this
+# extension and the script LOADs it. Saying "pure SQL, no extension" is what put
+# this in a CI job with no build, where it failed five runs straight.
+# duck_blocks_validate() lives in an extension this repo cannot load at all, so
+# before these macros existed nothing had ever checked this reader's output
+# against the canonical rules.
 .PHONY: check-conformance
 check-conformance:
 	python3 scripts/check_conformance.py
+
+# Run EVERY check and report every failure.
+#
+# Each check is a separate target, which meant the only way to run them all was
+# to remember all three -- and running two of three is indistinguishable from
+# running three when you only read the last line. Recipe lines also stop at the
+# first failure, so a naive `check: check-vocabulary check-conformance
+# check-producer` would leave later checks unrun and look like a single problem
+# when there might be three. (duck_block_utils hit exactly this: eight scripts as
+# sequential recipe lines, a failure in check 2 left 6 of 8 unrun.)
+#
+# So: keep going, collect names, and print what FAILED and what never ran.
+.PHONY: check
+check:
+	@fail=""; \
+	for c in "vocabulary:scripts/check_duck_block_vocabulary.py" \
+	         "conformance:scripts/check_conformance.py" \
+	         "producer:scripts/check_against_producer.py"; do \
+	  name=$${c%%:*}; script=$${c##*:}; \
+	  printf '\n=== %s ===\n' "$$name"; \
+	  python3 "$$script" || fail="$$fail $$name"; \
+	done; \
+	printf '\n'; \
+	if [ -n "$$fail" ]; then echo "FAILED:$$fail"; exit 1; else echo "all checks passed"; fi

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,12 @@ check-vocabulary:
 .PHONY: check-producer
 check-producer:
 	python3 scripts/check_against_producer.py
+
+# Check this reader's output against the canonical duck_block conformance rules.
+# Unlike check-producer this has NO external dependency: the rules are pure SQL,
+# so it cannot skip. duck_blocks_validate() lives in an extension this repo
+# cannot load at all, so before these macros existed nothing had ever checked
+# this reader's output against the canonical rules.
+.PHONY: check-conformance
+check-conformance:
+	python3 scripts/check_conformance.py

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,30 @@ check-producer:
 check-conformance:
 	python3 scripts/check_conformance.py
 
+# HOW TO VERIFY A BRANCH BY HAND, since several registries in these scripts carry
+# a "WATCHED" note saying to re-plant an entry and watch it fire, and none of them
+# said how to look. The rule, learned the expensive way on 2026-09-01:
+#
+#   run the thing under test UNPIPED, ONE input at a time, and print the WHOLE
+#   output before drawing anything from it.
+#
+# Three false readings in one investigation that night, none from the code: a
+# glob that expanded to two paths so the command under test got a nonsense
+# argument; `| tail -4` truncating the error above the output being read; and
+# `rc=$?` after a pipe reporting tail's exit code rather than the program's. All
+# three die under that rule.
+#
+# The uncomfortable half, worth keeping because it is not obvious: what caught it
+# was the SIZE of the conclusion, not the method. It would have retracted a
+# premise this repo's tooling is built on, which is loud enough to force a second
+# look. A smaller false reading goes straight into the commit message. So
+# conclusion-size is doing the work verification should do, and the SMALL
+# findings are the unguarded ones. (duck_block_utils' framing, and it is the
+# durable part of that exchange.)
+#
+# An automated check gets perturbed at least once. A shell pipeline gets read and
+# believed every time.
+
 # Run EVERY check and report every failure.
 #
 # Each check is a separate target, which meant the only way to run them all was

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,11 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 .PHONY: check-vocabulary
 check-vocabulary:
 	python3 scripts/check_duck_block_vocabulary.py
+
+# Render live duck_block_utils output through this writer. Complements the test
+# suite rather than duplicating it: the suite replays producer output as literals
+# so it can never skip, but literals only contain shapes someone already knew
+# about. Skips loudly when the producer is unavailable.
+.PHONY: check-producer
+check-producer:
+	python3 scripts/check_against_producer.py

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Reads Markdown files and returns one row per file.
 - `include_filepath := false` - Include file_path column in output (alias: `filename`)
 - `content_as_varchar := false` - Return content as VARCHAR instead of MARKDOWN type
 - `maximum_file_size := 16777216` - Maximum file size in bytes (16MB default)
-- `extract_metadata := true` - Extract frontmatter into the `metadata` column. This uses the same **line-split key/value** reader as [`md_extract_metadata`](#content-extraction-functions) — each line split on the first `:`, typed as `MAP(VARCHAR, VARCHAR)` — **not** a full YAML parser (nested maps, lists, and multiline `|`/`>` scalars are not interpreted). For real YAML, use the `yaml` extension's `read_yaml_frontmatter` — see [Frontmatter Handling](#frontmatter-handling).
+- `extract_metadata := true` - Extract frontmatter into the `metadata` column. This uses the same **line-split key/value** reader as [`md_extract_metadata`](#content-extraction-functions) — each line split on the first `:` (or the first `=` inside a `+++` TOML block), typed as `MAP(VARCHAR, VARCHAR)` — **not** a full YAML parser (nested maps, lists, and multiline `|`/`>` scalars are not interpreted). For real YAML, use the `yaml` extension's `read_yaml_frontmatter` — see [Frontmatter Handling](#frontmatter-handling).
 - `normalize_content := true` - Normalize Markdown content
 - `extract_extensions := NULL` - Opt-in add-on extractors (comma-separated VARCHAR; see [Optional Add-On Extractors](#optional-add-on-extractors-extract_extensions)). When set, adds `wikilinks` and/or `tags` `LIST<STRUCT>` columns to the output
 
@@ -130,7 +130,7 @@ Reads Markdown files and parses them into block-level elements (headings, paragr
 
 **Element Types:** `heading`, `paragraph`, `code`, `blockquote`, `list`, `table`, `hr`, `metadata`
 
-YAML frontmatter is emitted as `element_type = 'metadata'` with `attributes['role'] = 'frontmatter'` and `encoding = 'yaml'`, carrying the raw text between the `---` fences. The type says it is a verbatim metadata blob; the role says which source construct produced it. (Before spec 6.2 this was `element_type = 'frontmatter'`, which was never a declared duck_block type. `duck_blocks_to_md` still accepts the old name so stored data keeps rendering.)
+Frontmatter is emitted as `element_type = 'metadata'` with `attributes['role'] = 'frontmatter'`, carrying the raw text between the fences. Both dialects are recognised: `---` fences give `encoding = 'yaml'`, and Hugo-style `+++` fences give `encoding = 'toml'`. The fence is restored from the encoding on write, so a TOML document round-trips as TOML rather than being relabelled YAML. The type says it is a verbatim metadata blob; the role says which source construct produced it. (Before spec 6.2 this was `element_type = 'frontmatter'`, which was never a declared duck_block type. `duck_blocks_to_md` still accepts the old name so stored data keeps rendering.)
 
 **Encoding:** `text` for plain content, `json` for structured content (lists, tables), `yaml` for frontmatter
 
@@ -235,8 +235,8 @@ Available tokens: `wikilinks`, `tags`, and the `obsidian` flavor (= both). Unkno
          (md_stats(content, exact := true)).link_count   -- cmark: real links only, references and autolinks included
   FROM read_markdown('docs/*.md');
   ```
-- **`md_extract_metadata(markdown)`** - Extract frontmatter as `MAP(VARCHAR, VARCHAR)`. This is a lightweight **line-split key/value** reader (each line split on the first `:`), *not* a full YAML parser — nested maps, lists, and multiline scalars are not interpreted. For real YAML — nested maps, lists, `|`/`>` blocks — use the `yaml` extension's `read_yaml_frontmatter`; see [Frontmatter Handling](#frontmatter-handling).
-- **`md_extract_frontmatter(markdown)`** - Extract the **raw** frontmatter block (the text between the `---` fences) as `VARCHAR`, or `NULL` when there is no frontmatter. Composes with `duckdb_yaml` for real YAML parsing without this extension carrying a YAML parser: e.g. `SELECT yaml(md_extract_frontmatter(content))`.
+- **`md_extract_metadata(markdown)`** - Extract frontmatter as `MAP(VARCHAR, VARCHAR)`. This is a lightweight **line-split key/value** reader (each line split on the first `:`, or the first `=` inside a `+++` TOML block), *not* a full YAML or TOML parser — nested maps, lists, and multiline scalars are not interpreted. For real YAML — nested maps, lists, `|`/`>` blocks — use the `yaml` extension's `read_yaml_frontmatter`; see [Frontmatter Handling](#frontmatter-handling).
+- **`md_extract_frontmatter(markdown)`** - Extract the **raw** frontmatter block (the text between the `---` or `+++` fences) as `VARCHAR`, or `NULL` when there is no frontmatter. Composes with `duckdb_yaml` for real YAML parsing without this extension carrying a YAML parser: e.g. `SELECT yaml(md_extract_frontmatter(content))`.
 - **`md_extract_section(markdown, section_id, [include_subsections])`** - Extract specific section by ID. With `include_subsections := true`, includes all nested content (full mode); default is minimal mode.
 - **`md_extract_sections(markdown, [min_level, max_level, content_mode])`** - Extract all sections as a list. Supports optional level filtering and content_mode ('minimal', 'full', 'smart').
 - **`md_section_breadcrumb(markdown, section_id)`** - Generate breadcrumb path for a section (returns "Title1 > Title2 > Title3" format)

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Convert document blocks to/from Markdown. These functions work with the `duck_bl
 **duck_block structure:**
 ```sql
 STRUCT(
-    kind          VARCHAR,              -- 'block' or 'inline'
+    kind          VARCHAR,              -- 'block', 'inline' or 'value' (metadata)
     element_type  VARCHAR,              -- 'heading', 'paragraph', 'bold', 'link', etc.
     content       VARCHAR,              -- Text content
     level         INTEGER,              -- Document nesting depth (1 for top-level, 0 for frontmatter)
@@ -574,7 +574,7 @@ COPY blocks TO 'output.md' (FORMAT MARKDOWN, markdown_mode 'blocks');
 ```sql
 COPY blocks TO 'doc.md' (FORMAT MARKDOWN,
     markdown_mode 'blocks',
-    kind_column 'kind',               -- Column with kind ('block' or 'inline', default: 'kind')
+    kind_column 'kind',               -- Column holding the kind (default: 'kind')
     element_type_column 'element_type',-- Column with element type (default: 'element_type')
     content_column 'content',          -- Column with block content (default: 'content')
     level_column 'level',              -- Column with level/depth (default: 'level')

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Reads Markdown files and parses them into block-level elements (headings, paragr
 
 Frontmatter is emitted as `element_type = 'metadata'` with `attributes['role'] = 'frontmatter'`, carrying the raw text between the fences. Both dialects are recognised: `---` fences give `encoding = 'yaml'`, and Hugo-style `+++` fences give `encoding = 'toml'`. The fence is restored from the encoding on write, so a TOML document round-trips as TOML rather than being relabelled YAML. The type says it is a verbatim metadata blob; the role says which source construct produced it. (Before spec 6.2 this was `element_type = 'frontmatter'`, which was never a declared duck_block type. `duck_blocks_to_md` still accepts the old name so stored data keeps rendering.)
 
-**Encoding:** `text` for plain content, `json` for structured content (lists, tables), `yaml` for frontmatter
+**Encoding:** `text` for plain content, `json` for table content, `yaml`/`toml` for frontmatter.
+
+Lists are **structural**: a `list` carries no content of its own, and its items are `list_item` children with their text in `paragraph` blocks beneath them, one level deeper at each step (`list` → `list_item` → `paragraph` → inlines). Nested lists are `list` blocks inside a `list_item`. Before this, a list's items were packed into a JSON array in its `content`, which flattened inline formatting and discarded nested lists entirely.
 
 ```sql
 -- Parse document into blocks

--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ Reads Markdown files and parses them into block-level elements (headings, paragr
 
 **Note on level vs heading_level:** For headings, the H1-H6 level is stored in `attributes['heading_level']` (preferred). If not present, the `level` field is used as a fallback.
 
-**Element Types:** `heading`, `paragraph`, `code`, `blockquote`, `list`, `table`, `hr`, `frontmatter`
+**Element Types:** `heading`, `paragraph`, `code`, `blockquote`, `list`, `table`, `hr`, `metadata`
+
+YAML frontmatter is emitted as `element_type = 'metadata'` with `attributes['role'] = 'frontmatter'` and `encoding = 'yaml'`, carrying the raw text between the `---` fences. The type says it is a verbatim metadata blob; the role says which source construct produced it. (Before spec 6.2 this was `element_type = 'frontmatter'`, which was never a declared duck_block type. `duck_blocks_to_md` still accepts the old name so stored data keeps rendering.)
 
 **Encoding:** `text` for plain content, `json` for structured content (lists, tables), `yaml` for frontmatter
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Reads Markdown files and parses them into block-level elements (headings, paragr
 - `include_filepath := false` - Include file_path column in output (alias: `filename`)
 - `extract_extensions := NULL` - Opt-in add-on extractors (see [Optional Add-On Extractors](#optional-add-on-extractors-extract_extensions)). When set, adds per-block `wikilinks` and/or `tags` columns extracted from each block's content.
 
-**Returns:** `(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER, encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER)`. With `extract_extensions`, the requested add-on columns are appended.
+**Returns:** `(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER, encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER)`. `level` is structural **depth**, minimum 1 — a heading's rank is `attributes['heading_level']`, not `level`. (`read_markdown_sections` has a `level` column too, but that one is heading rank, 0-6.) With `extract_extensions`, the requested add-on columns are appended.
 
 **Note on level vs heading_level:** For headings, the H1-H6 level is stored in `attributes['heading_level']` (preferred). If not present, the `level` field is used as a fallback.
 
@@ -177,7 +177,7 @@ Reads Markdown files and parses them into hierarchical sections.
 **Returns:** `(section_id VARCHAR, section_path VARCHAR, level INTEGER, title VARCHAR, content MARKDOWN, parent_id VARCHAR, start_line BIGINT, end_line BIGINT)` or with `include_filepath := true` adds `file_path VARCHAR` column.
 
 **Notes:**
-- When `extract_metadata := true`, the frontmatter block is included as a special section with `level=0`, `section_id='frontmatter'`, and the **raw, unparsed** text between the `---` delimiters as the content. Nothing in this extension interprets that text as YAML — see [Frontmatter Handling](#frontmatter-handling).
+- When `extract_metadata := true`, the frontmatter block is included as a special section with `level=0`, `section_id='frontmatter'`, and the **raw, unparsed** text between the `---` (or `+++`) delimiters as the content. This `level` is heading **rank** (0 for frontmatter, 1-6 for headings) and is a different measurement from `read_markdown_blocks`' `level`, which is structural **depth** and is 1 for every top-level element including frontmatter. Nothing in this extension interprets that text as YAML — see [Frontmatter Handling](#frontmatter-handling).
 - The `section_path` column provides hierarchical navigation paths like `"parent/child/grandchild"`.
 - Fragment syntax `'file.md#section-id'` returns the matching section and all its descendants.
 

--- a/conformance/duck_block_conformance.sql
+++ b/conformance/duck_block_conformance.sql
@@ -76,10 +76,18 @@
 -- file offered only one of the two, so the mistake was available to make.
 CREATE OR REPLACE MACRO duck_block_declared_kinds() AS (['block', 'inline', 'value']);
 
+-- Declared `encoding` values. Also a literal until 2026-09-01, and also compared
+-- against the build by check_conformance_macro.py -- this list was hardcoded in FOUR
+-- places across the repo, so adding `toml` was a five-file change with four copies
+-- nothing checked.
+CREATE OR REPLACE MACRO duck_block_declared_encodings() AS (
+    ['text', 'json', 'yaml', 'html', 'xml', 'latex', 'markdown', 'toml']
+);
+
 CREATE OR REPLACE MACRO duck_block_is_valid(elem) AS (
     list_contains(duck_block_declared_kinds(), elem.kind)
     AND elem.element_type IS NOT NULL
-    AND elem.encoding IN ('text', 'json', 'yaml', 'html', 'xml', 'latex', 'markdown')
+    AND list_contains(duck_block_declared_encodings(), elem.encoding)
     AND elem.level IS NOT NULL
     AND elem.level >= 1
     AND elem.element_order IS NOT NULL
@@ -149,7 +157,7 @@ CREATE OR REPLACE MACRO duck_blocks_errors(blocks) AS TABLE (
     SELECT el.element_order, 'encoding',
            'Invalid encoding ' || chr(39) || el.encoding || chr(39)
       FROM e WHERE el.encoding IS NOT NULL
-        AND NOT list_contains(['text','json','yaml','html','xml','latex','markdown'], el.encoding)
+        AND NOT list_contains(duck_block_declared_encodings(), el.encoding)
     UNION ALL
     SELECT el.element_order, 'level',
            CASE WHEN el.level IS NULL

--- a/conformance/duck_block_conformance.sql
+++ b/conformance/duck_block_conformance.sql
@@ -176,6 +176,59 @@ CREATE OR REPLACE MACRO duck_blocks_errors(blocks) AS TABLE (
     SELECT ord, 'element_order', 'Duplicate element_order value' FROM dup
 );
 
+-- ADVISORY WARNINGS. Legal shapes that are superseded, non-canonical, or lose
+-- information. Separate from duck_blocks_errors: none of these makes a document
+-- invalid, and a consumer must still read data that trips them.
+--
+-- Added because webbed asked whether "content iff a single text child" applies to
+-- `figure` as well as `list_item`. It does -- the rule is universal and the extension's
+-- normalizer and linter are both type-blind -- but the vendorable file had validity and
+-- no advisory rules, so a producer who cannot load the extension had NO INSTRUMENT
+-- EXPRESSING THE PREFERENCE. Two conformant producers could differ on the same document
+-- with nothing objecting, which is the divergence this vocabulary exists to remove.
+--
+-- Compared against the extension's duck_blocks_lint() by test/check_conformance_macro.py.
+CREATE OR REPLACE MACRO duck_blocks_warnings(blocks) AS TABLE (
+    WITH e AS (SELECT unnest(blocks) AS el, generate_subscripts(blocks, 1) AS pos),
+    nxt AS (
+        SELECT el, pos,
+               lead(el) OVER (ORDER BY pos) AS nx,
+               lag(el)  OVER (ORDER BY pos) AS pv
+        FROM e
+    )
+    -- A `plain` that is the only child of a content-empty container. Its text belongs
+    -- in that container's own `content`. UNIVERSAL: figure, section, div, blockquote,
+    -- caption and list_item alike -- decided by what sits BESIDE the run, never by
+    -- which element_type is above it.
+    SELECT el.element_order AS element_order, 'plain_should_be_content' AS rule,
+           'plain is the only child of ' || pv.element_type ||
+           '; its text belongs in that element''s content' AS message
+    FROM nxt
+    WHERE el.element_type = 'plain' AND el.kind = 'block'
+      AND pv IS NOT NULL AND pv.kind = 'block'
+      AND coalesce(pv.content, '') = '' AND pv.level = el.level - 1
+      AND (nx IS NULL OR nx.level < el.level OR nx.kind <> 'block')
+    UNION ALL
+    -- A table not in the native schema.
+    SELECT el.element_order, 'table_not_native',
+           'table content is not the native {headers,rows} schema'
+    FROM e WHERE el.element_type = 'table'
+      AND coalesce(el.content, '') <> '' AND position('"headers"' IN el.content) = 0
+    UNION ALL
+    SELECT el.element_order, 'deflist_superseded',
+           'deflist is superseded by list with list_type=''definition'''
+    FROM e WHERE el.element_type = 'deflist'
+    UNION ALL
+    SELECT el.element_order, 'heading_without_rank',
+           'heading without attributes[''heading_level'']: do NOT fall back to level'
+    FROM e WHERE el.element_type = 'heading'
+      AND coalesce(el.attributes['heading_level'], '') = ''
+    UNION ALL
+    SELECT el.element_order, 'undeclared_element_type',
+           'element_type ' || el.element_type || ' is not in the vocabulary'
+    FROM e WHERE NOT list_contains(duck_block_declared_types(), el.element_type)
+);
+
 -- Document shape. The other 2, and they are the ones a per-element check CANNOT see:
 --
 --   duplicate element_order  needs the whole list

--- a/conformance/duck_block_conformance.sql
+++ b/conformance/duck_block_conformance.sql
@@ -215,6 +215,14 @@ CREATE OR REPLACE MACRO duck_blocks_warnings(blocks) AS TABLE (
     FROM e WHERE el.element_type = 'table'
       AND coalesce(el.content, '') <> '' AND position('"headers"' IN el.content) = 0
     UNION ALL
+    -- A `list` carrying content is the pre-structural shape: items in a JSON array
+    -- instead of `list_item` children. The list case is more damaging than the table
+    -- one -- a nested list comes back as one run-together string that a consumer
+    -- cannot tell from real text.
+    SELECT el.element_order, 'list_not_structural',
+           'list carries content; its items belong in list_item children at level + 1'
+    FROM e WHERE el.element_type = 'list' AND coalesce(el.content, '') <> ''
+    UNION ALL
     SELECT el.element_order, 'deflist_superseded',
            'deflist is superseded by list with list_type=''definition'''
     FROM e WHERE el.element_type = 'deflist'

--- a/conformance/duck_block_conformance.sql
+++ b/conformance/duck_block_conformance.sql
@@ -1,0 +1,150 @@
+-- VENDORED COPY -- do not edit. Any change here is drift, by definition.
+--
+--   upstream : teaguesterling/duckdb_duck_block_utils
+--              conformance/duck_block_conformance.sql
+--   commit   : 8378fa42d30d6068772dc48f0e789b9a73bdadb7
+--              (8378fa4, 2026-09-01)
+--
+-- Vendored because it is the ONLY conformance this extension can run. DuckDB
+-- matches extension ABI on the exact version string and this repo builds DuckDB
+-- from a pinned submodule, so duck_block_utils cannot be loaded here by any
+-- route -- not INSTALL, not LOAD '<path>'. Its duck_blocks_validate() has
+-- therefore never been runnable against this reader, which is a fair part of
+-- why the defects found today survived. This file needs nothing but DuckDB.
+--
+-- The embedded type list is a SECOND copy of the vocabulary. Two copies checked
+-- by the same party cannot detect their own disagreement, so
+-- `make check-vocabulary` compares it against the vendored header, which is
+-- itself compared against upstream. Drift in either link fails.
+--
+-- duck_block conformance checks, PURE SQL -- no duck_block_utils required.
+--
+-- WHY THIS FILE EXISTS. duck_blocks_validate() ships inside an extension built for a
+-- specific DuckDB version, and DuckDB matches extension ABI by EXACT version string.
+-- An extension that vendors its own DuckDB submodule pinned off-release reports e.g.
+-- 'v1.5.5-dev154' and CANNOT LOAD duck_block_utils by any route -- not INSTALL, not
+-- LOAD '<path>', and publishing would not change it.
+--
+-- Raised by the webbed session, whose metadata blocks carried a NULL level for three
+-- major spec versions with nothing in a position to object: the check that would have
+-- caught it was one they structurally could not run. If markdown and panduck vendor
+-- duckdb too, none of the three consuming extensions could run the validator, which
+-- explains a great deal about how long these defects survived.
+--
+-- So conformance for that class of consumer has to be SHAPE-BASED, not
+-- extension-based. Copy this file; it needs nothing but DuckDB.
+--
+-- It is kept honest by test/check_conformance_macro.py, which runs both these macros
+-- and the real duck_blocks_validate() over the same corpus and FAILS if they disagree.
+-- Two copies of one rule checked by the same party cannot detect their own
+-- disagreement -- this repo shipped exactly that defect in an image's alt text -- so
+-- the two implementations are compared rather than merely both maintained.
+
+-- WHAT THIS BUYS YOU, from the panduck session and sharper than the framing above:
+-- the value is not "the same checks without a dependency". It is TWO CHECKS YOU COULD
+-- NOT HAVE HAD AT ALL. Duplicate element_order and level-jumping-by-more-than-one are
+-- inexpressible in a per-element macro, and the second is the rule whose absence caused
+-- a year of drift across four extensions -- so every consumer who copied the
+-- per-element macro this spec published until 2026-09-01 was unguarded against
+-- precisely the defect most likely to bite them.
+
+-- USAGE, and read this before the first call fails.
+--
+--   SELECT duck_blocks_are_valid(<a LIST(duck_block) expression>);
+--
+-- If your producer is a TABLE function, DuckDB rejects passing it inline:
+--
+--   SELECT duck_blocks_are_valid(my_reader('doc.epub'));
+--     -> Binder Error: Table function cannot contain subqueries
+--
+-- Materialise it first:
+--
+--   CREATE TEMP TABLE b AS SELECT my_reader('doc.epub') AS blk;
+--   SELECT duck_blocks_are_valid(blk) FROM b;
+--
+-- Reported by the panduck session on first use. It is worth stating here because the
+-- error names SUBQUERIES and the caller did not write one, so the fix is not
+-- discoverable from the message -- and checking a producer's output is the whole point
+-- of this file. A scalar producer passes inline fine (measured); the restriction is
+-- specific to table functions.
+--
+-- The macros are `duck_block_is_valid` (one element) and `duck_blocks_are_valid` (a
+-- document). The FILE name is not a macro name -- also panduck, who grepped for it.
+
+-- Per-element shape. Covers 4 of the 6 things duck_blocks_validate reports.
+CREATE OR REPLACE MACRO duck_block_is_valid(elem) AS (
+    elem.kind IN ('block', 'inline', 'value')
+    AND elem.element_type IS NOT NULL
+    AND elem.encoding IN ('text', 'json', 'yaml', 'html', 'xml', 'latex', 'markdown')
+    AND elem.level IS NOT NULL
+    AND elem.level >= 1
+    AND elem.element_order IS NOT NULL
+    AND elem.element_order >= 0
+);
+
+-- Declared element_type names, for the check the EXTENSION does and this file could
+-- not. An element_type outside the vocabulary was invisible to everything until
+-- 2026-09-01: `duck_blocks_validate` accepted any string. duckdb_markdown emits
+-- `frontmatter` where the vocabulary declares `metadata` and nothing objected.
+--
+-- This list is a COPY of duck_block_type_names(), which is the kind of thing that
+-- drifts. test/check_conformance_macro.py compares the two on every `make check` and
+-- FAILS if they differ, so it is a copy that cannot rot silently -- the same reason the
+-- macros above are compared against the real validator rather than merely maintained.
+--
+-- Kept SEPARATE from duck_blocks_are_valid deliberately: an unknown type is a LINT, not
+-- an invalidity. A consumer built against an older vocabulary must still read data from
+-- a newer producer, so a name you do not recognise is reported, not refused. Rejecting
+-- it would make every additive spec release break every consumer who had not upgraded.
+CREATE OR REPLACE MACRO duck_block_declared_types() AS (
+    [
+        'blockquote', 'blocks', 'bold', 'bool', 'caption', 'cite', 'code', 'deflist',
+        'div', 'figure', 'generic', 'heading', 'hr', 'image', 'inlines', 'italic',
+        'lineblock', 'linebreak', 'link', 'list', 'list_item', 'map', 'math', 'metadata',
+        'note', 'page_break', 'paragraph', 'plain', 'quoted', 'raw', 'section',
+        'smallcaps', 'softbreak', 'space', 'span', 'strikethrough', 'string', 'subscript',
+        'superscript', 'table', 'text', 'underline', 'version'
+    ]
+);
+
+-- Which elements carry a type this vocabulary does not declare. Empty is conforming;
+-- anything listed should probably be `generic` with the original name kept in
+-- attributes['source_type'], so it reads as a gap rather than a private invention.
+CREATE OR REPLACE MACRO duck_blocks_undeclared_types(blocks) AS (
+    -- coalesce, because an aggregate over ZERO rows returns NULL, and a conforming
+    -- document has zero rows here. NULL is the one answer this must never give: it
+    -- reads as "could not tell" and as "none" equally, which is the ambiguity every
+    -- check in this file exists to remove. Caught by running it, not by writing it.
+    coalesce(
+        (SELECT list_sort(list_distinct(list(e.element_type)))
+         FROM unnest(blocks) AS t(e)
+         WHERE NOT list_contains(duck_block_declared_types(), e.element_type)),
+        []::VARCHAR[]
+    )
+);
+
+-- Document shape. The other 2, and they are the ones a per-element check CANNOT see:
+--
+--   duplicate element_order  needs the whole list
+--   level jumping by >1      needs ADJACENCY. `level` is structural depth in a
+--                            depth-first ordering, so a document descends one at a
+--                            time; a jump means the element's parent is missing.
+--                            This is the rule whose absence caused a year of drift
+--                            across four extensions, and it is precisely the one a
+--                            per-element macro cannot express -- so a consumer given
+--                            only the element macro is unguarded against the defect
+--                            most likely to bite them.
+CREATE OR REPLACE MACRO duck_blocks_are_valid(blocks) AS (
+    -- every element individually
+    NOT EXISTS (SELECT 1 FROM unnest(blocks) AS t(e) WHERE NOT duck_block_is_valid(e))
+    -- element_order unique
+    AND (SELECT count(DISTINCT e.element_order) = count(*) FROM unnest(blocks) AS t(e))
+    -- depth-first ordering descends one level at a time
+    AND NOT EXISTS (
+        SELECT 1 FROM (
+            SELECT e.level AS lvl,
+                   lag(e.level) OVER (ORDER BY i) AS prev
+            FROM unnest(blocks) WITH ORDINALITY AS t(e, i)
+        ) WHERE prev IS NOT NULL AND lvl > prev + 1
+    )
+);

--- a/conformance/duck_block_conformance.sql
+++ b/conformance/duck_block_conformance.sql
@@ -2,8 +2,8 @@
 --
 --   upstream : teaguesterling/duckdb_duck_block_utils
 --              conformance/duck_block_conformance.sql
---   commit   : 8378fa42d30d6068772dc48f0e789b9a73bdadb7
---              (8378fa4, 2026-09-01)
+--   commit   : 4565c602c607ae4d4ff3f915180b1e329beb3019
+--              (4565c60, 2026-09-01)
 --
 -- Vendored because it is the ONLY conformance this extension can run. DuckDB
 -- matches extension ABI on the exact version string and this repo builds DuckDB
@@ -12,7 +12,7 @@
 -- therefore never been runnable against this reader, which is a fair part of
 -- why the defects found today survived. This file needs nothing but DuckDB.
 --
--- The embedded type list is a SECOND copy of the vocabulary. Two copies checked
+-- The embedded type AND kind lists are a SECOND copy of the vocabulary. Two copies checked
 -- by the same party cannot detect their own disagreement, so
 -- `make check-vocabulary` compares it against the vendored header, which is
 -- itself compared against upstream. Drift in either link fails.
@@ -72,8 +72,19 @@
 -- document). The FILE name is not a macro name -- also panduck, who grepped for it.
 
 -- Per-element shape. Covers 4 of the 6 things duck_blocks_validate reports.
+-- Declared `kind` values. A LITERAL here until 2026-09-01, which is how the version of
+-- this check published in the spec came to enumerate two kinds when three exist -- the
+-- instruction that leaves a producer with nowhere to put a document's title. It is a
+-- macro now for the same reason the type list is: check_conformance_macro.py compares
+-- it against duck_block_kind_names() and FAILS on drift, so the copy cannot rot.
+--
+-- Kinds and element types are DIFFERENT AXES and both are needed. duckdb_markdown
+-- reported a false positive from comparing the type list against the kind names; the
+-- file offered only one of the two, so the mistake was available to make.
+CREATE OR REPLACE MACRO duck_block_declared_kinds() AS (['block', 'inline', 'value']);
+
 CREATE OR REPLACE MACRO duck_block_is_valid(elem) AS (
-    elem.kind IN ('block', 'inline', 'value')
+    list_contains(duck_block_declared_kinds(), elem.kind)
     AND elem.element_type IS NOT NULL
     AND elem.encoding IN ('text', 'json', 'yaml', 'html', 'xml', 'latex', 'markdown')
     AND elem.level IS NOT NULL

--- a/conformance/duck_block_conformance.sql
+++ b/conformance/duck_block_conformance.sql
@@ -1,22 +1,3 @@
--- VENDORED COPY -- do not edit. Any change here is drift, by definition.
---
---   upstream : teaguesterling/duckdb_duck_block_utils
---              conformance/duck_block_conformance.sql
---   commit   : 4565c602c607ae4d4ff3f915180b1e329beb3019
---              (4565c60, 2026-09-01)
---
--- Vendored because it is the ONLY conformance this extension can run. DuckDB
--- matches extension ABI on the exact version string and this repo builds DuckDB
--- from a pinned submodule, so duck_block_utils cannot be loaded here by any
--- route -- not INSTALL, not LOAD '<path>'. Its duck_blocks_validate() has
--- therefore never been runnable against this reader, which is a fair part of
--- why the defects found today survived. This file needs nothing but DuckDB.
---
--- The embedded type AND kind lists are a SECOND copy of the vocabulary. Two copies checked
--- by the same party cannot detect their own disagreement, so
--- `make check-vocabulary` compares it against the vendored header, which is
--- itself compared against upstream. Drift in either link fails.
---
 -- duck_block conformance checks, PURE SQL -- no duck_block_utils required.
 --
 -- WHY THIS FILE EXISTS. duck_blocks_validate() ships inside an extension built for a
@@ -62,11 +43,23 @@
 --   CREATE TEMP TABLE b AS SELECT my_reader('doc.epub') AS blk;
 --   SELECT duck_blocks_are_valid(blk) FROM b;
 --
--- Reported by the panduck session on first use. It is worth stating here because the
--- error names SUBQUERIES and the caller did not write one, so the fix is not
--- discoverable from the message -- and checking a producer's output is the whole point
--- of this file. A scalar producer passes inline fine (measured); the restriction is
--- specific to table functions.
+-- MATERIALISE FIRST, ALWAYS. Do not try to work out whether your producer is exempt.
+--
+-- This file said "a scalar producer passes inline fine; the restriction is specific to
+-- table functions". That was measured -- and measured on THIS repo's producers, which
+-- are the ones that happen to work. panduck's producer is also scalar and does NOT
+-- work, because what trips the binder is what the producer EXPANDS TO once inlined
+-- into a subquery position, not the kind it is declared as. panduck's dispatch runs
+-- through `query()`, which rejects a subquery in its argument including one that
+-- arrives by macro inlining.
+--
+-- So the exemption is not knowable from here: it depends on an implementation this
+-- file cannot see. An accurate-sounding exemption is worse than none, because it
+-- invites exactly the inline call that fails, with an error naming subqueries the
+-- caller never wrote.
+--
+-- Reported twice by the panduck session: once as the restriction, once to correct the
+-- exemption I wrote in response to it.
 --
 -- The macros are `duck_block_is_valid` (one element) and `duck_blocks_are_valid` (a
 -- document). The FILE name is not a macro name -- also panduck, who grepped for it.
@@ -132,6 +125,47 @@ CREATE OR REPLACE MACRO duck_blocks_undeclared_types(blocks) AS (
          WHERE NOT list_contains(duck_block_declared_types(), e.element_type)),
         []::VARCHAR[]
     )
+);
+
+-- ERRORS WITH DETAIL, not just a verdict. Requested by Teague after panduck hit the
+-- gap immediately: `duck_blocks_are_valid` tells you a fixture broke and nothing about
+-- WHERE, so they were bisecting a twelve-fixture gate by hand. This returns the same
+-- {element_order, field, message} rows the extension's `duck_blocks_validate` does,
+-- and check_conformance_macro.py compares the two so they cannot drift apart.
+--
+-- A boolean is the right thing for a gate and the wrong thing for a FAILING gate.
+CREATE OR REPLACE MACRO duck_blocks_errors(blocks) AS TABLE (
+    WITH e AS (SELECT unnest(blocks) AS el, generate_subscripts(blocks, 1) AS pos),
+    lv AS (SELECT el, pos, el.level AS lvl, lag(el.level) OVER (ORDER BY pos) AS prev FROM e),
+    dup AS (SELECT el.element_order AS ord FROM e GROUP BY 1 HAVING count(*) > 1)
+    SELECT el.element_order AS element_order, 'kind' AS field,
+           'Invalid kind ' || chr(39) || coalesce(el.kind, 'NULL') || chr(39)
+             || '; see duck_block_kind_names()' AS message
+      FROM e WHERE NOT list_contains(duck_block_declared_kinds(), el.kind)
+    UNION ALL
+    SELECT el.element_order, 'element_type', 'element_type is NULL'
+      FROM e WHERE el.element_type IS NULL
+    UNION ALL
+    SELECT el.element_order, 'encoding',
+           'Invalid encoding ' || chr(39) || el.encoding || chr(39)
+      FROM e WHERE el.encoding IS NOT NULL
+        AND NOT list_contains(['text','json','yaml','html','xml','latex','markdown'], el.encoding)
+    UNION ALL
+    SELECT el.element_order, 'level',
+           CASE WHEN el.level IS NULL
+                THEN 'level is NULL; every element carries an explicit depth, top level is 1'
+                ELSE 'level ' || el.level || ' is below 1; top level is 1' END
+      FROM e WHERE el.level IS NULL OR el.level < 1
+    UNION ALL
+    SELECT el.element_order, 'level',
+           'level jumps from ' || prev || ' to ' || lvl
+             || '; depth-first ordering descends one at a time, so this element''s parent is missing'
+      FROM lv WHERE prev IS NOT NULL AND lvl > prev + 1
+    UNION ALL
+    SELECT el.element_order, 'element_order', 'element_order must be non-negative'
+      FROM e WHERE el.element_order IS NULL OR el.element_order < 0
+    UNION ALL
+    SELECT ord, 'element_order', 'Duplicate element_order value' FROM dup
 );
 
 -- Document shape. The other 2, and they are the ones a per-element check CANNOT see:

--- a/docs/doc_block_spec.md
+++ b/docs/doc_block_spec.md
@@ -1,10 +1,33 @@
-# Duck Block Specification
+# Duck Block Specification — SUPERSEDED
 
-**Version**: 2.0
-**Status**: Stable
-**Last Updated**: 2025-01
+> **This document is no longer normative. Do not implement against it.**
+>
+> The canonical duck_block specification is owned by `duck_block_utils`:
+> `docs/duck_blocks_spec.md` in `teaguesterling/duckdb_duck_block_utils`,
+> with the machine-readable vocabulary in `src/include/duck_block_vocabulary.hpp`
+> (`SPEC_VERSION`, currently 6.1). This repository vendors that header at
+> `src/include/duck_block_vocabulary.hpp` and checks it for drift with
+> `make check-vocabulary`.
+>
+> **Why this matters rather than being tidiness.** This document said `kind` is
+> "'block' or 'inline'". A third kind, `value`, carries document metadata — and
+> a writer built on the two-kind definition treats metadata as body content,
+> which is precisely the defect that put a document's own title into its body as
+> prose in this extension (fixed 2026-08-31). An implementer conforming to the
+> text below would have built that bug. Two published specifications disagreeing
+> is not a documentation problem: whoever follows the wrong one is conforming.
+>
+> Its **MUST** statements about "all compliant extensions" no longer bind
+> anything. Corrections are marked inline below where a claim is actively
+> wrong; the rest is retained as history, not as instruction.
+>
+> Superseded 2026-09-01, against duck_block spec 6.1.
 
-A format-agnostic specification for representing documents as sequences of typed blocks in DuckDB. This specification enables interoperability between document format extensions, allowing documents to be converted, transformed, and analyzed using SQL.
+**Version**: 2.0 (superseded — unrelated to duck_block `SPEC_VERSION`, now 6.1)
+**Status**: Historical
+**Last Updated**: 2026-09-01
+
+A format-agnostic specification for representing documents as sequences of typed blocks in DuckDB. This specification enabled interoperability between document format extensions; that role now belongs to the canonical spec linked above.
 
 ## Overview
 
@@ -28,7 +51,7 @@ All compliant extensions MUST produce rows with these columns:
 
 | Column | Type | Required | Description |
 |--------|------|----------|-------------|
-| `kind` | VARCHAR | Yes | 'block' or 'inline' |
+| `kind` | VARCHAR | Yes | 'block' or 'inline' — **OUTDATED: also `value`**, which carries document metadata. A consumer that treats non-inline as block renders metadata as body text. |
 | `element_type` | VARCHAR | Yes | Element type identifier |
 | `content` | VARCHAR | Yes | Primary content of the element |
 | `level` | INTEGER | No | Hierarchy level, nesting depth, or NULL |
@@ -47,6 +70,10 @@ Optional columns:
 Distinguishes between block-level and inline elements:
 - **'block'**: Block-level elements (headings, paragraphs, code blocks, lists, tables)
 - **'inline'**: Inline elements (bold, italic, links, images within text)
+- **'value'** — **MISSING FROM THIS DOCUMENT.** Non-prose data attached to a
+  document, currently its metadata. `kind` is an open discriminator: filter with
+  an **allowlist** (`kind` is block or inline), never a blocklist ("not inline,
+  therefore block"), or every future kind is rendered as body content.
 
 Block elements are rendered with trailing newlines. Inline elements are concatenated without trailing newlines.
 
@@ -70,7 +97,16 @@ Document nesting depth or heading level:
 - Frontmatter/metadata: 0
 - Not applicable: NULL
 
-**Note:** For headings, the H1-H6 level should preferably be stored in `attributes['heading_level']`. If not present, the `level` field is used as a fallback.
+**OUTDATED.** Since duck_block spec 3.0 `level` is explicit structural depth on
+*every* element and is **never semantic** — no NULLs, top level 1, children at
+parent+1. A consumer reading `level` to decide how deeply to nest a quote, or
+how far to indent a list, over-nests by however many containers sit above it.
+
+**Note:** For headings, the H1-H6 level should preferably be stored in
+`attributes['heading_level']`. If not present, the `level` field is used as a
+fallback. — **The fallback is unsafe under 3.0 and later**, where `level` is
+structural depth: a heading inside two containers reads as an h3 whatever it
+actually is. `attributes['heading_level']` is the only sound source.
 
 #### encoding
 Declares how `content` should be interpreted:

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -119,7 +119,7 @@ All ecosystem extensions share the common `duck_block` structure:
 
 ```sql
 STRUCT(
-    kind          VARCHAR,              -- 'block' or 'inline'
+    kind          VARCHAR,              -- 'block', 'inline' or 'value' (metadata)
     element_type  VARCHAR,              -- 'heading', 'paragraph', 'bold', etc.
     content       VARCHAR,              -- Text content
     level         INTEGER,              -- Heading level or nesting depth

--- a/docs/markdown_doc_block.md
+++ b/docs/markdown_doc_block.md
@@ -22,7 +22,7 @@ The extension uses the `duck_block` struct shape from the `duck_block_utils` spe
 
 ```sql
 STRUCT(
-    kind          VARCHAR,              -- 'block' or 'inline'
+    kind          VARCHAR,              -- 'block', 'inline' or 'value' (metadata)
     element_type  VARCHAR,              -- 'heading', 'paragraph', 'bold', 'link', etc.
     content       VARCHAR,              -- Text content
     level         INTEGER,              -- Document nesting depth (1 for top-level)
@@ -134,7 +134,7 @@ COPY query TO 'output.md' (
     FORMAT MARKDOWN,
     markdown_mode 'blocks',  -- or 'duck_block'
     -- Column mapping (defaults shown)
-    kind_column 'kind',                -- 'block' or 'inline' (default: 'kind')
+    kind_column 'kind',                -- column holding the kind (default: 'kind')
     element_type_column 'element_type',
     content_column 'content',
     level_column 'level',

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -47,6 +47,24 @@ SCHEMA = ("STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INT
           "encoding VARCHAR, attributes MAP(VARCHAR,VARCHAR), element_order INTEGER)")
 
 # Documents to push through, with the words that must survive the trip.
+# Round trips that are KNOWN not to be stable, with the reason. Recorded rather
+# than silently tolerated: an unexplained exclusion and a forgotten defect look
+# identical later. Anything NOT listed here that drifts is a failure.
+KNOWN_UNSTABLE = {
+    "figure": "this writer emits a figure's caption as a separate italic line, but "
+              "`![alt](src)` ALREADY carries that text -- a reader infers a figure "
+              "and its caption from a lone image, so the caption appears twice and "
+              "a further copy is added on every pass. A real defect in this writer, "
+              "not an inherent limit: markdown has one slot for that text and this "
+              "fills two. Unfixed -- suppressing the caption needs the caption "
+              "branch to know its sibling image's alt.",
+    "line block": "a line block has no markdown syntax, so this writer emits hard "
+                  "breaks. The producer folds those back into paragraph content as "
+                  "a raw newline rather than linebreak inlines, so the break "
+                  "degrades from hard to soft. The words and the line count "
+                  "survive. Upstream shape, not a defect here.",
+}
+
 CASES = [
     ("heading",        "# Title\n",                              ["Title"]),
     ("nested inlines", "Text with **bold *inner*** here.\n",     ["bold", "inner"]),
@@ -54,7 +72,12 @@ CASES = [
     ("ordered list",   "3. one\n4. two\n",                       ["one", "two"]),
     ("blockquote",     "> quoted para\n>\n> second para\n",      ["quoted", "second"]),
     ("table",          "| A | B |\n|---|---|\n| 1 | 2 |\n",      ["A", "B", "1", "2"]),
-    ("definition list","Term\n:   Definition\n",                 ["Term", "Definition"]),
+    # Multi-block on purpose: a definition's continuation block must be indented
+    # far enough that a reader keeps it inside the definition. At two spaces it
+    # reads as a new top-level paragraph, which splits the list and strands the
+    # block between the halves -- caught by the round trip, not by rendering.
+    ("definition list","HTTP\n:   hypertext transfer protocol\n\nTLS\n:   transport layer security\n\n    a second block\n\nDNS\n:   sense one\n:   sense two\n",
+                       ["HTTP", "hypertext", "TLS", "transport", "a second block", "DNS", "sense one", "sense two"]),
     ("line block",     "| Roses are red\n| Violets are blue\n",  ["Roses", "Violets"]),
     ("figure",         "![A caption](img.png)\n",                ["img.png", "A caption"]),
     ("code",           "```py\nprint(1)\n```\n",                 ["print(1)"]),
@@ -121,12 +144,28 @@ def main():
     for name, markdown, expected in CASES:
         out = render(to_blocks(args.producer, markdown))
         missing = [w for w in expected if w not in out]
-        status = "ok " if not missing else "LOST"
-        print(f"  {status} {name:<16} {out.splitlines()[0][:44] if out.strip() else '(empty)'}")
+        # Rendering once proves the words survive; rendering the OUTPUT again
+        # proves the markdown says what it meant. A definition continuation
+        # indented too shallowly renders fine and re-reads as a different
+        # document, which only the second pass can see.
+        second = render(to_blocks(args.producer, out)) if out.strip() else out
+        unstable = second.strip() != out.strip()
+        known = name in KNOWN_UNSTABLE
         if missing:
-            failures.append((name, missing, out))
+            status = "LOST"
+        elif unstable:
+            status = "note" if known else "DRIFT"
+        else:
+            status = "ok  "
+        print(f"  {status} {name:<16} {out.splitlines()[0][:42] if out.strip() else '(empty)'}")
+        if missing or (unstable and not known):
+            failures.append((name, missing, out if missing else f"unstable:\n{out!r}\n{second!r}"))
 
     print()
+    for name in sorted(n for n, _, _ in [(c[0], 0, 0) for c in CASES] if n in KNOWN_UNSTABLE):
+        print(f"note {name}: round trip is known-unstable -- {KNOWN_UNSTABLE[name]}")
+    if KNOWN_UNSTABLE:
+        print()
     if failures:
         for name, missing, out in failures:
             print(f"FAILED {name}: lost {missing}\n       rendered: {out!r}")

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -58,11 +58,16 @@ KNOWN_UNSTABLE = {
               "not an inherent limit: markdown has one slot for that text and this "
               "fills two. Unfixed -- suppressing the caption needs the caption "
               "branch to know its sibling image's alt.",
-    "line block": "a line block has no markdown syntax, so this writer emits hard "
-                  "breaks. The producer folds those back into paragraph content as "
-                  "a raw newline rather than linebreak inlines, so the break "
-                  "degrades from hard to soft. The words and the line count "
-                  "survive. Upstream shape, not a defect here.",
+    "line block": "PLAIN-TEXT case only; a line block containing any rich inline "
+                  "is now stable. A line block has no markdown syntax, so this "
+                  "writer emits hard breaks -- but a hard break in TEXT-ONLY "
+                  "content is flattened by the producer to a raw newline in "
+                  "`content` rather than a linebreak inline, so it re-reads as a "
+                  "soft break. Not specific to line blocks: an ordinary paragraph "
+                  "written `alpha  \\nbeta` comes back as content 'alpha\\nbeta' and "
+                  "loses the same distinction, while `alpha **x**  \\nbeta` keeps it "
+                  "because the bold forces inline children. Upstream shape, "
+                  "formatting rather than words, and reported.",
 }
 
 CASES = [

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -151,7 +151,7 @@ def main():
         print("               Every result below would be meaningless; not run.")
         return 1
 
-    failures = []
+    failures, expired = [], []
     for name, markdown, expected in CASES:
         out = render(to_blocks(args.producer, markdown))
         missing = [w for w in expected if w not in out]
@@ -162,6 +162,8 @@ def main():
         second = render(to_blocks(args.producer, out)) if out.strip() else out
         unstable = second.strip() != out.strip()
         known = name in KNOWN_UNSTABLE
+        if known and not unstable:
+            expired.append(name)
         if missing:
             status = "LOST"
         elif unstable:
@@ -173,10 +175,35 @@ def main():
             failures.append((name, missing, out if missing else f"unstable:\n{out!r}\n{second!r}"))
 
     print()
-    for name in sorted(n for n, _, _ in [(c[0], 0, 0) for c in CASES] if n in KNOWN_UNSTABLE):
+
+    # AUDIT THE EXCLUSIONS. An entry whose case now passes has expired, and an
+    # expired exclusion is worse than none: it goes on excusing a case that no
+    # longer needs it and hides the next regression behind an explanation
+    # nobody rechecks. `line block` lived here and expired within an hour of
+    # being written, caught only because it happened to be re-measured.
+    #
+    # This FAILS rather than warns, because the instinct on meeting a stale
+    # reason is to fix the wording, and the notice arrives exactly when you are
+    # least inclined to delete something you wrote. The fix is to delete the
+    # entry, not to reword it. (Adopted from duck_block_utils, who built the
+    # same audit over their sweep's exemption registries.)
+    dead = [n for n in KNOWN_UNSTABLE if n not in {c[0] for c in CASES}]
+    for name in expired:
+        print(f"EXPIRED {name}: listed as known-unstable, but its round trip is now STABLE.")
+        print(f"         DELETE the entry -- do not reword it. Recorded reason was:")
+        print(f"         {KNOWN_UNSTABLE[name]}")
+    for name in dead:
+        print(f"EXPIRED {name}: listed as known-unstable but no longer has a case. DELETE it.")
+    if expired or dead:
+        print()
+
+    for name in sorted(n for n in {c[0] for c in CASES} if n in KNOWN_UNSTABLE and n not in expired):
         print(f"note {name}: round trip is known-unstable -- {KNOWN_UNSTABLE[name]}")
     if KNOWN_UNSTABLE:
         print()
+    if expired or dead:
+        print("FAILED: the exclusion list is out of date.")
+        return 1
     if failures:
         for name, missing, out in failures:
             print(f"FAILED {name}: lost {missing}\n       rendered: {out!r}")

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -67,13 +67,6 @@ SCHEMA = ("STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INT
 # wrongness is what the sqllogictest suite is for. Three arms, three
 # properties, and none of them subsumes another.
 KNOWN_UNSTABLE = {
-    "figure": "this writer emits a figure's caption as a separate italic line, but "
-              "`![alt](src)` ALREADY carries that text -- a reader infers a figure "
-              "and its caption from a lone image, so the caption appears twice and "
-              "a further copy is added on every pass. A real defect in this writer, "
-              "not an inherent limit: markdown has one slot for that text and this "
-              "fills two. Unfixed -- suppressing the caption needs the caption "
-              "branch to know its sibling image's alt.",
 }
 
 CASES = [

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Render real duck_block_utils output through this extension's writer.
+
+WHY THIS EXISTS SEPARATELY FROM THE TEST SUITE.
+
+test/sql/duck_block_*.test replay producer output as struct literals, on
+purpose: a test that depends on another extension being installed skips
+silently when it is not, and a silent skip is zero coverage wearing the
+costume of some. Those tests can never skip.
+
+But literals only ever contain shapes someone already knew about. Every
+content-loss defect found on 2026-08-31 -- a list_item's text dropped, a
+blockquote rendered as raw Pandoc AST, a whole list rendering as nothing --
+was found by running a LIVE producer through the writer and looking, and none
+of them could have been found by the suite. So this is the other half, kept
+runnable rather than performed once by hand.
+
+WHY IT IS A BRIDGE RATHER THAN A LOAD. DuckDB matches extension ABI on the
+exact version string, and this repo builds DuckDB from a pinned submodule --
+so its binary reports a dev hash and REFUSES a release-built extension
+outright. That is permanent, not a symptom of duck_block_utils being
+unpublished: any consumer vendoring a duckdb submodule needs this shape
+forever. So the producer runs in the system duckdb, this extension's writer
+runs in this repo's build, and JSON crosses between them.
+
+Usage:
+    python3 scripts/check_against_producer.py [--producer PATH] [--pandoc]
+
+Exits 1 on a rendering that loses content, 0 otherwise. Skips LOUDLY, never
+silently, when the producer is unavailable.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EXT_MD = os.path.join(REPO, "build/release/extension/markdown/markdown.duckdb_extension")
+MD_DUCKDB = os.path.join(REPO, "build/release/duckdb")
+DEFAULT_PRODUCER = os.path.expanduser(
+    "~/Projects/duckdb_duck_block_utils/build/release/extension/"
+    "duck_block_utils/duck_block_utils.duckdb_extension")
+SCHEMA = ("STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER, "
+          "encoding VARCHAR, attributes MAP(VARCHAR,VARCHAR), element_order INTEGER)")
+
+# Documents to push through, with the words that must survive the trip.
+CASES = [
+    ("heading",        "# Title\n",                              ["Title"]),
+    ("nested inlines", "Text with **bold *inner*** here.\n",     ["bold", "inner"]),
+    ("bullet list",    "- alpha\n- beta\n",                      ["alpha", "beta"]),
+    ("ordered list",   "3. one\n4. two\n",                       ["one", "two"]),
+    ("blockquote",     "> quoted para\n>\n> second para\n",      ["quoted", "second"]),
+    ("table",          "| A | B |\n|---|---|\n| 1 | 2 |\n",      ["A", "B", "1", "2"]),
+    ("definition list","Term\n:   Definition\n",                 ["Term", "Definition"]),
+    ("line block",     "| Roses are red\n| Violets are blue\n",  ["Roses", "Violets"]),
+    ("figure",         "![A caption](img.png)\n",                ["img.png", "A caption"]),
+    ("code",           "```py\nprint(1)\n```\n",                 ["print(1)"]),
+]
+
+
+def sql(binary, text, unsigned=True):
+    with tempfile.NamedTemporaryFile("w", suffix=".sql", delete=False) as f:
+        f.write(text)
+        path = f.name
+    try:
+        argv = [binary] + (["-unsigned"] if unsigned else []) + ["-noheader", "-list"]
+        r = subprocess.run(argv, stdin=open(path), capture_output=True, text=True)
+        if r.returncode != 0 or r.stderr.strip():
+            raise RuntimeError((r.stderr or "rc=%d" % r.returncode).strip())
+        return r.stdout.strip()
+    finally:
+        os.unlink(path)
+
+
+def to_blocks(producer, markdown):
+    """markdown -> pandoc AST -> duck_blocks, via the producer."""
+    ast = subprocess.run(["pandoc", "-f", "markdown", "-t", "json"],
+                         input=markdown, capture_output=True, text=True).stdout.strip()
+    q = ast.replace("'", "''")
+    return sql("duckdb", f"LOAD '{producer}';\nSELECT to_json(pandoc_ast_to_blocks('{q}'));\n")
+
+
+def render(blocks_json):
+    """duck_blocks -> markdown, via this repo's writer."""
+    q = blocks_json.replace("'", "''")
+    return sql(MD_DUCKDB,
+               f"LOAD '{EXT_MD}';\n"
+               f"SELECT duck_blocks_to_md(from_json('{q}'::JSON, '[\"{SCHEMA}\"]'));\n")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--producer", default=os.environ.get("DUCK_BLOCK_UTILS", DEFAULT_PRODUCER))
+    args = ap.parse_args()
+
+    for what, ok in (("this extension's build", os.path.exists(EXT_MD)),
+                     ("a system `duckdb` on PATH", shutil.which("duckdb")),
+                     ("`pandoc` on PATH", shutil.which("pandoc")),
+                     (f"a duck_block_utils build at {args.producer}", os.path.exists(args.producer))):
+        if not ok:
+            # Loudly. A silent skip here would report health it never checked.
+            print(f"SKIPPED: needs {what}.")
+            print("         Nothing was verified. This is not a pass.")
+            return 0
+
+    # Asymmetric pre-flight: put a shape through the bridge whose answer is
+    # already known, and specifically one it MUST fail on. A bridge that cannot
+    # object returns silence indistinguishable from a clean bill of health, and
+    # the quiet direction is the one that ships.
+    control = json.dumps([{"kind": "block", "element_type": "paragraph", "content": "CONTROLWORD",
+                           "level": 1, "encoding": "text", "attributes": {}, "element_order": 0}])
+    if "CONTROLWORD" not in render(control):
+        print("BRIDGE BROKEN: the control document did not survive rendering.")
+        print("               Every result below would be meaningless; not run.")
+        return 1
+
+    failures = []
+    for name, markdown, expected in CASES:
+        out = render(to_blocks(args.producer, markdown))
+        missing = [w for w in expected if w not in out]
+        status = "ok " if not missing else "LOST"
+        print(f"  {status} {name:<16} {out.splitlines()[0][:44] if out.strip() else '(empty)'}")
+        if missing:
+            failures.append((name, missing, out))
+
+    print()
+    if failures:
+        for name, missing, out in failures:
+            print(f"FAILED {name}: lost {missing}\n       rendered: {out!r}")
+        return 1
+    print(f"OK: {len(CASES)} documents rendered from live producer output, no content lost.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -69,12 +69,27 @@ SCHEMA = ("STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INT
 KNOWN_UNSTABLE = {
 }
 
+# (name, markdown, words that must survive, [substrings that must NOT appear]).
+#
+# The fourth field exists because the third CANNOT see a lost separator:
+# "quoted parasecond para" contains both "quoted" and "second", so a
+# words-survive assertion passes on output where two paragraphs were
+# concatenated. Forbidding the join is the assertion that matches the property.
+#
+# Worth being exact about what this did and did not miss. This check runs
+# duck_block_utils' output through THIS writer, and that path was always
+# correct -- the concatenation defect was in this repo's READER, which this
+# check never touches. So the coarse assertion did not hide that bug; a missing
+# DIRECTION did (covered now by duck_block_container_children.test). The
+# coarseness was a real latent weakness on the writer side, and is closed here
+# rather than left because it happened not to be the one that bit.
 CASES = [
     ("heading",        "# Title\n",                              ["Title"]),
     ("nested inlines", "Text with **bold *inner*** here.\n",     ["bold", "inner"]),
-    ("bullet list",    "- alpha\n- beta\n",                      ["alpha", "beta"]),
-    ("ordered list",   "3. one\n4. two\n",                       ["one", "two"]),
-    ("blockquote",     "> quoted para\n>\n> second para\n",      ["quoted", "second"]),
+    ("bullet list",    "- alpha\n- beta\n",                      ["alpha", "beta"], ["alphabeta"]),
+    ("ordered list",   "3. one\n4. two\n",                       ["one", "two"], ["onetwo"]),
+    ("blockquote",     "> quoted para\n>\n> second para\n",      ["quoted", "second"],
+                       ["parasecond"]),
     ("table",          "| A | B |\n|---|---|\n| 1 | 2 |\n",      ["A", "B", "1", "2"]),
     # Multi-block on purpose: a definition's continuation block must be indented
     # far enough that a reader keeps it inside the definition. At two spaces it
@@ -145,9 +160,12 @@ def main():
         return 1
 
     failures, expired = [], []
-    for name, markdown, expected in CASES:
+    for case in CASES:
+        name, markdown, expected = case[0], case[1], case[2]
+        forbidden = case[3] if len(case) > 3 else []
         out = render(to_blocks(args.producer, markdown))
         missing = [w for w in expected if w not in out]
+        joined = [w for w in forbidden if w in out]
         # Rendering once proves the words survive; rendering the OUTPUT again
         # proves the markdown says what it meant. A definition continuation
         # indented too shallowly renders fine and re-reads as a different
@@ -157,15 +175,19 @@ def main():
         known = name in KNOWN_UNSTABLE
         if known and not unstable:
             expired.append(name)
-        if missing:
+        if joined:
+            status = "JOIN"
+        elif missing:
             status = "LOST"
         elif unstable:
             status = "note" if known else "DRIFT"
         else:
             status = "ok  "
         print(f"  {status} {name:<16} {out.splitlines()[0][:42] if out.strip() else '(empty)'}")
-        if missing or (unstable and not known):
-            failures.append((name, missing, out if missing else f"unstable:\n{out!r}\n{second!r}"))
+        if joined or missing or (unstable and not known):
+            detail = (f"joined across a block boundary: {joined}\n{out!r}" if joined
+                      else out if missing else f"unstable:\n{out!r}\n{second!r}")
+            failures.append((name, missing or joined, detail))
 
     print()
 

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -50,6 +50,22 @@ SCHEMA = ("STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INT
 # Round trips that are KNOWN not to be stable, with the reason. Recorded rather
 # than silently tolerated: an unexplained exclusion and a forgotten defect look
 # identical later. Anything NOT listed here that drifts is a failure.
+#
+# ENTRIES EXPIRE. `line block` lived here and was removed once upstream fixed
+# the break constructors -- keeping it would have hidden the next regression
+# behind an explanation that had stopped being true. Re-read the reason before
+# trusting an entry; the reason is what tells you it has expired, which is why
+# these record WHY rather than merely THAT.
+#
+# WHAT THIS ARM DOES AND DOES NOT CATCH. It compares pass one against pass two,
+# so it finds output that MEANS something different when read back -- a
+# definition continuation indented two columns instead of four, a caption that
+# duplicates on every pass. It does NOT catch output that is consistently
+# wrong: rendering a hard break as a soft one round-trips perfectly, because
+# the degraded form is self-consistent. Verified by perturbation in both
+# directions. Content loss is caught by the word check below; consistent
+# wrongness is what the sqllogictest suite is for. Three arms, three
+# properties, and none of them subsumes another.
 KNOWN_UNSTABLE = {
     "figure": "this writer emits a figure's caption as a separate italic line, but "
               "`![alt](src)` ALREADY carries that text -- a reader infers a figure "
@@ -58,16 +74,6 @@ KNOWN_UNSTABLE = {
               "not an inherent limit: markdown has one slot for that text and this "
               "fills two. Unfixed -- suppressing the caption needs the caption "
               "branch to know its sibling image's alt.",
-    "line block": "PLAIN-TEXT case only; a line block containing any rich inline "
-                  "is now stable. A line block has no markdown syntax, so this "
-                  "writer emits hard breaks -- but a hard break in TEXT-ONLY "
-                  "content is flattened by the producer to a raw newline in "
-                  "`content` rather than a linebreak inline, so it re-reads as a "
-                  "soft break. Not specific to line blocks: an ordinary paragraph "
-                  "written `alpha  \\nbeta` comes back as content 'alpha\\nbeta' and "
-                  "loses the same distinction, while `alpha **x**  \\nbeta` keeps it "
-                  "because the bold forces inline children. Upstream shape, "
-                  "formatting rather than words, and reported.",
 }
 
 CASES = [

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -66,6 +66,19 @@ SCHEMA = ("STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INT
 # directions. Content loss is caught by the word check below; consistent
 # wrongness is what the sqllogictest suite is for. Three arms, three
 # properties, and none of them subsumes another.
+# WATCHED, 2026-09-01. Nothing in a green run can show that the audit below
+# works: this dict is empty, so both of its loops iterate over nothing and the
+# branches never execute. An audit nobody has seen run is the same evidence as no
+# audit and it presents better -- duck_block_utils found a staleness branch that
+# had never executed once while every green run printed that it had passed.
+#
+# So both were fired, and this is the record:
+#   {"heading": ...}       -> EXPIRED heading: ... its round trip is now STABLE
+#   {"no_such_case": ...}  -> EXPIRED no_such_case: ... no longer has a case
+# Both exit non-zero. Re-plant either to re-watch it.
+#
+# This version at least stays quiet when empty rather than asserting its own
+# verdict, so a green run claims nothing it cannot back.
 KNOWN_UNSTABLE = {
 }
 

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -61,18 +61,22 @@ CASES = [
     ("the metadata block carries role='frontmatter'",
      r"""(SELECT list(e.attributes['role']) FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n')) AS e) WHERE e.element_type = 'metadata')""",
      "[frontmatter]"),
-    # The remaining half of the open decision: level 0 versus structural depth
-    # (>= 1). This is the ONLY thing keeping a frontmatter document invalid, and
-    # it is Teague's call, not a defect to patch at the point of emission.
-    ("a frontmatter document is non-conformant as emitted",
+    # Was the one recorded exception: frontmatter emitted level 0, which
+    # duck_block_is_valid rejects. Ruled level 1 upstream at 2771e9e and fixed, so
+    # this asserts CONFORMANCE now. Kept rather than deleted -- it is the document
+    # that was non-conformant, so it is the one worth holding conformant.
+    ("a frontmatter document is fully conformant",
      r"duck_blocks_are_valid(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n'))",
-     "false"),
-    # ...and level is the SOLE cause, proven rather than asserted: raise level to
-    # the conformant minimum and change NOTHING else, and the document validates.
-    # Without this, the line above would still pass if a second, unrelated defect
-    # appeared -- "invalid" is not evidence of WHY.
-    ("...and raising level to 1 alone makes it conformant",
-     r"""duck_blocks_are_valid([{kind: x.kind, element_type: x.element_type, content: x.content, level: greatest(x.level, 1), encoding: x.encoding, attributes: x.attributes, element_order: x.element_order} for x in parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n')])""",
+     "true"),
+    # The level itself, asserted directly so a regression to 0 names the field
+    # rather than showing up as a bare "invalid".
+    ("the metadata block carries level 1, not 0",
+     r"""(SELECT list(e.level) FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n')) AS e) WHERE e.element_type = 'metadata')""",
+     "[1]"),
+    # TOML frontmatter takes the same path and must be conformant too -- it is a
+    # newer branch of the same scanner, so it is the likelier one to regress.
+    ("a TOML frontmatter document is conformant",
+     r"duck_blocks_are_valid(parse_markdown_to_duck_blocks(e'+++\ntitle = \"T\"\n+++\n\nB.\n'))",
      "true"),
 ]
 
@@ -154,7 +158,11 @@ def main():
         print(f"  {'ok  ' if ok else 'FAIL'} {name}" + ("" if ok else f"   want {want!r}, got {actual!r}"))
         bad += not ok
     print()
-    print("OK: this reader conforms, with the one recorded exception."
+    # No exceptions any more: the level-0 frontmatter row was the last one, ruled
+    # and fixed 2026-09-01. Saying "with the one recorded exception" after it was
+    # gone would be a summary line claiming a caveat that no longer exists, which
+    # is the same defect as claiming a guard that does not.
+    print(f"OK: this reader conforms on all {len(cases)} assertions, no exceptions."
           if not bad else f"FAILED: {bad} conformance assertion(s).")
     return 1 if bad else 0
 

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Check this reader's output against the canonical duck_block conformance rules.
+
+WHY THIS IS A SCRIPT AND NOT A TEST. The rules live in
+conformance/duck_block_conformance.sql, loaded with DuckDB's `.read`, which is a
+CLI dot-command and not SQL -- sqllogictest cannot use it. Inlining the macros
+into a .test would make a THIRD copy of the vocabulary, which is the defect this
+whole arrangement exists to avoid.
+
+WHY IT CANNOT SKIP. duck_blocks_validate() lives in duck_block_utils, which this
+repo cannot load at all: DuckDB matches extension ABI on the exact version string
+and this build reports a dev hash from a pinned submodule. So this reader's
+output had never been checked against the canonical rules by anything, ever.
+These macros are pure SQL and need nothing but DuckDB, so unlike
+check-producer this has no dependency that can go missing and no skip path.
+
+CONTROL FIRST. Every silence here is worthless unless the macros can object --
+their type check accepted ANY string until it was fixed upstream on 2026-09-01.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EXT = os.path.join(REPO, "build/release/extension/markdown/markdown.duckdb_extension")
+DUCKDB = os.path.join(REPO, "build/release/duckdb")
+RULES = os.path.join(REPO, "conformance/duck_block_conformance.sql")
+
+# (name, sql expression, expected literal). Controls first, deliberately.
+CASES = [
+    ("CONTROL undeclared type is reported",
+     "duck_blocks_undeclared_types([{kind:'block',element_type:'zzzz_not_a_type',content:'x',"
+     "level:1,encoding:'text',attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:0}])",
+     "[zzzz_not_a_type]"),
+    ("CONTROL invalid element is rejected",
+     "duck_block_is_valid({kind:'block',element_type:'paragraph',content:'x',level:0,"
+     "encoding:'text',attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:0})",
+     "false"),
+    ("prose is conformant",
+     r"duck_blocks_are_valid(parse_markdown_to_duck_blocks(e'# H\n\nBody **b** and [l](http://x).\n'))",
+     "true"),
+    ("lists, quotes, tables, code are conformant",
+     r"bool_and(duck_blocks_are_valid(parse_markdown_to_duck_blocks(md))) FROM (VALUES "
+     r"(e'- one\n- two\n'),(e'3. one\n4. two\n'),(e'> q\n'),(e'| A |\n|---|\n| 1 |\n'),"
+     r"(e'```py\nx=1\n```\n'),(e'Plain.\n')) d(md)",
+     "true"),
+    ("every emitted type is declared",
+     r"duck_blocks_undeclared_types(parse_markdown_to_duck_blocks(e'# H\n\nB **b**.\n\n- i\n\n> q\n'))",
+     "[]"),
+    # The one exception, asserted so it stays exactly one type wide and cannot
+    # change silently. Recorded as an open decision at the point of emission in
+    # src/markdown_utils.cpp: `metadata` is the declared name.
+    ("frontmatter is the ONLY undeclared type emitted",
+     r"duck_blocks_undeclared_types(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n'))",
+     "[frontmatter]"),
+    # Second half of the same open decision: level 0 versus structural depth.
+    ("a frontmatter document is otherwise non-conformant only on level",
+     r"duck_blocks_are_valid(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n'))",
+     "false"),
+]
+
+
+def main():
+    for what, ok in (("this extension's build", os.path.exists(EXT)),
+                     ("the vendored rules at conformance/", os.path.exists(RULES))):
+        if not ok:
+            print(f"FAILED: missing {what}. This check has no skip path by design.")
+            return 1
+
+    sql = [f"LOAD '{EXT}';", f".read {RULES}", ".mode list", ".header off"]
+    sql += [f"SELECT {expr};" for _, expr, _ in CASES]
+    with tempfile.NamedTemporaryFile("w", suffix=".sql", delete=False) as f:
+        f.write("\n".join(sql) + "\n")
+        path = f.name
+    try:
+        r = subprocess.run([DUCKDB, "-unsigned", "-noheader", "-list"],
+                           stdin=open(path), capture_output=True, text=True)
+    finally:
+        os.unlink(path)
+    if r.returncode != 0 or "Error" in r.stderr:
+        print("FAILED: could not run the rules.\n" + (r.stderr.strip() or r.stdout.strip()))
+        return 1
+
+    got = [l for l in r.stdout.strip().splitlines() if l.strip()]
+    if len(got) != len(CASES):
+        print(f"FAILED: expected {len(CASES)} results, got {len(got)}:\n{r.stdout}")
+        return 1
+
+    bad = 0
+    for (name, _, want), actual in zip(CASES, got):
+        ok = actual.strip() == want
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}" + ("" if ok else f"   want {want!r}, got {actual!r}"))
+        bad += not ok
+    print()
+    print("OK: this reader conforms, with the one recorded exception."
+          if not bad else f"FAILED: {bad} conformance assertion(s).")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -17,6 +17,7 @@ check-producer this has no dependency that can go missing and no skip path.
 CONTROL FIRST. Every silence here is worthless unless the macros can object --
 their type check accepted ANY string until it was fixed upstream on 2026-09-01.
 """
+import glob
 import os
 import re
 import subprocess
@@ -138,6 +139,46 @@ def absorption_cases():
     ]
 
 
+
+def corpus_cases():
+    """Every markdown document in the repo, through the advisory rules.
+
+    The CASES above are hand-built shapes; this is what the reader actually does
+    to real documents. duck_blocks_warnings() is upstream's advisory set -- the
+    preferences that validity does not express, so that two conformant producers
+    cannot silently differ on the same document. duck_blocks_are_valid() also
+    carries the two DOCUMENT-shape rules a per-element check cannot see: unique
+    element_order, and depth descending one level at a time. Upstream calls the
+    level-jump rule the one whose absence caused a year of drift across four
+    extensions.
+
+    Reported as the LIST OF OFFENDING FILES rather than a count, so a failure
+    names the document instead of asserting that some document somewhere is bad.
+    """
+    corpus = sorted(glob.glob(os.path.join(REPO, "test/data/*.md")) +
+                    glob.glob(os.path.join(REPO, "docs/*.md")) +
+                    [os.path.join(REPO, "README.md")])
+    corpus = [f for f in corpus if os.path.exists(f)]
+    if not corpus:
+        return []
+    def lit(p):
+        return "'" + p.replace("'", "''") + "'"
+    warn = " UNION ALL ".join(
+        f"SELECT {lit(os.path.relpath(f, REPO))} AS f FROM duck_blocks_warnings("
+        f"(SELECT parse_markdown_to_duck_blocks(content) FROM read_text({lit(f)})))"
+        for f in corpus)
+    invalid = " UNION ALL ".join(
+        f"SELECT {lit(os.path.relpath(f, REPO))} AS f FROM read_text({lit(f)}) "
+        f"WHERE NOT duck_blocks_are_valid(parse_markdown_to_duck_blocks(content))"
+        for f in corpus)
+    return [
+        (f"no advisory warning on any of {len(corpus)} repo documents",
+         f"(SELECT coalesce(list(DISTINCT f), []) FROM ({warn}))", "[]"),
+        (f"all {len(corpus)} repo documents are valid (order + level shape)",
+         f"(SELECT coalesce(list(DISTINCT f), []) FROM ({invalid}))", "[]"),
+    ]
+
+
 def main():
     for what, ok in (("this extension's build", os.path.exists(EXT)),
                      ("the vendored rules at conformance/", os.path.exists(RULES))):
@@ -145,7 +186,7 @@ def main():
             print(f"FAILED: missing {what}. This check has no skip path by design.")
             return 1
 
-    cases = CASES + absorption_cases()
+    cases = CASES + absorption_cases() + corpus_cases()
 
     sql = [f"LOAD '{EXT}';", f".read {RULES}", ".mode list", ".header off"]
     sql += [f"SELECT {expr};" for _, expr, _ in cases]

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -18,6 +18,7 @@ CONTROL FIRST. Every silence here is worthless unless the macros can object --
 their type check accepted ANY string until it was fixed upstream on 2026-09-01.
 """
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -76,6 +77,49 @@ CASES = [
 ]
 
 
+
+def absorption_cases():
+    """Every declared type, checked for the run-eating bug.
+
+    A block ABSORBS the inline run that follows it. Three declared types render
+    without using their content -- `hr`, `page_break`, `generic` -- so absorbing
+    into one DELETED the run: an `hr` followed by "Section two" emitted the rule
+    and dropped the sentence, in duck_blocks_to_md itself. It survived because
+    the only path that exercised it rendered one element at a time and never
+    absorbed anything.
+
+    Generated from the VENDORED type list rather than a list kept here, so a new
+    content-discarding type upstream fails this the first time it is vendored,
+    instead of quietly eating runs until someone reads the output.
+    """
+    m = re.search(r"duck_block_declared_types\(\) AS \(\s*\[(.*?)\]",
+                  open(RULES).read(), re.S)
+    types = re.findall(r"'([^']+)'", m.group(1)) if m else []
+    if not types:
+        return []
+    values = ",".join(f"('{t}')" for t in types)
+    probe = (lambda marker:
+             "(SELECT coalesce(list(t), []) FROM (VALUES " + values + ") v(t) WHERE "
+             "duck_blocks_to_md(["
+             "{kind:'block',element_type:v.t,content:'',level:1,encoding:'text',"
+             "attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:0},"
+             "{kind:'inline',element_type:'text',content:'KEEPME',level:2,encoding:'text',"
+             "attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:1}"
+             "]) NOT LIKE '%" + marker + "%')")
+    # CONTROL: with a marker that is never emitted, EVERY type must be reported.
+    # Without it a probe that silently matched nothing would read as "no type
+    # loses the run" -- a pass that means the detection is broken, not that the
+    # renderer is right.
+    control = ("(SELECT count(*) FROM (VALUES " + values + ") v(t) WHERE "
+               "duck_blocks_to_md([{kind:'block',element_type:v.t,content:'',level:1,"
+               "encoding:'text',attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:0}]) "
+               "NOT LIKE '%ZZ_NEVER_EMITTED%')")
+    return [
+        (f"CONTROL the run probe can detect loss (all {len(types)} types)", control, str(len(types))),
+        ("no declared type eats the inline run that follows it", probe("KEEPME"), "[]"),
+    ]
+
+
 def main():
     for what, ok in (("this extension's build", os.path.exists(EXT)),
                      ("the vendored rules at conformance/", os.path.exists(RULES))):
@@ -83,8 +127,10 @@ def main():
             print(f"FAILED: missing {what}. This check has no skip path by design.")
             return 1
 
+    cases = CASES + absorption_cases()
+
     sql = [f"LOAD '{EXT}';", f".read {RULES}", ".mode list", ".header off"]
-    sql += [f"SELECT {expr};" for _, expr, _ in CASES]
+    sql += [f"SELECT {expr};" for _, expr, _ in cases]
     with tempfile.NamedTemporaryFile("w", suffix=".sql", delete=False) as f:
         f.write("\n".join(sql) + "\n")
         path = f.name
@@ -98,12 +144,12 @@ def main():
         return 1
 
     got = [l for l in r.stdout.strip().splitlines() if l.strip()]
-    if len(got) != len(CASES):
-        print(f"FAILED: expected {len(CASES)} results, got {len(got)}:\n{r.stdout}")
+    if len(got) != len(cases):
+        print(f"FAILED: expected {len(cases)} results, got {len(got)}:\n{r.stdout}")
         return 1
 
     bad = 0
-    for (name, _, want), actual in zip(CASES, got):
+    for (name, _, want), actual in zip(cases, got):
         ok = actual.strip() == want
         print(f"  {'ok  ' if ok else 'FAIL'} {name}" + ("" if ok else f"   want {want!r}, got {actual!r}"))
         bad += not ok

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -48,16 +48,31 @@ CASES = [
     ("every emitted type is declared",
      r"duck_blocks_undeclared_types(parse_markdown_to_duck_blocks(e'# H\n\nB **b**.\n\n- i\n\n> q\n'))",
      "[]"),
-    # The one exception, asserted so it stays exactly one type wide and cannot
-    # change silently. Recorded as an open decision at the point of emission in
-    # src/markdown_utils.cpp: `metadata` is the declared name.
-    ("frontmatter is the ONLY undeclared type emitted",
+    # Was "[frontmatter]" until spec 6.2 settled the name as `metadata` +
+    # attributes['role']='frontmatter'. Kept as an assertion rather than deleted:
+    # it is the one document that USED to carry an undeclared type, so it is the
+    # one most worth holding at zero.
+    ("a frontmatter document emits no undeclared type",
      r"duck_blocks_undeclared_types(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n'))",
+     "[]"),
+    # The role is what now carries what the old type name said. Asserted so that
+    # renaming the type back, or dropping the role, is a failure and not a silence.
+    ("the metadata block carries role='frontmatter'",
+     r"""(SELECT list(e.attributes['role']) FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n')) AS e) WHERE e.element_type = 'metadata')""",
      "[frontmatter]"),
-    # Second half of the same open decision: level 0 versus structural depth.
-    ("a frontmatter document is otherwise non-conformant only on level",
+    # The remaining half of the open decision: level 0 versus structural depth
+    # (>= 1). This is the ONLY thing keeping a frontmatter document invalid, and
+    # it is Teague's call, not a defect to patch at the point of emission.
+    ("a frontmatter document is non-conformant as emitted",
      r"duck_blocks_are_valid(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n'))",
      "false"),
+    # ...and level is the SOLE cause, proven rather than asserted: raise level to
+    # the conformant minimum and change NOTHING else, and the document validates.
+    # Without this, the line above would still pass if a second, unrelated defect
+    # appeared -- "invalid" is not evidence of WHY.
+    ("...and raising level to 1 alone makes it conformant",
+     r"""duck_blocks_are_valid([{kind: x.kind, element_type: x.element_type, content: x.content, level: greatest(x.level, 1), encoding: x.encoding, attributes: x.attributes, element_order: x.element_order} for x in parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\nB.\n')])""",
+     "true"),
 ]
 
 

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -30,6 +30,20 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # build in the lightweight job -- which is how this check spent its first four
 # runs failing with "missing this extension's build", correctly refusing to skip
 # in a job that could never satisfy it.
+# WATCHED, 2026-09-01, both override paths, because they were added for CI and
+# nothing local had ever taken them:
+#   MARKDOWN_EXTENSION=<v1.5.4 CI artifact>  -> loads, 18/18, rc=0
+#   DUCKDB_BIN=<released v1.5.4 CLI>         -> the local dev extension will not
+#                                               load into it, and this FAILS rc=1
+# The second is the mismatch shape duck_block_utils hit, where an extension path
+# pinned to one build and a binary falling through to another made the check SKIP
+# silently. It cannot skip here -- there is no fallback and no skip path -- but
+# the mismatch was fired rather than reasoned about.
+#
+# Note the asymmetry is real and not a bug: a v1.5.4 markdown artifact DOES load
+# into this dev build, while duck_block_utils' extension does not (it is stamped
+# v1.5.5 and this reports b155d6f63c). That is why check_against_producer.py
+# still needs its JSON bridge and this check does not.
 EXT = os.environ.get("MARKDOWN_EXTENSION") or os.path.join(
     REPO, "build/release/extension/markdown/markdown.duckdb_extension")
 DUCKDB = os.environ.get("DUCKDB_BIN") or os.path.join(REPO, "build/release/duckdb")

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -179,6 +179,50 @@ def corpus_cases():
     ]
 
 
+
+def container_cases():
+    """Every declared type as a container with TWO block children.
+
+    Two, not one, and with a LEAD child before the probe: a walk that stops after
+    the first child passes a single-child probe and looks correct. That is how a
+    definition list dropped everything after its first child upstream for as long
+    as the shape had existed, and how this repo's blockquote concatenated its
+    children unnoticed.
+
+    Checks both failure modes the container defects here took: children JOINED
+    with no separator (ALPHA + BETA -> ALPHABETA, which a words-survive assertion
+    cannot see) and children DROPPED.
+    """
+    m = re.search(r"duck_block_declared_types\(\) AS \(\s*\[(.*?)\]",
+                  open(RULES).read(), re.S)
+    types = re.findall(r"'([^']+)'", m.group(1)) if m else []
+    if not types:
+        return []
+    def probe(t):
+        return ("duck_blocks_to_md(["
+                f"{{kind:'block',element_type:'{t}',content:NULL,level:1,encoding:'text',"
+                "attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:0},"
+                "{kind:'block',element_type:'paragraph',content:'ALPHA',level:2,encoding:'text',"
+                "attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:1},"
+                "{kind:'block',element_type:'paragraph',content:'BETA',level:2,encoding:'text',"
+                "attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:2}])")
+    union = " UNION ALL ".join(f"SELECT '{t}' AS t, {probe(t)} AS out" for t in types)
+    # CONTROL: the detector must fire on output that really is joined. Without
+    # it, a probe that silently matched nothing would read as "no type joins its
+    # children" -- a pass meaning the detection is broken, not the code correct.
+    control = ("(SELECT coalesce(list(t), []) FROM (SELECT 'x' AS t, "
+               "duck_blocks_to_md([{kind:'block',element_type:'paragraph',content:'ALPHABETA',"
+               "level:1,encoding:'text',attributes:MAP{}::MAP(VARCHAR,VARCHAR),element_order:0}]) AS out) "
+               "WHERE out LIKE '%ALPHABETA%')")
+    return [
+        ("CONTROL the join detector fires on joined output", control, "[x]"),
+        (f"no declared type JOINS its two block children ({len(types)} types)",
+         f"(SELECT coalesce(list(t), []) FROM ({union}) WHERE out LIKE '%ALPHABETA%')", "[]"),
+        (f"no declared type DROPS either block child ({len(types)} types)",
+         f"(SELECT coalesce(list(t), []) FROM ({union}) WHERE out NOT LIKE '%ALPHA%' OR out NOT LIKE '%BETA%')", "[]"),
+    ]
+
+
 def main():
     for what, ok in (("this extension's build", os.path.exists(EXT)),
                      ("the vendored rules at conformance/", os.path.exists(RULES))):
@@ -186,7 +230,7 @@ def main():
             print(f"FAILED: missing {what}. This check has no skip path by design.")
             return 1
 
-    cases = CASES + absorption_cases() + corpus_cases()
+    cases = CASES + absorption_cases() + container_cases() + corpus_cases()
 
     sql = [f"LOAD '{EXT}';", f".read {RULES}", ".mode list", ".header off"]
     sql += [f"SELECT {expr};" for _, expr, _ in cases]

--- a/scripts/check_conformance.py
+++ b/scripts/check_conformance.py
@@ -24,8 +24,14 @@ import sys
 import tempfile
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-EXT = os.path.join(REPO, "build/release/extension/markdown/markdown.duckdb_extension")
-DUCKDB = os.path.join(REPO, "build/release/duckdb")
+# Overridable so CI can run this against the BUILT ARTIFACT with a released
+# duckdb CLI. Locally both default to this repo's build. In CI there is no local
+# build in the lightweight job -- which is how this check spent its first four
+# runs failing with "missing this extension's build", correctly refusing to skip
+# in a job that could never satisfy it.
+EXT = os.environ.get("MARKDOWN_EXTENSION") or os.path.join(
+    REPO, "build/release/extension/markdown/markdown.duckdb_extension")
+DUCKDB = os.environ.get("DUCKDB_BIN") or os.path.join(REPO, "build/release/duckdb")
 RULES = os.path.join(REPO, "conformance/duck_block_conformance.sql")
 
 # (name, sql expression, expected literal). Controls first, deliberately.
@@ -75,7 +81,15 @@ CASES = [
      "[1]"),
     # TOML frontmatter takes the same path and must be conformant too -- it is a
     # newer branch of the same scanner, so it is the likelier one to regress.
-    ("a TOML frontmatter document is conformant",
+    #
+    # Asserts the ENCODING rather than mere validity, because validity passes
+    # VACUOUSLY on a build that does not recognise `+++`: the fence falls through
+    # to prose, and prose is conformant. Caught by running this against an older
+    # artifact, where it reported ok for a reader that had no TOML support at all.
+    ("a TOML frontmatter document yields a toml metadata block",
+     r"""(SELECT list(e.encoding) FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'+++\ntitle = "T"\n+++\n\nB.\n')) AS e) WHERE e.element_type = 'metadata')""",
+     "[toml]"),
+    ("...and that document is conformant",
      r"duck_blocks_are_valid(parse_markdown_to_duck_blocks(e'+++\ntitle = \"T\"\n+++\n\nB.\n'))",
      "true"),
 ]

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -135,6 +135,11 @@ def check_vendored_conformance(root, vocab):
     for label, macro, expected in (
         ("kinds", "duck_block_declared_kinds", vocab["kinds"]),
         ("types", "duck_block_declared_types", vocab["types"]),
+        # Encodings became a THIRD axis upstream on 2026-09-01, after the list had
+        # been hardcoded in four places and nothing compared them. A new list that
+        # nothing compares is the same gap that let `role` go unguarded here, so it
+        # is compared from the day it appears rather than the day it drifts.
+        ("encodings", "duck_block_declared_encodings", vocab["encodings"]),
     ):
         m = re.search(r"MACRO " + macro + r"\(\) AS \(\s*\[(.*?)\]", text, re.S)
         if not m:
@@ -330,6 +335,7 @@ def main():
     vocab_axes = {
         "kinds": {v for k, v in vocabulary_of(local).items() if k.startswith("KIND_")},
         "types": {v for k, v in vocabulary_of(local).items() if not k.startswith("KIND_")},
+        "encodings": {v for k, v in local.items() if k.startswith("ENCODING_") and not v.isdigit()},
     }
     for problem in check_vendored_conformance(root, vocab_axes):
         breaking = True

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -71,6 +71,10 @@ INTENTIONAL_FALLTHROUGH = {
     "VALUE_STRING": "RenderMetaValue's else arm takes content verbatim, which is "
                     "also the right handling for any value type this build "
                     "does not know",
+    "TYPE_PLAIN": "a text run with no paragraph semantics; the unknown-block "
+                  "terminal arm already renders it exactly as a paragraph, "
+                  "verified at top level, in a tight list item and inside a "
+                  "container. A branch would restate the fallback",
 }
 
 

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -68,6 +68,12 @@ CONST_RE = re.compile(r'static\s+constexpr\s+[\w:*\s]+?\**(\w+)\s*=\s*(?:"([^"]*
 # Vocabulary we deliberately render through a fallthrough rather than a branch.
 # Recorded here so the check stays silent about them and loud about everything
 # else -- an unexplained gap and an intentional one look identical otherwise.
+# WATCHED, 2026-09-01, both expiry branches, since a green run cannot show that
+# either works and the entries here are load-bearing (emptying this dict makes
+# both reappear as GAPS, which is how that was verified rather than assumed):
+#   {"TYPE_NO_LONGER_REAL": ...}  -> EXPIRED ... upstream no longer publishes it
+#   {"TYPE_HEADING": ...}         -> EXPIRED ... this build now branches on it
+# Both exit non-zero. Re-plant either to re-watch it.
 INTENTIONAL_FALLTHROUGH = {
     "VALUE_STRING": "RenderMetaValue's else arm takes content verbatim, which is "
                     "also the right handling for any value type this build "

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Check this extension's duck_block vocabulary against upstream.
+
+A submodule pin and a vendored copy have the same defect: neither notices when
+upstream moves. This closes that, and reports two different things:
+
+  DRIFT    a constant upstream renamed, removed, or changed the value of.
+           Breaking -- our string literals silently stop matching.
+  GAPS     an element type upstream publishes that our renderers never branch
+           on. Not breaking, but it renders through a fallthrough, which is how
+           inline `generic` came to drop its source_type silently.
+
+Constants are compared by name and value, not by diffing text, so churn that
+does not change the vocabulary (idx_t -> uint64_t, comments, formatting) stays
+quiet. A check that cries wolf gets ignored, and then it is worth nothing.
+"""
+import argparse
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+
+HEADER_REL = "src/include/duck_block_vocabulary.hpp"
+LOCAL_CANDIDATES = [
+    HEADER_REL,                                     # vendored (this repo)
+    "third_party/duck_block_utils/" + HEADER_REL,   # submodule, if one is ever used
+]
+UPSTREAM_URL = ("https://raw.githubusercontent.com/teaguesterling/"
+                "duckdb_duck_block_utils/main/" + HEADER_REL)
+CONST_RE = re.compile(r'static\s+constexpr\s+[\w:*\s]+?\**(\w+)\s*=\s*(?:"([^"]*)"|([0-9]+))\s*;')
+
+# Vocabulary we deliberately render through a fallthrough rather than a branch.
+# Recorded here so the check stays silent about them and loud about everything
+# else -- an unexplained gap and an intentional one look identical otherwise.
+INTENTIONAL_FALLTHROUGH = {
+    "VALUE_STRING": "RenderMetaValue's else arm takes content verbatim, which is "
+                    "also the right handling for any value type this build "
+                    "does not know",
+}
+
+
+def parse_constants(text):
+    out = {}
+    for name, sval, ival in CONST_RE.findall(text):
+        out[name] = sval if ival == "" else ival
+    return out
+
+
+def find_local(root):
+    for rel in LOCAL_CANDIDATES:
+        path = os.path.join(root, rel)
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def read_upstream(source, ref):
+    """Read the upstream header, from a local clone or over HTTPS.
+
+    Vendoring means there is no local upstream to read, so the network is the
+    default. A local clone stays supported for working offline.
+    """
+    if source is None:
+        try:
+            with urllib.request.urlopen(UPSTREAM_URL, timeout=30) as response:
+                return response.read().decode("utf-8")
+        except Exception as exc:
+            sys.exit(f"error: cannot fetch {UPSTREAM_URL}\n{exc}\n"
+                     f"       pass --upstream PATH to compare against a local clone instead")
+    try:
+        return subprocess.check_output(
+            ["git", "-C", source, "show", f"{ref}:{HEADER_REL}"],
+            stderr=subprocess.PIPE, text=True)
+    except subprocess.CalledProcessError as exc:
+        sys.exit(f"error: cannot read {HEADER_REL} from {source}@{ref}\n{exc.stderr.strip()}")
+
+
+def handled_types(src):
+    """element_type / kind values our renderers actually branch on."""
+    text = open(src).read()
+    named = set(re.findall(r'Vocab::([A-Z_]+)', text))
+    literal = set(re.findall(r'element_type == "([a-z_:]+)"', text))
+    return named, literal
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--upstream", default=None,
+                    help="path to a duck_block_utils clone (default: fetch over HTTPS)")
+    ap.add_argument("--ref", default="origin/main",
+                    help="upstream ref to compare against (default: origin/main)")
+    ap.add_argument("--fetch", action="store_true", help="git fetch the upstream ref first")
+    args = ap.parse_args()
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    local_path = find_local(root)
+    if not local_path:
+        sys.exit("error: no duck_block_vocabulary.hpp found in " + " or ".join(LOCAL_CANDIDATES))
+
+    upstream_repo = args.upstream
+    if upstream_repo is not None:
+        # A submodule's .git is a file pointing at the real gitdir, not a directory.
+        if not os.path.exists(os.path.join(upstream_repo, ".git")):
+            sys.exit(f"error: {upstream_repo} is not a git clone")
+        if args.fetch:
+            subprocess.run(["git", "-C", upstream_repo, "fetch", "--quiet", "origin"], check=False)
+
+    local = parse_constants(open(local_path).read())
+    upstream = parse_constants(read_upstream(upstream_repo, args.ref))
+    if not upstream:
+        sys.exit("error: parsed no constants from upstream -- has the header's shape changed?")
+
+    print(f"local    {os.path.relpath(local_path, root)}  ({len(local)} constants)")
+    origin = f"{upstream_repo}@{args.ref}" if upstream_repo else UPSTREAM_URL
+    print(f"upstream {origin}  ({len(upstream)} constants)")
+    print(f"spec     local {local.get('SPEC_VERSION','?')}  upstream {upstream.get('SPEC_VERSION','?')}")
+    print()
+
+    removed = sorted(set(local) - set(upstream))
+    added = sorted(set(upstream) - set(local))
+    changed = sorted(k for k in set(local) & set(upstream) if local[k] != upstream[k])
+
+    breaking = False
+    if removed:
+        breaking = True
+        print("DRIFT  gone upstream (our references would no longer compile):")
+        for k in removed:
+            print(f"         {k} = {local[k]!r}")
+    if changed:
+        breaking = True
+        print("DRIFT  value changed upstream (our output silently stops matching):")
+        for k in changed:
+            print(f"         {k}: {local[k]!r} -> {upstream[k]!r}")
+    if added:
+        print("NEW    published upstream, not in our copy:")
+        for k in added:
+            print(f"         {k} = {upstream[k]!r}")
+    if not (removed or changed or added):
+        print("vocabulary is in sync")
+
+    # Gaps: types upstream publishes that no renderer branches on.
+    named, literal = handled_types(os.path.join(root, "src/duck_block_functions.cpp"))
+    vocab_types = {k: v for k, v in upstream.items()
+                   if k.startswith(("TYPE_", "INLINE_", "VALUE_", "KIND_"))}
+    gaps = sorted(k for k, v in vocab_types.items()
+                  if k not in named and v not in literal and k not in INTENTIONAL_FALLTHROUGH)
+    if gaps:
+        print()
+        print("GAPS   published but not branched on (renders via fallthrough):")
+        for k in gaps:
+            print(f"         {k} = {vocab_types[k]!r}")
+
+    print()
+    if breaking:
+        print("FAILED: vocabulary drift is breaking. Update the copy and the references.")
+        return 1
+    if added:
+        print("OK with news: upstream added vocabulary. Review whether we should handle it.")
+    else:
+        print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -40,6 +40,59 @@ INTENTIONAL_FALLTHROUGH = {
 }
 
 
+def vocabulary_of(constants):
+    """The element-type constants, excluding struct field offsets.
+
+    Selecting on the name prefix alone also catches KIND_IDX, which is a field
+    offset rather than an element type -- it reported as a GAP, which is the
+    noise that teaches people to ignore the arm that earns its keep. Vocabulary
+    values are lowercase tokens; offsets are digits. (Found by panduck.)
+    """
+    return {k: v for k, v in constants.items()
+            if k.startswith(("TYPE_", "INLINE_", "VALUE_", "KIND_")) and not v.isdigit()}
+
+
+def classify(local, upstream):
+    """Split the comparison into removed / changed / added, by name AND value."""
+    removed = sorted(set(local) - set(upstream))
+    added = sorted(set(upstream) - set(local))
+    changed = sorted(k for k in set(local) & set(upstream) if local[k] != upstream[k])
+    return removed, changed, added
+
+
+def self_test():
+    """Pin the properties this check exists for, rather than asserting them in a
+    comment. A guard nobody has watched fail is not yet a guard."""
+    base = {"TYPE_PAGE": "page_break", "TYPE_FIGURE": "figure", "KIND_IDX": "0"}
+    failures = []
+
+    # A rename, with the constant COUNT held identical.
+    renamed = {"TYPE_PAGE_BREAK": "page_break", "TYPE_FIGURE": "figure", "KIND_IDX": "0"}
+    removed, changed, added = classify(base, renamed)
+    if len(base) != len(renamed) or removed != ["TYPE_PAGE"] or not added:
+        failures.append("rename not caught with the count held constant")
+
+    # A value change, count identical, names identical.
+    revalued = dict(base, TYPE_PAGE="pagebreak")
+    removed, changed, added = classify(base, revalued)
+    if len(base) != len(revalued) or changed != ["TYPE_PAGE"] or removed or added:
+        failures.append("value change not caught with names and count identical")
+
+    # Cosmetic churn: same names, same values, different text. Must be silent.
+    removed, changed, added = classify(base, dict(base))
+    if removed or changed or added:
+        failures.append("cosmetic churn was not silent")
+
+    # Field offsets are not vocabulary.
+    if "KIND_IDX" in vocabulary_of(base):
+        failures.append("KIND_IDX selected as an element type")
+
+    for line in failures:
+        print("SELF-TEST FAILED: " + line)
+    print("self-test: " + ("FAILED" if failures else "all properties hold"))
+    return 1 if failures else 0
+
+
 def parse_constants(text):
     out = {}
     for name, sval, ival in CONST_RE.findall(text):
@@ -91,7 +144,12 @@ def main():
     ap.add_argument("--ref", default="origin/main",
                     help="upstream ref to compare against (default: origin/main)")
     ap.add_argument("--fetch", action="store_true", help="git fetch the upstream ref first")
+    ap.add_argument("--self-test", action="store_true",
+                    help="check the checker: rename, value change and cosmetic churn")
     args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
 
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     local_path = find_local(root)
@@ -117,9 +175,7 @@ def main():
     print(f"spec     local {local.get('SPEC_VERSION','?')}  upstream {upstream.get('SPEC_VERSION','?')}")
     print()
 
-    removed = sorted(set(local) - set(upstream))
-    added = sorted(set(upstream) - set(local))
-    changed = sorted(k for k in set(local) & set(upstream) if local[k] != upstream[k])
+    removed, changed, added = classify(local, upstream)
 
     breaking = False
     if removed:
@@ -141,8 +197,7 @@ def main():
 
     # Gaps: types upstream publishes that no renderer branches on.
     named, literal = handled_types(os.path.join(root, "src/duck_block_functions.cpp"))
-    vocab_types = {k: v for k, v in upstream.items()
-                   if k.startswith(("TYPE_", "INLINE_", "VALUE_", "KIND_"))}
+    vocab_types = vocabulary_of(upstream)
     gaps = sorted(k for k, v in vocab_types.items()
                   if k not in named and v not in literal and k not in INTENTIONAL_FALLTHROUGH)
     if gaps:

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -22,6 +22,7 @@ import sys
 import urllib.request
 
 HEADER_REL = "src/include/duck_block_vocabulary.hpp"
+CONFORMANCE_REL = "conformance/duck_block_conformance.sql"
 LOCAL_CANDIDATES = [
     HEADER_REL,                                     # vendored (this repo)
     "third_party/duck_block_utils/" + HEADER_REL,   # submodule, if one is ever used
@@ -110,6 +111,33 @@ def compare_spec_version(local, upstream):
         return True, (f"MINOR behind {local} -> {upstream}: this copy claims a newer "
                       f"spec than upstream publishes")
     return False, None
+
+
+def check_vendored_conformance(root, vocab_values):
+    """The conformance SQL embeds the type list -- a SECOND copy of the vocabulary.
+
+    Two copies checked by the same party cannot detect their own disagreement, so
+    the embedded list is compared against the vendored header here. The header is
+    compared against upstream above, so drift in either link fails. Without this,
+    adding a type upstream would make the vendored SQL report it as undeclared --
+    a false positive from a check whose whole job is telling truth from typo.
+    """
+    path = os.path.join(root, CONFORMANCE_REL)
+    if not os.path.exists(path):
+        return []
+    text = open(path).read()
+    m = re.search(r"MACRO duck_block_declared_types\(\) AS \(\s*\[(.*?)\]", text, re.S)
+    if not m:
+        return [f"{CONFORMANCE_REL}: could not find the declared-types list to compare"]
+    embedded = set(re.findall(r"'([^']+)'", m.group(1)))
+    missing = sorted(vocab_values - embedded)
+    extra = sorted(embedded - vocab_values)
+    problems = []
+    if missing:
+        problems.append(f"{CONFORMANCE_REL} is MISSING types the header declares: {missing}")
+    if extra:
+        problems.append(f"{CONFORMANCE_REL} lists types the header does not: {extra}")
+    return problems
 
 
 def vocabulary_of(constants):
@@ -287,6 +315,17 @@ def main():
             print(f"         {k} = {upstream[k]!r}")
     if not (removed or changed or added):
         print("vocabulary constants are in sync")
+
+    # The vendored conformance SQL carries its own copy of the type list.
+    # element_types only -- KIND_* are kinds, which duck_block_declared_types()
+    # correctly does not list. Comparing the two sets whole reported block, inline
+    # and value as missing on this check's first run: a false positive from the
+    # check, not drift in the file.
+    element_types = {v for k, v in vocabulary_of(local).items() if not k.startswith("KIND_")}
+    for problem in check_vendored_conformance(root, element_types):
+        breaking = True
+        print("DRIFT  " + problem)
+        print("       Re-vendor conformance/duck_block_conformance.sql from upstream.")
 
     # Gaps: types upstream publishes that no renderer branches on.
     named, literal = handled_types(os.path.join(root, "src/duck_block_functions.cpp"))

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -266,9 +266,28 @@ def read_upstream(source, ref):
         sys.exit(f"error: cannot read {HEADER_REL} from {source}@{ref}\n{exc.stderr.strip()}")
 
 
+def strip_comments(text):
+    """Remove // and /* */ so a MENTION is not mistaken for a use.
+
+    This scan asks which vocabulary constants the renderers branch on, and the
+    answer feeds the fallthrough audit -- so a constant named only in a comment
+    would read as handled and SUPPRESS a real gap. That is the same
+    loose-pattern failure duck_block_utils hit measuring their own header, where
+    a `TYPE_[A-Z_]+` matched the header's own cautionary example and manufactured
+    four phantom findings. Theirs invented findings; this direction hides them,
+    which is quieter and therefore worse to leave to luck.
+
+    Measured when this was written: zero comment-only mentions across all three
+    sources, so nothing changes today. It is the next explanatory comment naming
+    a constant that this is for.
+    """
+    text = re.sub(r'/\*.*?\*/', '', text, flags=re.S)
+    return re.sub(r'//[^\n]*', '', text)
+
+
 def handled_types(src):
     """element_type / kind values our renderers actually branch on."""
-    text = open(src).read()
+    text = strip_comments(open(src).read())
     named = set(re.findall(r'Vocab::([A-Z_]+)', text))
     literal = set(re.findall(r'element_type == "([a-z_:]+)"', text))
     return named, literal

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -289,6 +289,32 @@ def main():
     vocab_types = vocabulary_of(upstream)
     gaps = sorted(k for k, v in vocab_types.items()
                   if k not in named and v not in literal and k not in INTENTIONAL_FALLTHROUGH)
+
+    # AUDIT THE ALLOWLIST, in BOTH ways an entry expires. An entry that excuses
+    # nothing is worse than none: it reads as a considered decision while
+    # guarding a case that no longer exists.
+    #
+    #   stale key   the constant was renamed or removed upstream, so the entry
+    #               matches nothing. Invisible to any check that only asks
+    #               whether the excused case still fails -- the case is simply
+    #               absent, which looks exactly like the exemption working.
+    #   superseded  the type is now branched on explicitly, so it is not a
+    #               fallthrough at all. Filtered out before the allowlist is
+    #               consulted, so it would never be reported either.
+    #
+    # (The first mode is duck_block_utils'; the second is the one they took
+    # from here. Neither audit had both until tonight.)
+    for key, reason in sorted(INTENTIONAL_FALLTHROUGH.items()):
+        if key not in vocab_types:
+            breaking = True
+            print(f"EXPIRED  {key}: allowlisted as an intentional fallthrough, but upstream")
+            print(f"         no longer publishes it. DELETE the entry -- it excuses nothing.")
+            print(f"         Recorded reason was: {reason}")
+        elif key in named or vocab_types[key] in literal:
+            breaking = True
+            print(f"EXPIRED  {key}: allowlisted as an intentional fallthrough, but this build")
+            print(f"         now branches on it explicitly. DELETE the entry, do not reword it.")
+            print(f"         Recorded reason was: {reason}")
     if gaps:
         print()
         print("GAPS   published but not branched on (renders via fallthrough):")

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -224,6 +224,10 @@ def main():
     ap.add_argument("--ref", default="origin/main",
                     help="upstream ref to compare against (default: origin/main)")
     ap.add_argument("--fetch", action="store_true", help="git fetch the upstream ref first")
+    ap.add_argument("--strict", action="store_true",
+                    help="fail when the upstream copy could not be pinned to a sha "
+                         "(for CI, where a green run that verified nothing is worse "
+                         "than a red one)")
     ap.add_argument("--self-test", action="store_true",
                     help="check the checker: rename, value change and cosmetic churn")
     args = ap.parse_args()
@@ -326,8 +330,15 @@ def main():
         print("FAILED: vocabulary drift is breaking. Update the copy and the references.")
         return 1
     if not verified:
-        # Never claim a clean bill of health from a copy we could not date.
+        # Never claim a clean bill of health from a copy we could not date. Locally
+        # this is a warning so an API outage does not block work; in CI it is a
+        # failure, because a green check that verified nothing is worse than a red
+        # one -- it is indistinguishable from a real pass by anyone reading the
+        # badge, which is the whole hazard this script exists to avoid.
         print("UNVERIFIED: no drift seen, but the upstream copy could not be pinned to a sha.")
+        if args.strict:
+            print("FAILED: --strict, and this result is unverified.")
+            return 1
         return 0
     if added:
         print("OK with news: upstream added vocabulary. Review whether we should handle it.")

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -145,7 +145,21 @@ def check_vendored_conformance(root, vocab):
         if not m:
             problems.append(f"{CONFORMANCE_REL}: no {macro}() list to compare")
             continue
-        embedded = set(re.findall(r"'([^']+)'", m.group(1)))
+        entries = re.findall(r"'([^']+)'", m.group(1))
+        embedded = set(entries)
+        # MULTIPLICITY, checked before the set comparison that would hide it.
+        # Building a set() is the coarser measurement: a list that names `code`
+        # twice compares equal to one that names it once, so len() lies and any
+        # join against it double-counts. duck_block_utils shipped exactly that --
+        # duck_block_type_names() returned 47 rows for a 43-type vocabulary --
+        # and every check there built a set() from it, so nothing could see it.
+        # Five names legitimately live on two AXES here (code, generic, image,
+        # raw as block and inline; list as block and value), which is why the
+        # header has more constants than names and why a duplicate in a flat
+        # list is easy to introduce and invisible to compare.
+        duped = sorted({v for v in entries if entries.count(v) > 1})
+        if duped:
+            problems.append(f"{CONFORMANCE_REL}: {label} listed more than once: {duped}")
         missing = sorted(expected - embedded)
         extra = sorted(embedded - expected)
         if missing:

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -74,6 +74,40 @@ INTENTIONAL_FALLTHROUGH = {
 }
 
 
+def parse_version(text):
+    """MAJOR.MINOR -> (major, minor); (None, None) when unparseable."""
+    m = re.match(r"^\s*(\d+)\.(\d+)", text or "")
+    return (int(m.group(1)), int(m.group(2))) if m else (None, None)
+
+
+def compare_spec_version(local, upstream):
+    """Apply the vocabulary's stated version contract.
+
+    MAJOR bumps for a breaking change, MINOR for an additive one, and the header
+    says to assert MAJOR equality plus a MINOR floor rather than equality on the
+    whole string -- equality goes red on releases that cannot affect us, and a
+    check that cries wolf gets muted.
+
+    Returns (breaking, note). Note that upstream's own recorded history has one
+    counterexample: 1.1 -> 1.2 was breaking and shipped as a minor, and it is
+    what broke this writer in three places. The contract holds from 2.0 onward,
+    so a minor bump is reported loudly rather than silently, but not failed.
+    """
+    lo, up = parse_version(local), parse_version(upstream)
+    if lo == (None, None) or up == (None, None):
+        return True, f"SPEC_VERSION unparseable (local {local!r}, upstream {upstream!r})"
+    if lo[0] != up[0]:
+        return True, (f"MAJOR changed {local} -> {upstream}: a breaking shape or "
+                      f"vocabulary change this build has not migrated for")
+    if up[1] > lo[1]:
+        return False, (f"MINOR ahead {local} -> {upstream}: additive by contract, so "
+                       f"nothing here should break -- review and re-vendor when convenient")
+    if up[1] < lo[1]:
+        return True, (f"MINOR behind {local} -> {upstream}: this copy claims a newer "
+                      f"spec than upstream publishes")
+    return False, None
+
+
 def vocabulary_of(constants):
     """The element-type constants, excluding struct field offsets.
 
@@ -116,6 +150,14 @@ def self_test():
     removed, changed, added = classify(base, dict(base))
     if removed or changed or added:
         failures.append("cosmetic churn was not silent")
+
+    # The version contract: major equality, minor floor.
+    for lo, up, want_breaking in (("2.0", "2.0", False), ("2.0", "2.1", False),
+                                  ("2.0", "3.0", True), ("2.0", "1.2", True),
+                                  ("2.1", "2.0", True)):
+        got, _ = compare_spec_version(lo, up)
+        if got != want_breaking:
+            failures.append(f"spec {lo} -> {up}: expected breaking={want_breaking}, got {got}")
 
     # Field offsets are not vocabulary.
     if "KIND_IDX" in vocabulary_of(base):
@@ -212,8 +254,15 @@ def main():
     print()
 
     removed, changed, added = classify(local, upstream)
+    # SPEC_VERSION is a version, not vocabulary: it has its own contract.
+    changed = [k for k in changed if k != "SPEC_VERSION"]
+    spec_breaking, spec_note = compare_spec_version(
+        local.get("SPEC_VERSION", ""), upstream.get("SPEC_VERSION", ""))
 
-    breaking = False
+    breaking = spec_breaking
+    if spec_note:
+        print(("SPEC   " if spec_breaking else "SPEC   ") + spec_note)
+        print()
     if removed:
         breaking = True
         print("DRIFT  gone upstream (our references would no longer compile):")

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -278,7 +278,7 @@ def main():
         for k in added:
             print(f"         {k} = {upstream[k]!r}")
     if not (removed or changed or added):
-        print("vocabulary is in sync")
+        print("vocabulary constants are in sync")
 
     # Gaps: types upstream publishes that no renderer branches on.
     named, literal = handled_types(os.path.join(root, "src/duck_block_functions.cpp"))

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -113,7 +113,7 @@ def compare_spec_version(local, upstream):
     return False, None
 
 
-def check_vendored_conformance(root, vocab_values):
+def check_vendored_conformance(root, vocab):
     """The conformance SQL embeds the type list -- a SECOND copy of the vocabulary.
 
     Two copies checked by the same party cannot detect their own disagreement, so
@@ -126,17 +126,27 @@ def check_vendored_conformance(root, vocab_values):
     if not os.path.exists(path):
         return []
     text = open(path).read()
-    m = re.search(r"MACRO duck_block_declared_types\(\) AS \(\s*\[(.*?)\]", text, re.S)
-    if not m:
-        return [f"{CONFORMANCE_REL}: could not find the declared-types list to compare"]
-    embedded = set(re.findall(r"'([^']+)'", m.group(1)))
-    missing = sorted(vocab_values - embedded)
-    extra = sorted(embedded - vocab_values)
     problems = []
-    if missing:
-        problems.append(f"{CONFORMANCE_REL} is MISSING types the header declares: {missing}")
-    if extra:
-        problems.append(f"{CONFORMANCE_REL} lists types the header does not: {extra}")
+    # Kinds and element types are DIFFERENT AXES and are compared separately.
+    # Conflating them is not hypothetical: this check's first version compared the
+    # header's whole vocabulary against the types list alone and reported block,
+    # inline and value as missing. The file exported only one axis then, which is
+    # what made the mistake available; both are exported now.
+    for label, macro, expected in (
+        ("kinds", "duck_block_declared_kinds", vocab["kinds"]),
+        ("types", "duck_block_declared_types", vocab["types"]),
+    ):
+        m = re.search(r"MACRO " + macro + r"\(\) AS \(\s*\[(.*?)\]", text, re.S)
+        if not m:
+            problems.append(f"{CONFORMANCE_REL}: no {macro}() list to compare")
+            continue
+        embedded = set(re.findall(r"'([^']+)'", m.group(1)))
+        missing = sorted(expected - embedded)
+        extra = sorted(embedded - expected)
+        if missing:
+            problems.append(f"{CONFORMANCE_REL} is MISSING {label} the header declares: {missing}")
+        if extra:
+            problems.append(f"{CONFORMANCE_REL} lists {label} the header does not: {extra}")
     return problems
 
 
@@ -317,12 +327,11 @@ def main():
         print("vocabulary constants are in sync")
 
     # The vendored conformance SQL carries its own copy of the type list.
-    # element_types only -- KIND_* are kinds, which duck_block_declared_types()
-    # correctly does not list. Comparing the two sets whole reported block, inline
-    # and value as missing on this check's first run: a false positive from the
-    # check, not drift in the file.
-    element_types = {v for k, v in vocabulary_of(local).items() if not k.startswith("KIND_")}
-    for problem in check_vendored_conformance(root, element_types):
+    vocab_axes = {
+        "kinds": {v for k, v in vocabulary_of(local).items() if k.startswith("KIND_")},
+        "types": {v for k, v in vocabulary_of(local).items() if not k.startswith("KIND_")},
+    }
+    for problem in check_vendored_conformance(root, vocab_axes):
         breaking = True
         print("DRIFT  " + problem)
         print("       Re-vendor conformance/duck_block_conformance.sql from upstream.")

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -23,6 +23,16 @@ import urllib.request
 
 HEADER_REL = "src/include/duck_block_vocabulary.hpp"
 CONFORMANCE_REL = "conformance/duck_block_conformance.sql"
+# WATCHED, 2026-09-01. The second candidate has NEVER been taken: this repo
+# vendors, so find_local() always matches the first and returns. Unreached by
+# HISTORY rather than unreachable by construction -- nothing in the source shows
+# it, which is why a sweep for empty registries does not find this shape and only
+# looking for it does. (duck_block_utils' distinction; their sweep found their
+# one empty registry by parsing and missed the never-expired entries entirely.)
+#
+# Fired in isolation against a temp root:
+#   candidate 1 absent, candidate 2 present -> returns candidate 2
+#   neither present                         -> returns None (the exit at the end)
 LOCAL_CANDIDATES = [
     HEADER_REL,                                     # vendored (this repo)
     "third_party/duck_block_utils/" + HEADER_REL,   # submodule, if one is ever used

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -26,8 +26,42 @@ LOCAL_CANDIDATES = [
     HEADER_REL,                                     # vendored (this repo)
     "third_party/duck_block_utils/" + HEADER_REL,   # submodule, if one is ever used
 ]
-UPSTREAM_URL = ("https://raw.githubusercontent.com/teaguesterling/"
-                "duckdb_duck_block_utils/main/" + HEADER_REL)
+UPSTREAM_OWNER = "teaguesterling"
+UPSTREAM_REPO = "duckdb_duck_block_utils"
+UPSTREAM_BRANCH = "main"
+
+
+def _get(url, accept=None):
+    headers = {"Accept": accept} if accept else {}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    return urllib.request.urlopen(
+        urllib.request.Request(url, headers=headers), timeout=30).read().decode("utf-8")
+
+
+def fetch_upstream_header():
+    """Fetch the upstream header, defeating the raw-endpoint CDN cache.
+
+    raw.githubusercontent.com serves a BRANCH url from a cache that can lag the
+    branch by minutes. That produced a false "in sync" here against a copy two
+    spec versions old -- a false negative in the reassuring direction, from the
+    tool whose whole job is to catch exactly that. So resolve the branch to a
+    commit sha first and fetch the sha-pinned url, which is immutable and
+    therefore never stale. Returns (text, provenance, verified).
+    """
+    raw = "https://raw.githubusercontent.com/{}/{}/{{}}/{}".format(
+        UPSTREAM_OWNER, UPSTREAM_REPO, HEADER_REL)
+    try:
+        sha = _get("https://api.github.com/repos/{}/{}/commits/{}".format(
+            UPSTREAM_OWNER, UPSTREAM_REPO, UPSTREAM_BRANCH),
+            accept="application/vnd.github.sha").strip()
+        return _get(raw.format(sha)), "{}@{}".format(UPSTREAM_BRANCH, sha[:12]), True
+    except Exception as exc:
+        # Fall back to the branch url so an API outage or rate limit does not
+        # block work -- but never report this result as verified.
+        text = _get(raw.format(UPSTREAM_BRANCH))
+        return text, "{} (branch url; sha lookup failed: {})".format(UPSTREAM_BRANCH, exc), False
 CONST_RE = re.compile(r'static\s+constexpr\s+[\w:*\s]+?\**(\w+)\s*=\s*(?:"([^"]*)"|([0-9]+))\s*;')
 
 # Vocabulary we deliberately render through a fallthrough rather than a branch.
@@ -116,15 +150,15 @@ def read_upstream(source, ref):
     """
     if source is None:
         try:
-            with urllib.request.urlopen(UPSTREAM_URL, timeout=30) as response:
-                return response.read().decode("utf-8")
+            return fetch_upstream_header()
         except Exception as exc:
-            sys.exit(f"error: cannot fetch {UPSTREAM_URL}\n{exc}\n"
+            sys.exit(f"error: cannot fetch the upstream header\n{exc}\n"
                      f"       pass --upstream PATH to compare against a local clone instead")
     try:
-        return subprocess.check_output(
+        text = subprocess.check_output(
             ["git", "-C", source, "show", f"{ref}:{HEADER_REL}"],
             stderr=subprocess.PIPE, text=True)
+        return text, f"{source}@{ref}", True
     except subprocess.CalledProcessError as exc:
         sys.exit(f"error: cannot read {HEADER_REL} from {source}@{ref}\n{exc.stderr.strip()}")
 
@@ -165,13 +199,15 @@ def main():
             subprocess.run(["git", "-C", upstream_repo, "fetch", "--quiet", "origin"], check=False)
 
     local = parse_constants(open(local_path).read())
-    upstream = parse_constants(read_upstream(upstream_repo, args.ref))
+    upstream_text, provenance, verified = read_upstream(upstream_repo, args.ref)
+    upstream = parse_constants(upstream_text)
     if not upstream:
         sys.exit("error: parsed no constants from upstream -- has the header's shape changed?")
 
     print(f"local    {os.path.relpath(local_path, root)}  ({len(local)} constants)")
-    origin = f"{upstream_repo}@{args.ref}" if upstream_repo else UPSTREAM_URL
-    print(f"upstream {origin}  ({len(upstream)} constants)")
+    print(f"upstream {provenance}  ({len(upstream)} constants)")
+    if not verified:
+        print("WARNING  upstream copy is UNVERIFIED and may be a stale cache")
     print(f"spec     local {local.get('SPEC_VERSION','?')}  upstream {upstream.get('SPEC_VERSION','?')}")
     print()
 
@@ -210,6 +246,10 @@ def main():
     if breaking:
         print("FAILED: vocabulary drift is breaking. Update the copy and the references.")
         return 1
+    if not verified:
+        # Never claim a clean bill of health from a copy we could not date.
+        print("UNVERIFIED: no drift seen, but the upstream copy could not be pinned to a sha.")
+        return 0
     if added:
         print("OK with news: upstream added vocabulary. Review whether we should handle it.")
     else:

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -670,8 +670,12 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 	string result;
 
 	if (element_type == "frontmatter" || element_type == Vocab::TYPE_METADATA) {
-		// YAML frontmatter
-		result = "---\n" + content + "\n---\n\n";
+		// The FENCE follows the encoding: `+++` for TOML, `---` otherwise. Writing
+		// `---` around a TOML body is a worse failure than not recognising TOML at
+		// all -- the bytes then parse cleanly as the wrong format instead of
+		// failing loudly, and the round-trip silently relabels a Hugo document.
+		const string fence = (encoding == Vocab::ENCODING_TOML) ? "+++" : "---";
+		result = fence + "\n" + content + "\n" + fence + "\n\n";
 	} else if (element_type == Vocab::TYPE_HEADING) {
 		// ATX heading with level
 		// Per spec: heading_level attribute takes priority, fall back to level field

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1023,6 +1023,17 @@ static constexpr int MAX_DUCK_BLOCK_NESTING = 64;
 // RenderDuckBlocksToMarkdown (list of duck_blocks)
 //===--------------------------------------------------------------------===//
 
+static string DuckBlockElementType(const Value &block_value) {
+	if (block_value.IsNull()) {
+		return "";
+	}
+	auto &fields = StructValue::GetChildren(block_value);
+	if (fields.size() < DUCK_BLOCK_FIELD_COUNT || fields[Vocab::ELEMENT_TYPE_IDX].IsNull()) {
+		return "";
+	}
+	return fields[Vocab::ELEMENT_TYPE_IDX].ToString();
+}
+
 // Read an element's own content, for the walk. Absent is spelled two ways --
 // the builders write NULL, the Pandoc reader writes an empty string.
 static string DuckBlockContent(const Value &block_value) {
@@ -1299,6 +1310,52 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 						result += line.empty() ? ">\n" : "> " + line + "\n";
 					}
 					result += "\n";
+					last_was_inline = false;
+					i = scope_end;
+					continue;
+				}
+			}
+		}
+
+		// A figure's caption is often just the image's alt text -- markdown's own
+		// `![alt](src)` carries it, and a reader infers BOTH a figure and its
+		// caption from a lone image. Emitting the caption separately then says it
+		// twice, and re-reading that output yields the inferred caption plus a
+		// stray italic paragraph, so another copy accrues on every pass.
+		//
+		// Suppressed only when the caption IS the alt. A caption saying something
+		// the alt does not is information the image syntax cannot carry.
+		if (kind == Vocab::KIND_BLOCK && element_type == Vocab::TYPE_FIGURE && content.empty() &&
+		    depth < MAX_DUCK_BLOCK_NESTING) {
+			const idx_t scope_end = SkipElementScope(list_children, i, end);
+			const int32_t child_level = DuckBlockLevel(list_children[i]) + 1;
+			idx_t caption_begin = scope_end, caption_end = scope_end;
+			string alt;
+			for (idx_t j = i + 1; j < scope_end; j++) {
+				const string child_type = DuckBlockElementType(list_children[j]);
+				if (child_type == Vocab::TYPE_CAPTION && DuckBlockLevel(list_children[j]) == child_level &&
+				    caption_begin == scope_end) {
+					caption_begin = j;
+					caption_end = SkipElementScope(list_children, j, scope_end);
+				} else if (alt.empty() && child_type == Vocab::TYPE_IMAGE) {
+					alt = GetAttributeOf(list_children[j], "alt");
+					if (alt.empty()) {
+						alt = DuckBlockContent(list_children[j]);
+					}
+				}
+			}
+			if (caption_begin < scope_end && !alt.empty()) {
+				string caption_text =
+				    caption_end > caption_begin + 1
+				        ? RenderDuckBlockRange(list_children, caption_begin + 1, caption_end, depth + 1)
+				        : DuckBlockContent(list_children[caption_begin]);
+				StringUtil::Trim(caption_text);
+				if (caption_text == alt) {
+					if (last_was_inline) {
+						result += "\n\n";
+					}
+					result += RenderDuckBlockRange(list_children, i + 1, caption_begin, depth + 1);
+					result += RenderDuckBlockRange(list_children, caption_end, scope_end, depth + 1);
 					last_was_inline = false;
 					i = scope_end;
 					continue;

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1138,7 +1138,15 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 					}
 					for (idx_t j = i + 1; j < scope_end;) {
 						if (DuckBlockLevel(list_children[j]) != item_level) {
-							j++;
+							// Not an item -- a producer we do not recognise, or a
+							// shape from a spec we have not seen. Render it anyway
+							// rather than advancing past it: this decides whether
+							// the child EXISTS, and that must not be keyed on it
+							// matching a shape we know. Losing the list structure
+							// costs formatting; dropping it costs the text.
+							const idx_t stray_end = SkipElementScope(list_children, j, scope_end);
+							result += RenderDuckBlockRange(list_children, j, stray_end, depth + 1);
+							j = stray_end;
 							continue;
 						}
 						const idx_t item_end = SkipElementScope(list_children, j, scope_end);

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -13,6 +13,14 @@ namespace duckdb {
 
 using namespace duckdb_yyjson;
 
+// Claims in this file about ANOTHER repository's behaviour carry a date and,
+// where they came from someone else, the label RELAYED. A reason has no expiry
+// and no attribution unless it is given one: two comments here were true when
+// written and wrong within the day -- one measured and then outlived by a spec
+// change, one accurately reported and then restated without its provenance.
+// Neither was careless, so "be more careful" would not have prevented either.
+// A date and a source are actionable; a better sentence is not.
+
 // The duck_block vocabulary, consumed from duck_block_utils as a submodule.
 // Spelling these as constants rather than string literals is what makes a
 // renamed or removed element type a compile error here instead of output that
@@ -535,7 +543,8 @@ void DuckBlockFunctions::ParsePandocTable(const string &content, vector<string> 
 // vocabulary name -- "em"/"emphasis" for italic, "strong" for bold, "del" for
 // strikethrough, and so on.
 //
-// MEASURED, because this was previously described here and to other consumers
+// MEASURED 2026-08-31 against duck_block_utils spec 6.1, because this was
+// previously described here and to other consumers
 // as "legacy names this extension's own parser emits", and that is false: it
 // emits none of them. Nor does duck_block_utils, nor webbed -- webbed MAPS the
 // HTML tags `em`/`strong`/`del` onto the canonical names and carries the same
@@ -1186,7 +1195,8 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 					// owns the role='definition' items following it until the next
 					// term. One term may own several definitions, which is distinct
 					// from one definition of several blocks -- many items versus one
-					// item with children. Measured off the live producer rather than
+					// item with children. Measured 2026-08-31 off the live producer
+					// (duck_block_utils spec 6.1) rather than
 					// taken from its description.
 					if (list_type == "definition") {
 						bool first_term = true;
@@ -1336,8 +1346,9 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 		// Blocks and inlines sit on SEPARATE level scales: the spec puts a
 		// top-level inline at level 1 while a top-level block records NULL. And
 		// producers disagree about where a block's inline run begins -- the
-		// builders emit level 1 (measured here); panduck reported the same of its
-		// four readers, relayed and unverified from this side. The Pandoc path
+		// builders emit level 1 (MEASURED 2026-08-31, duck_block_utils spec 6.1);
+		// panduck reported the same of its four readers -- RELAYED 2026-08-31,
+		// never verified from this side. The Pandoc path
 		// emits 2. So a block takes the whole contiguous inline run that follows
 		// it rather than trusting the level, which is the only rule that reads
 		// both; among inlines the level IS the nesting, so a wrapper there takes

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -531,6 +531,21 @@ void DuckBlockFunctions::ParsePandocTable(const string &content, vector<string> 
 // RenderInlineElementToMarkdown (helper for inline elements)
 //===--------------------------------------------------------------------===//
 
+// Several branches below accept an HTML-flavoured alias beside the canonical
+// vocabulary name -- "em"/"emphasis" for italic, "strong" for bold, "del" for
+// strikethrough, and so on.
+//
+// MEASURED, because this was previously described here and to other consumers
+// as "legacy names this extension's own parser emits", and that is false: it
+// emits none of them. Nor does duck_block_utils, nor webbed -- webbed MAPS the
+// HTML tags `em`/`strong`/`del` onto the canonical names and carries the same
+// accepting aliases in its own writer, so two consumers hold identical
+// leniency that no observed producer exercises.
+//
+// Kept rather than deleted: accepting an alias costs nothing and removing one
+// can only break a producer nobody here has looked at. But it is defensive
+// acceptance, not compatibility with anything known, and the difference
+// matters if someone later reasons from its presence.
 string DuckBlockFunctions::RenderInlineElementToMarkdown(const string &element_type, const string &content,
                                                          const Value &attributes) {
 	if (element_type == Vocab::INLINE_LINK) {

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -697,9 +697,14 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 	} else if (element_type == Vocab::TYPE_LIST) {
 		// List - content is JSON encoded
 		if (encoding == "json" && content.length() > 2 && content[0] == '[') {
-			// Producers signal ordering with list_type; `ordered` is the legacy form.
-			bool ordered =
-			    GetAttribute(attributes, "ordered") == "true" || GetAttribute(attributes, "list_type") == "ordered";
+			// `ordered` is the CANONICAL name for orderedness (spec v1.0);
+			// `list_type` is a later alias that arrived with the Pandoc reader.
+			// Both producers now emit both, so prefer the canonical name when it
+			// is present -- checking the alias first lets it override an explicit
+			// `ordered=false`.
+			const string ordered_attr = GetAttribute(attributes, "ordered");
+			const bool ordered =
+			    !ordered_attr.empty() ? (ordered_attr == "true") : (GetAttribute(attributes, "list_type") == "ordered");
 			int start = 1;
 			string start_str = GetAttribute(attributes, "start");
 			const bool start_from_attribute = !start_str.empty();
@@ -1113,7 +1118,11 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 			if (element_type == Vocab::TYPE_LIST) {
 				const idx_t scope_end = SkipElementScope(list_children, i, end);
 				if (scope_end > i + 1) {
-					const bool ordered = GetAttributeOf(block_value, "list_type") == "ordered";
+					// Canonical `ordered` first, then the `list_type` alias.
+					const string ordered_attr = GetAttributeOf(block_value, "ordered");
+					const bool ordered = !ordered_attr.empty()
+					                         ? (ordered_attr == "true")
+					                         : (GetAttributeOf(block_value, "list_type") == "ordered");
 					const string number_style = GetAttributeOf(block_value, "number_style");
 					const string number_delim = GetAttributeOf(block_value, "number_delim");
 					int number = 1;

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -676,7 +676,7 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 		// ATX heading with level
 		// Per spec: heading_level attribute takes priority, fall back to level field
 		int32_t heading_level = 1;
-		string heading_level_attr = GetAttribute(attributes, "heading_level");
+		string heading_level_attr = GetAttribute(attributes, Vocab::ATTR_HEADING_LEVEL);
 		if (!heading_level_attr.empty()) {
 			try {
 				heading_level = std::stoi(heading_level_attr);
@@ -726,7 +726,7 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 			// -- definition and navigation lists -- that `ordered=false` can only
 			// say a list is not. Both producers emit both names, so this decides
 			// only which one wins when they disagree.
-			const string list_type = GetAttribute(attributes, "list_type");
+			const string list_type = GetAttribute(attributes, Vocab::ATTR_LIST_TYPE);
 			const bool ordered =
 			    !list_type.empty() ? (list_type == "ordered") : (GetAttribute(attributes, "ordered") == "true");
 			int start = 1;
@@ -910,7 +910,7 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 		// verbatim source fragment that would be noise in a markdown document, but
 		// dropping it silently is what `generic` exists to prevent -- so name the
 		// construct and leave a trace a reader can grep for.
-		string source_type = SanitizeForHtmlComment(GetAttribute(attributes, "source_type"));
+		string source_type = SanitizeForHtmlComment(GetAttribute(attributes, Vocab::ATTR_SOURCE_TYPE));
 		if (source_type.empty()) {
 			result = "<!-- unsupported block -->\n\n";
 		} else {
@@ -1183,7 +1183,7 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 				const idx_t scope_end = SkipElementScope(list_children, i, end);
 				if (scope_end > i + 1) {
 					// Canonical `list_type` first, then the legacy `ordered` alias.
-					const string list_type = GetAttributeOf(block_value, "list_type");
+					const string list_type = GetAttributeOf(block_value, Vocab::ATTR_LIST_TYPE);
 					const bool ordered = !list_type.empty() ? (list_type == "ordered")
 					                                        : (GetAttributeOf(block_value, "ordered") == "true");
 					const string number_style = GetAttributeOf(block_value, "number_style");
@@ -1225,7 +1225,7 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 							StringUtil::Trim(text);
 							// Anything not marked a definition is a label: an item whose
 							// role is missing reads as a term rather than disappearing.
-							if (GetAttributeOf(list_children[j], "role") == "definition") {
+							if (GetAttributeOf(list_children[j], Vocab::ATTR_ROLE) == Vocab::ROLE_DEFINITION) {
 								// ":" plus three spaces, so a continuation block lands at
 								// four. Two was not enough: a reader takes a 2-space block
 								// as a new top-level paragraph, which splits the list in
@@ -1822,7 +1822,7 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 
 					    // Get heading level: attribute takes priority, fall back to level field
 					    int32_t heading_level = 1;
-					    string heading_level_attr = GetAttribute(attributes, "heading_level");
+					    string heading_level_attr = GetAttribute(attributes, Vocab::ATTR_HEADING_LEVEL);
 					    if (!heading_level_attr.empty()) {
 						    try {
 							    heading_level = std::stoi(heading_level_attr);

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -731,8 +731,8 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 			// say a list is not. Both producers emit both names, so this decides
 			// only which one wins when they disagree.
 			const string list_type = GetAttribute(attributes, Vocab::ATTR_LIST_TYPE);
-			const bool ordered =
-			    !list_type.empty() ? (list_type == "ordered") : (GetAttribute(attributes, "ordered") == "true");
+			const bool ordered = !list_type.empty() ? (list_type == Vocab::LIST_TYPE_ORDERED)
+			                                        : (GetAttribute(attributes, Vocab::ATTR_ORDERED_LEGACY) == "true");
 			int start = 1;
 			string start_str = GetAttribute(attributes, "start");
 			const bool start_from_attribute = !start_str.empty();
@@ -817,7 +817,7 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 	} else if (element_type == Vocab::TYPE_LIST_ITEM) {
 		// List item - render with bullet prefix
 		// Check if ordered from attributes
-		bool ordered = GetAttribute(attributes, "ordered") == "true";
+		bool ordered = GetAttribute(attributes, Vocab::ATTR_ORDERED_LEGACY) == "true";
 		string item_num = GetAttribute(attributes, "item_number");
 		if (ordered && !item_num.empty()) {
 			result = item_num + ". " + content + "\n";
@@ -1206,8 +1206,9 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 				if (scope_end > i + 1) {
 					// Canonical `list_type` first, then the legacy `ordered` alias.
 					const string list_type = GetAttributeOf(block_value, Vocab::ATTR_LIST_TYPE);
-					const bool ordered = !list_type.empty() ? (list_type == "ordered")
-					                                        : (GetAttributeOf(block_value, "ordered") == "true");
+					const bool ordered = !list_type.empty()
+					                         ? (list_type == Vocab::LIST_TYPE_ORDERED)
+					                         : (GetAttributeOf(block_value, Vocab::ATTR_ORDERED_LEGACY) == "true");
 					const string number_style = GetAttributeOf(block_value, "number_style");
 					const string number_delim = GetAttributeOf(block_value, "number_delim");
 					int number = 1;
@@ -1231,7 +1232,7 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 					// item with children. Measured 2026-08-31 off the live producer
 					// (duck_block_utils spec 6.1) rather than
 					// taken from its description.
-					if (list_type == "definition") {
+					if (list_type == Vocab::LIST_TYPE_DEFINITION) {
 						bool first_term = true;
 						for (idx_t j = i + 1; j < scope_end;) {
 							if (DuckBlockLevel(list_children[j]) != item_level) {

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1160,6 +1160,52 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 					if (last_was_inline) {
 						result += "\n\n";
 					}
+
+					// A definition list is a `list` whose items are terms and
+					// definitions as SIBLINGS at one level, paired by order: a term
+					// owns the role='definition' items following it until the next
+					// term. One term may own several definitions, which is distinct
+					// from one definition of several blocks -- many items versus one
+					// item with children. Measured off the live producer rather than
+					// taken from its description.
+					if (list_type == "definition") {
+						bool first_term = true;
+						for (idx_t j = i + 1; j < scope_end;) {
+							if (DuckBlockLevel(list_children[j]) != item_level) {
+								const idx_t stray_end = SkipElementScope(list_children, j, scope_end);
+								result += RenderDuckBlockRange(list_children, j, stray_end, depth + 1);
+								j = stray_end;
+								continue;
+							}
+							const idx_t item_end = SkipElementScope(list_children, j, scope_end);
+							string text = item_end > j + 1
+							                  ? RenderDuckBlockRange(list_children, j + 1, item_end, depth + 1)
+							                  : DuckBlockContent(list_children[j]);
+							StringUtil::Trim(text);
+							// Anything not marked a definition is a label: an item whose
+							// role is missing reads as a term rather than disappearing.
+							if (GetAttributeOf(list_children[j], "role") == "definition") {
+								// ":" plus three spaces, so a continuation block lands at
+								// four. Two was not enough: a reader takes a 2-space block
+								// as a new top-level paragraph, which splits the list in
+								// half and strands the block between the pieces. This is
+								// also Pandoc's own output width, so marker and pad agree.
+								result += IndentContinuation(text, ":   ");
+							} else {
+								if (!first_term) {
+									result += "\n";
+								}
+								result += text + "\n";
+								first_term = false;
+							}
+							j = item_end;
+						}
+						result += "\n";
+						last_was_inline = false;
+						i = scope_end;
+						continue;
+					}
+
 					for (idx_t j = i + 1; j < scope_end;) {
 						if (DuckBlockLevel(list_children[j]) != item_level) {
 							// Not an item -- a producer we do not recognise, or a

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -697,14 +697,14 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 	} else if (element_type == Vocab::TYPE_LIST) {
 		// List - content is JSON encoded
 		if (encoding == "json" && content.length() > 2 && content[0] == '[') {
-			// `ordered` is the CANONICAL name for orderedness (spec v1.0);
-			// `list_type` is a later alias that arrived with the Pandoc reader.
-			// Both producers now emit both, so prefer the canonical name when it
-			// is present -- checking the alias first lets it override an explicit
-			// `ordered=false`.
-			const string ordered_attr = GetAttribute(attributes, "ordered");
+			// `list_type` is CANONICAL for orderedness; `ordered` is a legacy
+			// alias. A boolean cannot grow, and the type set already wants values
+			// -- definition and navigation lists -- that `ordered=false` can only
+			// say a list is not. Both producers emit both names, so this decides
+			// only which one wins when they disagree.
+			const string list_type = GetAttribute(attributes, "list_type");
 			const bool ordered =
-			    !ordered_attr.empty() ? (ordered_attr == "true") : (GetAttribute(attributes, "list_type") == "ordered");
+			    !list_type.empty() ? (list_type == "ordered") : (GetAttribute(attributes, "ordered") == "true");
 			int start = 1;
 			string start_str = GetAttribute(attributes, "start");
 			const bool start_from_attribute = !start_str.empty();
@@ -1118,11 +1118,10 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 			if (element_type == Vocab::TYPE_LIST) {
 				const idx_t scope_end = SkipElementScope(list_children, i, end);
 				if (scope_end > i + 1) {
-					// Canonical `ordered` first, then the `list_type` alias.
-					const string ordered_attr = GetAttributeOf(block_value, "ordered");
-					const bool ordered = !ordered_attr.empty()
-					                         ? (ordered_attr == "true")
-					                         : (GetAttributeOf(block_value, "list_type") == "ordered");
+					// Canonical `list_type` first, then the legacy `ordered` alias.
+					const string list_type = GetAttributeOf(block_value, "list_type");
+					const bool ordered = !list_type.empty() ? (list_type == "ordered")
+					                                        : (GetAttributeOf(block_value, "ordered") == "true");
 					const string number_style = GetAttributeOf(block_value, "number_style");
 					const string number_delim = GetAttributeOf(block_value, "number_delim");
 					int number = 1;

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1575,11 +1575,22 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 			    string current_title;
 			    int32_t current_level = 0;
 			    string current_section_id;
-			    string current_content;
 			    vector<string> section_path_parts;
 
-			    auto flush_section = [&]() {
-				    if (!current_title.empty() || !current_content.empty()) {
+			    // Render a section's content through the SHARED range renderer rather
+			    // than element by element. The two walks over a block list have to
+			    // agree about how structure renders, and every structural rule --
+			    // list items, blockquote nesting, caption emphasis, a block's inline
+			    // children -- lives in that renderer. Walking elements individually
+			    // here produced a bullet with no text followed by loose prose, while
+			    // duck_blocks_to_md produced "- LISTWORD" from the same input.
+			    idx_t content_begin = 0;
+			    auto render_range = [&](idx_t begin, idx_t end) -> string {
+				    return end > begin ? RenderDuckBlockRange(list_children, begin, end, 0) : string();
+			    };
+
+			    auto flush_section = [&](const string &body) {
+				    if (!current_title.empty() || !body.empty()) {
 					    // Build section path
 					    string section_path;
 					    for (size_t i = 0; i < section_path_parts.size(); i++) {
@@ -1593,7 +1604,7 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 					    section_values.push_back(std::make_pair("section_path", Value(section_path)));
 					    section_values.push_back(std::make_pair("level", Value::INTEGER(current_level)));
 					    section_values.push_back(std::make_pair("title", Value(current_title)));
-					    section_values.push_back(std::make_pair("content", Value(current_content)));
+					    section_values.push_back(std::make_pair("content", Value(body)));
 
 					    sections.push_back(Value::STRUCT(section_values));
 				    }
@@ -1637,7 +1648,7 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 
 				    if (element_type == Vocab::TYPE_HEADING) {
 					    // Flush previous section
-					    flush_section();
+					    flush_section(render_range(content_begin, i));
 
 					    // Get heading level: attribute takes priority, fall back to level field
 					    int32_t heading_level = 1;
@@ -1674,27 +1685,24 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 						    current_section_id = StringUtil::Lower(content);
 						    std::replace(current_section_id.begin(), current_section_id.end(), ' ', '-');
 					    }
-					    current_content.clear();
+					    content_begin = i + 1;
 				    } else if (element_type == Vocab::TYPE_METADATA || element_type == "frontmatter") {
 					    // Metadata becomes level 0 section
-					    flush_section();
+					    flush_section(render_range(content_begin, i));
 					    current_title = "";
 					    current_level = 0;
 					    current_section_id = "frontmatter";
-					    current_content = content;
-					    flush_section();
+					    flush_section(content);
 					    current_title.clear();
-					    current_content.clear();
-				    } else {
-					    // Append rendered content to current section
-					    current_content +=
-					        RenderDuckBlockToMarkdown(kind, element_type, content, level, encoding, attributes);
+					    content_begin = i + 1;
 				    }
+				    // Anything else is section content, rendered as a range when the
+				    // section is flushed rather than one element at a time.
 				    i++;
 			    }
 
 			    // Flush final section
-			    flush_section();
+			    flush_section(render_range(content_begin, list_children.size()));
 
 			    result.SetValue(row_idx, Value::LIST(LogicalType::STRUCT(child_list_t<LogicalType> {
 			                                             {"section_id", LogicalType::VARCHAR},

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1336,7 +1336,8 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 		// Blocks and inlines sit on SEPARATE level scales: the spec puts a
 		// top-level inline at level 1 while a top-level block records NULL. And
 		// producers disagree about where a block's inline run begins -- the
-		// builders and all four panduck readers emit level 1, the Pandoc path
+		// builders emit level 1 (measured here); panduck reported the same of its
+		// four readers, relayed and unverified from this side. The Pandoc path
 		// emits 2. So a block takes the whole contiguous inline run that follows
 		// it rather than trusting the level, which is the only rule that reads
 		// both; among inlines the level IS the nesting, so a wrapper there takes

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -983,6 +983,19 @@ static constexpr int MAX_DUCK_BLOCK_NESTING = 64;
 // RenderDuckBlocksToMarkdown (list of duck_blocks)
 //===--------------------------------------------------------------------===//
 
+// Read an element's own content, for the walk. Absent is spelled two ways --
+// the builders write NULL, the Pandoc reader writes an empty string.
+static string DuckBlockContent(const Value &block_value) {
+	if (block_value.IsNull()) {
+		return "";
+	}
+	auto &fields = StructValue::GetChildren(block_value);
+	if (fields.size() < DUCK_BLOCK_FIELD_COUNT || fields[Vocab::CONTENT_IDX].IsNull()) {
+		return "";
+	}
+	return fields[Vocab::CONTENT_IDX].ToString();
+}
+
 // Read an attribute straight off a duck_block Value, for the walk, which has the
 // element rather than its already-extracted attributes map.
 static string GetAttributeOf(const Value &block_value, const string &key) {
@@ -1150,7 +1163,13 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 							continue;
 						}
 						const idx_t item_end = SkipElementScope(list_children, j, scope_end);
-						string inner = RenderDuckBlockRange(list_children, j + 1, item_end, depth + 1);
+						// An item's children are its content when it has any; its own
+						// content is its content when it does not. Rendering only the
+						// child scope dropped the text of every item that carried it
+						// directly, which is the shape the live producer emits.
+						string inner = item_end > j + 1
+						                   ? RenderDuckBlockRange(list_children, j + 1, item_end, depth + 1)
+						                   : DuckBlockContent(list_children[j]);
 						StringUtil::Trim(inner);
 						const string marker = ordered ? FormatListMarker(number++, number_style, number_delim) : "- ";
 						result += IndentContinuation(inner, marker);

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -839,7 +839,12 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 		string line;
 		vector<string> lines;
 		while (std::getline(iss, line)) {
-			if (!line.empty() && line.back() == '\r') {
+			// Trailing whitespace is stripped before the break is re-added: a rich
+			// line block arrives as a rendered inline run whose `linebreak`
+			// children have ALREADY emitted "  \n", and joining that again gave
+			// four trailing spaces. A plain-text one has none to strip, so it is
+			// unaffected.
+			while (!line.empty() && (line.back() == '\r' || line.back() == ' ' || line.back() == '\t')) {
 				line.pop_back();
 			}
 			lines.push_back(line);

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -6,11 +6,18 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "yyjson.hpp"
+#include "duck_block_vocabulary.hpp"
 #include <sstream>
 
 namespace duckdb {
 
 using namespace duckdb_yyjson;
+
+// The duck_block vocabulary, consumed from duck_block_utils as a submodule.
+// Spelling these as constants rather than string literals is what makes a
+// renamed or removed element type a compile error here instead of output that
+// silently stops matching.
+using Vocab = DuckBlockVocabulary;
 
 // Maximum Pandoc inline-nesting depth walked by ExtractPandocText. Guards
 // against unbounded recursion (stack overflow) on adversarially nested JSON.
@@ -197,6 +204,136 @@ static string ExtractPandocTextFromVal(yyjson_val *val, int depth) {
 		}
 	}
 	return "";
+}
+
+// Pandoc list JSON. BulletList is [[block,...], ...]; OrderedList wraps the same
+// item array in [[start, style, delim], [...]]. Neither is the ["a", "b"] shape
+// ParseJsonListItems reads, so a real producer's list parsed to nothing and the
+// items were dropped without a trace. Sets `start` only for the ordered form,
+// so an explicit start attribute keeps precedence for the legacy shape.
+static bool ParsePandocListItems(const string &content, vector<string> &items, int &start, bool start_from_attribute) {
+	if (content.empty()) {
+		return false;
+	}
+	yyjson_doc *doc = yyjson_read(content.c_str(), content.size(), 0);
+	if (!doc) {
+		return false;
+	}
+	yyjson_val *root = yyjson_doc_get_root(doc);
+	yyjson_val *item_array = root;
+	if (yyjson_is_arr(root) && yyjson_arr_size(root) == 2) {
+		yyjson_val *first = yyjson_arr_get(root, 0);
+		yyjson_val *second = yyjson_arr_get(root, 1);
+		// The ordered form is distinguishable because its leading triple starts
+		// with the list's first number; a bullet list's first item is an array of
+		// block objects.
+		if (yyjson_is_arr(first) && yyjson_arr_size(first) == 3 && yyjson_is_int(yyjson_arr_get(first, 0)) &&
+		    yyjson_is_arr(second)) {
+			if (!start_from_attribute) {
+				start = static_cast<int>(yyjson_get_int(yyjson_arr_get(first, 0)));
+			}
+			item_array = second;
+		}
+	}
+	if (yyjson_is_arr(item_array)) {
+		size_t idx, max;
+		yyjson_val *item;
+		yyjson_arr_foreach(item_array, idx, max, item) {
+			string text = ExtractPandocTextFromVal(item, 0);
+			if (!text.empty()) {
+				items.push_back(std::move(text));
+			}
+		}
+	}
+	yyjson_doc_free(doc);
+	return !items.empty();
+}
+
+// Flatten a Pandoc block array to text, keeping paragraph breaks between the
+// top-level blocks. Returns "" when the content is not a Pandoc block array, so
+// callers can fall back rather than replace real content with nothing.
+static string ExtractPandocBlocksText(const string &content) {
+	if (content.empty()) {
+		return "";
+	}
+	yyjson_doc *doc = yyjson_read(content.c_str(), content.size(), 0);
+	if (!doc) {
+		return "";
+	}
+	string result;
+	yyjson_val *root = yyjson_doc_get_root(doc);
+	if (yyjson_is_arr(root)) {
+		size_t idx, max;
+		yyjson_val *block;
+		yyjson_arr_foreach(root, idx, max, block) {
+			string text = ExtractPandocTextFromVal(block, 0);
+			if (text.empty()) {
+				continue;
+			}
+			if (!result.empty()) {
+				result += "\n\n";
+			}
+			result += text;
+		}
+	}
+	yyjson_doc_free(doc);
+	return result;
+}
+
+// Pandoc DefinitionList JSON: [ [ [term inlines], [ [def blocks], ... ] ], ... ].
+// Definitions are lists of blocks; ExtractPandocTextFromVal already flattens Para
+// and Plain, so a multi-block definition concatenates rather than being lost.
+static bool ParseDefinitionList(const string &content, vector<std::pair<string, vector<string>>> &entries) {
+	if (content.empty()) {
+		return false;
+	}
+	yyjson_doc *doc = yyjson_read(content.c_str(), content.size(), 0);
+	if (!doc) {
+		return false;
+	}
+	yyjson_val *root = yyjson_doc_get_root(doc);
+	if (yyjson_is_arr(root)) {
+		size_t idx, max;
+		yyjson_val *entry;
+		yyjson_arr_foreach(root, idx, max, entry) {
+			if (!yyjson_is_arr(entry) || yyjson_arr_size(entry) < 2) {
+				continue;
+			}
+			string term = ExtractPandocTextFromVal(yyjson_arr_get(entry, 0), 0);
+			vector<string> definitions;
+			yyjson_val *def_list = yyjson_arr_get(entry, 1);
+			if (yyjson_is_arr(def_list)) {
+				size_t d_idx, d_max;
+				yyjson_val *def;
+				yyjson_arr_foreach(def_list, d_idx, d_max, def) {
+					string text = ExtractPandocTextFromVal(def, 0);
+					if (!text.empty()) {
+						definitions.push_back(std::move(text));
+					}
+				}
+			}
+			entries.emplace_back(std::move(term), std::move(definitions));
+		}
+	}
+	yyjson_doc_free(doc);
+	return !entries.empty();
+}
+
+// Make a string safe to sit inside an HTML comment: "--" terminates one early, so
+// a source_type from an untrusted document must not be able to close it.
+static string SanitizeForHtmlComment(const string &text) {
+	string safe;
+	safe.reserve(text.size());
+	for (char c : text) {
+		if (c == '\n' || c == '\r') {
+			safe += ' ';
+		} else if (c == '-' && !safe.empty() && safe.back() == '-') {
+			continue;
+		} else {
+			safe += c;
+		}
+	}
+	return safe;
 }
 
 string DuckBlockFunctions::ExtractPandocText(const string &content, int depth) {
@@ -396,7 +533,7 @@ void DuckBlockFunctions::ParsePandocTable(const string &content, vector<string> 
 
 string DuckBlockFunctions::RenderInlineElementToMarkdown(const string &element_type, const string &content,
                                                          const Value &attributes) {
-	if (element_type == "link") {
+	if (element_type == Vocab::INLINE_LINK) {
 		// [text](href "title")
 		string href = GetAttribute(attributes, "href");
 		string title = GetAttribute(attributes, "title");
@@ -406,7 +543,7 @@ string DuckBlockFunctions::RenderInlineElementToMarkdown(const string &element_t
 		}
 		result += ")";
 		return result;
-	} else if (element_type == "image") {
+	} else if (element_type == Vocab::INLINE_IMAGE) {
 		// ![alt](src "title")
 		string src = GetAttribute(attributes, "src");
 		string title = GetAttribute(attributes, "title");
@@ -416,75 +553,82 @@ string DuckBlockFunctions::RenderInlineElementToMarkdown(const string &element_t
 		}
 		result += ")";
 		return result;
-	} else if (element_type == "bold" || element_type == "strong") {
+	} else if (element_type == Vocab::INLINE_BOLD || element_type == "strong") {
 		// **text**
 		return "**" + content + "**";
-	} else if (element_type == "italic" || element_type == "emphasis" || element_type == "em") {
+	} else if (element_type == Vocab::INLINE_ITALIC || element_type == "emphasis" || element_type == "em") {
 		// *text*
 		return "*" + content + "*";
-	} else if (element_type == "code") {
+	} else if (element_type == Vocab::INLINE_CODE) {
 		// `text` - inline code
 		// Handle content containing backticks
 		if (content.find('`') != string::npos) {
 			return "`` " + content + " ``";
 		}
 		return "`" + content + "`";
-	} else if (element_type == "text") {
+	} else if (element_type == Vocab::INLINE_TEXT) {
 		// Plain text
 		return content;
-	} else if (element_type == "space") {
+	} else if (element_type == Vocab::INLINE_SPACE) {
 		// Word separator
 		return " ";
-	} else if (element_type == "softbreak") {
+	} else if (element_type == Vocab::INLINE_SOFTBREAK) {
 		// Soft line break
 		return "\n";
-	} else if (element_type == "linebreak" || element_type == "br") {
+	} else if (element_type == Vocab::INLINE_LINEBREAK || element_type == "br") {
 		// Hard line break
 		return "  \n";
-	} else if (element_type == "strikethrough" || element_type == "del") {
+	} else if (element_type == Vocab::INLINE_STRIKETHROUGH || element_type == "del") {
 		// ~~text~~
 		return "~~" + content + "~~";
-	} else if (element_type == "superscript" || element_type == "sup") {
+	} else if (element_type == Vocab::INLINE_SUPERSCRIPT || element_type == "sup") {
 		// ^text^
 		return "^" + content + "^";
-	} else if (element_type == "subscript" || element_type == "sub") {
+	} else if (element_type == Vocab::INLINE_SUBSCRIPT || element_type == "sub") {
 		// ~text~
 		return "~" + content + "~";
-	} else if (element_type == "underline") {
+	} else if (element_type == Vocab::INLINE_UNDERLINE) {
 		// <u>text</u> (no standard markdown, use HTML)
 		return "<u>" + content + "</u>";
-	} else if (element_type == "smallcaps") {
+	} else if (element_type == Vocab::INLINE_SMALLCAPS) {
 		// No standard markdown for small caps, use span with style
 		return "<span style=\"font-variant: small-caps\">" + content + "</span>";
-	} else if (element_type == "math") {
+	} else if (element_type == Vocab::INLINE_MATH) {
 		// $text$ for inline, $$text$$ for display
 		string display = GetAttribute(attributes, "display");
 		if (display == "block") {
 			return "$$" + content + "$$";
 		}
 		return "$" + content + "$";
-	} else if (element_type == "raw") {
+	} else if (element_type == Vocab::INLINE_RAW) {
 		// Raw content as-is
 		return content;
-	} else if (element_type == "quoted") {
+	} else if (element_type == Vocab::INLINE_QUOTED) {
 		// Quoted text
 		string quote_type = GetAttribute(attributes, "quote_type");
 		if (quote_type == "single") {
 			return "'" + content + "'";
 		}
 		return "\"" + content + "\"";
-	} else if (element_type == "cite") {
+	} else if (element_type == Vocab::INLINE_CITE) {
 		// Citation [@key]
 		string key = GetAttribute(attributes, "key");
 		if (!key.empty()) {
 			return "[@" + key + "]";
 		}
 		return content;
-	} else if (element_type == "note") {
+	} else if (element_type == Vocab::INLINE_NOTE) {
 		// Footnote [^note]
 		return "[^" + content + "]";
-	} else if (element_type == "span") {
+	} else if (element_type == Vocab::INLINE_SPAN) {
 		// Generic span - just output content
+		return content;
+	} else if (element_type == Vocab::INLINE_GENERIC) {
+		// The inline backstop for a construct outside this vocabulary. Unlike its
+		// block counterpart it carries no content of its own -- the text is in its
+		// children, which reach us as `content` -- so passing it through loses only
+		// the wrapper identity, not the words. A comment would interrupt the prose
+		// it sits inside, so this is deliberately quieter than the block case.
 		return content;
 	} else {
 		// Unknown inline type - output as plain text
@@ -501,10 +645,10 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
                                                         const Value &attributes) {
 	string result;
 
-	if (element_type == "frontmatter" || element_type == "metadata") {
+	if (element_type == "frontmatter" || element_type == Vocab::TYPE_METADATA) {
 		// YAML frontmatter
 		result = "---\n" + content + "\n---\n\n";
-	} else if (element_type == "heading") {
+	} else if (element_type == Vocab::TYPE_HEADING) {
 		// ATX heading with level
 		// Per spec: heading_level attribute takes priority, fall back to level field
 		int32_t heading_level = 1;
@@ -524,29 +668,42 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 		if (heading_level > 6)
 			heading_level = 6;
 		result = string(heading_level, '#') + " " + content + "\n\n";
-	} else if (element_type == "paragraph") {
+	} else if (element_type == Vocab::TYPE_PARAGRAPH) {
 		// Plain paragraph
 		result = content + "\n\n";
-	} else if (element_type == "code") {
+	} else if (element_type == Vocab::TYPE_CODE) {
 		// Fenced code block
 		string language = GetAttribute(attributes, "language");
 		result = "```" + language + "\n" + content + "\n```\n\n";
-	} else if (element_type == "blockquote") {
-		// Block quote - add > prefix to each line
+	} else if (element_type == Vocab::TYPE_BLOCKQUOTE) {
+		// Block quote - add > prefix to each line.
+		// Producers emit the quote's blocks as a Pandoc array rather than as text
+		// (the released duck_block_utils and its main both do), and prefixing that
+		// verbatim put raw AST into the document behind a '>'.
+		string source = content;
+		if (encoding == Vocab::ENCODING_JSON) {
+			string extracted = ExtractPandocBlocksText(content);
+			if (!extracted.empty()) {
+				source = extracted;
+			}
+		}
 		string quoted;
-		std::istringstream iss(content);
+		std::istringstream iss(source);
 		std::string line;
 		while (std::getline(iss, line)) {
 			quoted += "> " + line + "\n";
 		}
 		result = quoted + "\n";
-	} else if (element_type == "list") {
+	} else if (element_type == Vocab::TYPE_LIST) {
 		// List - content is JSON encoded
 		if (encoding == "json" && content.length() > 2 && content[0] == '[') {
-			bool ordered = GetAttribute(attributes, "ordered") == "true";
+			// Producers signal ordering with list_type; `ordered` is the legacy form.
+			bool ordered =
+			    GetAttribute(attributes, "ordered") == "true" || GetAttribute(attributes, "list_type") == "ordered";
 			int start = 1;
 			string start_str = GetAttribute(attributes, "start");
-			if (!start_str.empty()) {
+			const bool start_from_attribute = !start_str.empty();
+			if (start_from_attribute) {
 				try {
 					start = std::stoi(start_str);
 				} catch (...) {
@@ -554,6 +711,9 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 			}
 
 			auto items = ParseJsonListItems(content);
+			if (items.empty()) {
+				ParsePandocListItems(content, items, start, start_from_attribute);
+			}
 			int item_num = start;
 			for (const auto &item : items) {
 				if (ordered) {
@@ -566,7 +726,7 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 		} else {
 			result = content + "\n\n";
 		}
-	} else if (element_type == "table") {
+	} else if (element_type == Vocab::TYPE_TABLE) {
 		// Table - content is JSON encoded
 		vector<string> headers;
 		vector<vector<string>> rows;
@@ -619,9 +779,9 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 		} else {
 			result = content + "\n\n";
 		}
-	} else if (element_type == "hr") {
+	} else if (element_type == Vocab::TYPE_HR) {
 		result = "---\n\n";
-	} else if (element_type == "list_item") {
+	} else if (element_type == Vocab::TYPE_LIST_ITEM) {
 		// List item - render with bullet prefix
 		// Check if ordered from attributes
 		bool ordered = GetAttribute(attributes, "ordered") == "true";
@@ -631,7 +791,7 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 		} else {
 			result = "- " + content + "\n";
 		}
-	} else if (element_type == "image") {
+	} else if (element_type == Vocab::TYPE_IMAGE) {
 		// Image: ![alt](src "title")
 		string src = GetAttribute(attributes, "src");
 		string alt = GetAttribute(attributes, "alt");
@@ -645,9 +805,72 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 			result += " \"" + title + "\"";
 		}
 		result += ")\n\n";
-	} else if (element_type == "raw" || element_type == "html" || element_type == "md:html_block") {
+	} else if (element_type == Vocab::TYPE_RAW || element_type == "html" || element_type == "md:html_block") {
 		// Raw content - output as-is
 		result = content + "\n\n";
+	} else if (element_type == Vocab::TYPE_DIV || element_type == Vocab::TYPE_SECTION ||
+	           element_type == Vocab::TYPE_FIGURE || element_type == Vocab::TYPE_CAPTION) {
+		// Containers carry no content of their own; their children follow at level+1
+		// and render themselves. Emitting the (empty) content here produced stray
+		// blank lines. `caption` additionally gets decorated by the list renderer,
+		// which is the only place with access to the children it scopes.
+		result = "";
+	} else if (element_type == Vocab::TYPE_LINEBLOCK) {
+		// Preserved line breaks. Markdown has no line-block syntax, and a bare
+		// newline inside a paragraph is a soft break that collapses to a space --
+		// so terminate each line with a hard break instead.
+		std::istringstream iss(content);
+		string line;
+		vector<string> lines;
+		while (std::getline(iss, line)) {
+			if (!line.empty() && line.back() == '\r') {
+				line.pop_back();
+			}
+			lines.push_back(line);
+		}
+		for (size_t i = 0; i < lines.size(); i++) {
+			result += lines[i];
+			if (i + 1 < lines.size()) {
+				result += "  \n";
+			}
+		}
+		result += "\n\n";
+	} else if (element_type == Vocab::TYPE_DEFLIST) {
+		// Definition list (Markdown Extra / Pandoc syntax)
+		vector<std::pair<string, vector<string>>> entries;
+		if (ParseDefinitionList(content, entries)) {
+			for (const auto &entry : entries) {
+				result += entry.first + "\n";
+				for (const auto &definition : entry.second) {
+					result += ": " + definition + "\n";
+				}
+				result += "\n";
+			}
+		} else {
+			result = content + "\n\n";
+		}
+	} else if (element_type == Vocab::TYPE_PAGE) {
+		// A physical pagination boundary, carrying no content. Markdown has no
+		// page-break syntax, and a `---` here would read as a thematic break (or,
+		// at the top of a document, as frontmatter delimiters), so leave the same
+		// kind of greppable trace `generic` does rather than lose the boundary.
+		string page_number = SanitizeForHtmlComment(GetAttribute(attributes, "page_number"));
+		if (page_number.empty()) {
+			result = "<!-- page break -->\n\n";
+		} else {
+			result = "<!-- page break: " + page_number + " -->\n\n";
+		}
+	} else if (element_type == Vocab::TYPE_GENERIC) {
+		// "Structurally valid, type not in this vocabulary." The content is a
+		// verbatim source fragment that would be noise in a markdown document, but
+		// dropping it silently is what `generic` exists to prevent -- so name the
+		// construct and leave a trace a reader can grep for.
+		string source_type = SanitizeForHtmlComment(GetAttribute(attributes, "source_type"));
+		if (source_type.empty()) {
+			result = "<!-- unsupported block -->\n\n";
+		} else {
+			result = "<!-- unsupported block: " + source_type + " -->\n\n";
+		}
 	} else {
 		// Unknown block type - output content as paragraph
 		result = content + "\n\n";
@@ -663,18 +886,20 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 string DuckBlockFunctions::RenderDuckBlockToMarkdown(const string &kind, const string &element_type,
                                                      const string &content, int32_t level, const string &encoding,
                                                      const Value &attributes) {
-	if (kind == "block") {
+	if (kind == Vocab::KIND_BLOCK) {
 		// Delegate to block rendering
 		return RenderBlockElementToMarkdown(element_type, content, level, encoding, attributes);
-	} else if (kind == "inline") {
+	} else if (kind == Vocab::KIND_INLINE) {
 		// Use inline rendering
 		return RenderInlineElementToMarkdown(element_type, content, attributes);
 	} else {
 		// Unknown kind - try to guess based on element_type
 		// Block types
-		if (element_type == "heading" || element_type == "paragraph" || element_type == "blockquote" ||
-		    element_type == "list" || element_type == "table" || element_type == "hr" || element_type == "metadata" ||
-		    element_type == "frontmatter" || element_type == "code" || element_type == "image") {
+		if (element_type == Vocab::TYPE_HEADING || element_type == Vocab::TYPE_PARAGRAPH ||
+		    element_type == Vocab::TYPE_BLOCKQUOTE || element_type == Vocab::TYPE_LIST ||
+		    element_type == Vocab::TYPE_TABLE || element_type == Vocab::TYPE_HR ||
+		    element_type == Vocab::TYPE_METADATA || element_type == "frontmatter" || element_type == Vocab::TYPE_CODE ||
+		    element_type == Vocab::TYPE_IMAGE) {
 			return RenderBlockElementToMarkdown(element_type, content, level, encoding, attributes);
 		}
 		// Assume inline otherwise
@@ -683,47 +908,513 @@ string DuckBlockFunctions::RenderDuckBlockToMarkdown(const string &kind, const s
 }
 
 //===--------------------------------------------------------------------===//
+// Kind filtering (duck_block `kind` is an open discriminator)
+//===--------------------------------------------------------------------===//
+
+// The seven core duck_block fields. Two optional trailing fields (source_format,
+// file_path) may follow, so this is a minimum, not an exact width.
+static constexpr idx_t DUCK_BLOCK_FIELD_COUNT = Vocab::ELEMENT_ORDER_IDX + 1;
+
+static string DuckBlockKind(const Value &block_value) {
+	if (block_value.IsNull()) {
+		return "";
+	}
+	auto &fields = StructValue::GetChildren(block_value);
+	if (fields.size() < DUCK_BLOCK_FIELD_COUNT || fields[Vocab::KIND_IDX].IsNull()) {
+		return "";
+	}
+	return fields[Vocab::KIND_IDX].ToString();
+}
+
+// `level` is structural nesting DEPTH, so a top-level element has depth 1 and
+// records NULL because it is not nested. Reading NULL as 0 also makes a scope
+// walk work, but it puts a top-level element one level shallower than its
+// siblings that do carry a level, so an element at level 1 next to one at NULL
+// reads as its child rather than its sibling.
+static constexpr int32_t DUCK_BLOCK_TOP_LEVEL = 1;
+
+static int32_t DuckBlockLevel(const Value &block_value) {
+	if (block_value.IsNull()) {
+		return DUCK_BLOCK_TOP_LEVEL;
+	}
+	auto &fields = StructValue::GetChildren(block_value);
+	if (fields.size() < DUCK_BLOCK_FIELD_COUNT || fields[Vocab::LEVEL_IDX].IsNull()) {
+		return DUCK_BLOCK_TOP_LEVEL;
+	}
+	return fields[Vocab::LEVEL_IDX].GetValue<int32_t>();
+}
+
+// `kind` gained a third value ('value', carrying document metadata) after this
+// writer was written, and more may follow. Allowlist what we know how to render:
+// a blocklist ("not inline, so it must be a block") turns every future kind into
+// body prose, which is how document titles ended up appended to documents.
+// An empty kind is legacy data and keeps its element_type-based guess.
+static bool IsRenderableKind(const string &kind) {
+	return kind.empty() || kind == Vocab::KIND_BLOCK || kind == Vocab::KIND_INLINE;
+}
+
+// A non-renderable element's children must go with it. Metadata nests by level
+// exactly as block containers do -- the scope runs from the marker to the first
+// element back at its own level -- and those children are ordinary kinds:
+// MetaInlines carries kind='inline' children, MetaBlocks carries kind='block'
+// ones. Skipping only the marker leaves them to render as stray prose.
+// Returns the index just past the scope opened at `marker_index`, never past `end`.
+static idx_t SkipElementScope(const vector<Value> &children, idx_t marker_index, idx_t end) {
+	const int32_t scope_level = DuckBlockLevel(children[marker_index]);
+	idx_t i = marker_index + 1;
+	while (i < end && DuckBlockLevel(children[i]) > scope_level) {
+		i++;
+	}
+	return i;
+}
+
+// Caption scopes are rendered by recursing into the range they open. Each level
+// consumes at least one element, so depth is bounded by the list length -- which
+// an adversarial document controls. Past this depth a caption is treated as a
+// plain container: its children still render, just without the emphasis.
+static constexpr int MAX_DUCK_BLOCK_NESTING = 64;
+
+//===--------------------------------------------------------------------===//
 // RenderDuckBlocksToMarkdown (list of duck_blocks)
 //===--------------------------------------------------------------------===//
 
-string DuckBlockFunctions::RenderDuckBlocksToMarkdown(const Value &blocks_value) {
-	if (blocks_value.IsNull() || blocks_value.type().id() != LogicalTypeId::LIST) {
+// Read an attribute straight off a duck_block Value, for the walk, which has the
+// element rather than its already-extracted attributes map.
+static string GetAttributeOf(const Value &block_value, const string &key) {
+	if (block_value.IsNull()) {
 		return "";
 	}
+	auto &fields = StructValue::GetChildren(block_value);
+	if (fields.size() < DUCK_BLOCK_FIELD_COUNT) {
+		return "";
+	}
+	return DuckBlockFunctions::GetAttribute(fields[Vocab::ATTRIBUTES_IDX], key);
+}
 
-	auto &list_children = ListValue::GetChildren(blocks_value);
+// Ordered-list markers. Pandoc carries the style and delimiter separately from
+// the number, so a list starting at iii) round-trips as iii) rather than 3.
+static string RomanNumeral(int n, bool upper) {
+	static const int values[] = {1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1};
+	static const char *lower[] = {"m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i"};
+	static const char *upper_s[] = {"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};
+	string out;
+	for (size_t i = 0; i < 13 && n > 0; i++) {
+		while (n >= values[i]) {
+			out += upper ? upper_s[i] : lower[i];
+			n -= values[i];
+		}
+	}
+	return out;
+}
+
+static string AlphaNumeral(int n, bool upper) {
+	string out;
+	while (n > 0) {
+		const int rem = (n - 1) % 26;
+		out.insert(out.begin(), static_cast<char>((upper ? 'A' : 'a') + rem));
+		n = (n - 1) / 26;
+	}
+	return out;
+}
+
+static string FormatListMarker(int number, const string &style, const string &delim) {
+	string text;
+	if (number < 1) {
+		number = 1;
+	}
+	if (style == "LowerRoman") {
+		text = RomanNumeral(number, false);
+	} else if (style == "UpperRoman") {
+		text = RomanNumeral(number, true);
+	} else if (style == "LowerAlpha") {
+		text = AlphaNumeral(number, false);
+	} else if (style == "UpperAlpha") {
+		text = AlphaNumeral(number, true);
+	} else {
+		// Decimal, Example, DefaultStyle, and anything this build does not know.
+		text = std::to_string(number);
+	}
+	return text + ((delim == "OneParen" || delim == "TwoParens") ? ")" : ".") + " ";
+}
+
+// Prefix the first line with `marker` and indent the rest to line up under it.
+// Blank lines stay genuinely blank rather than becoming trailing whitespace.
+static string IndentContinuation(const string &text, const string &marker) {
+	const string pad(marker.size(), ' ');
+	string out;
+	std::istringstream iss(text);
+	string line;
+	bool first = true;
+	while (std::getline(iss, line)) {
+		if (!line.empty() && line.back() == '\r') {
+			line.pop_back();
+		}
+		if (first) {
+			out += marker + line + "\n";
+			first = false;
+		} else if (line.empty()) {
+			out += "\n";
+		} else {
+			out += pad + line + "\n";
+		}
+	}
+	if (first) {
+		// Nothing to indent; still emit the marker so the item is not lost.
+		out += marker + "\n";
+	}
+	return out;
+}
+
+// Render [begin, end) of a duck_block list. Recursive, because a `caption` has to
+// be rendered as a unit before it can be decorated -- markdown has no caption
+// syntax, so the alternative is prose no reader can tell from body text.
+static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t begin, idx_t end, int depth) {
 	string result;
 	bool last_was_inline = false;
 
-	for (const auto &block_value : list_children) {
+	for (idx_t i = begin; i < end;) {
+		const auto &block_value = list_children[i];
 		if (block_value.IsNull()) {
+			i++;
 			continue;
 		}
 
 		auto &struct_children = StructValue::GetChildren(block_value);
-		if (struct_children.size() < 7) {
+		if (struct_children.size() < DUCK_BLOCK_FIELD_COUNT) {
+			i++;
 			continue;
 		}
 
 		// duck_block: kind, element_type, content, level, encoding, attributes, element_order
-		string kind = struct_children[0].IsNull() ? "" : struct_children[0].ToString();
-		string element_type = struct_children[1].IsNull() ? "" : struct_children[1].ToString();
-		string content = struct_children[2].IsNull() ? "" : struct_children[2].ToString();
-		int32_t level = struct_children[3].IsNull() ? 0 : struct_children[3].GetValue<int32_t>();
-		string encoding = struct_children[4].IsNull() ? "text" : struct_children[4].ToString();
-		Value attributes = struct_children[5];
+		string kind = struct_children[Vocab::KIND_IDX].IsNull() ? "" : struct_children[Vocab::KIND_IDX].ToString();
 
-		bool is_inline = (kind == "inline");
+		// Metadata and any future kind are not document content; drop the whole scope.
+		if (!IsRenderableKind(kind)) {
+			i = SkipElementScope(list_children, i, end);
+			continue;
+		}
+		string element_type = struct_children[Vocab::ELEMENT_TYPE_IDX].IsNull()
+		                          ? ""
+		                          : struct_children[Vocab::ELEMENT_TYPE_IDX].ToString();
+		string content =
+		    struct_children[Vocab::CONTENT_IDX].IsNull() ? "" : struct_children[Vocab::CONTENT_IDX].ToString();
+		int32_t level =
+		    struct_children[Vocab::LEVEL_IDX].IsNull() ? 0 : struct_children[Vocab::LEVEL_IDX].GetValue<int32_t>();
+		string encoding =
+		    struct_children[Vocab::ENCODING_IDX].IsNull() ? "text" : struct_children[Vocab::ENCODING_IDX].ToString();
+		Value attributes = struct_children[Vocab::ATTRIBUTES_IDX];
+
+		// Spec 1.2 made `list` and `blockquote` structural: the container carries
+		// no content of its own and its blocks follow as children by level. The
+		// older shape packed the whole thing into JSON content and is still what
+		// released producers emit, so the block renderer keeps handling that and
+		// these paths only take over when there is no content to render.
+		if (kind == Vocab::KIND_BLOCK && content.empty() && depth < MAX_DUCK_BLOCK_NESTING) {
+			if (element_type == Vocab::TYPE_LIST) {
+				const idx_t scope_end = SkipElementScope(list_children, i, end);
+				if (scope_end > i + 1) {
+					const bool ordered = GetAttributeOf(block_value, "list_type") == "ordered";
+					const string number_style = GetAttributeOf(block_value, "number_style");
+					const string number_delim = GetAttributeOf(block_value, "number_delim");
+					int number = 1;
+					const string start_attr = GetAttributeOf(block_value, "start");
+					if (!start_attr.empty()) {
+						try {
+							number = std::stoi(start_attr);
+						} catch (...) {
+						}
+					}
+					const int32_t item_level = DuckBlockLevel(list_children[i]) + 1;
+					if (last_was_inline) {
+						result += "\n\n";
+					}
+					for (idx_t j = i + 1; j < scope_end;) {
+						if (DuckBlockLevel(list_children[j]) != item_level) {
+							j++;
+							continue;
+						}
+						const idx_t item_end = SkipElementScope(list_children, j, scope_end);
+						string inner = RenderDuckBlockRange(list_children, j + 1, item_end, depth + 1);
+						StringUtil::Trim(inner);
+						const string marker = ordered ? FormatListMarker(number++, number_style, number_delim) : "- ";
+						result += IndentContinuation(inner, marker);
+						j = item_end;
+					}
+					result += "\n";
+					last_was_inline = false;
+					i = scope_end;
+					continue;
+				}
+			} else if (element_type == Vocab::TYPE_LIST_ITEM) {
+				// An item met without its container -- render it as a bullet rather
+				// than dropping the blocks it holds.
+				const idx_t scope_end = SkipElementScope(list_children, i, end);
+				if (scope_end > i + 1) {
+					string inner = RenderDuckBlockRange(list_children, i + 1, scope_end, depth + 1);
+					StringUtil::Trim(inner);
+					if (last_was_inline) {
+						result += "\n\n";
+					}
+					result += IndentContinuation(inner, "- ") + "\n";
+					last_was_inline = false;
+					i = scope_end;
+					continue;
+				}
+			} else if (element_type == Vocab::TYPE_BLOCKQUOTE) {
+				const idx_t scope_end = SkipElementScope(list_children, i, end);
+				if (scope_end > i + 1) {
+					string inner = RenderDuckBlockRange(list_children, i + 1, scope_end, depth + 1);
+					StringUtil::Trim(inner);
+					if (last_was_inline) {
+						result += "\n\n";
+					}
+					std::istringstream iss(inner);
+					string line;
+					while (std::getline(iss, line)) {
+						if (!line.empty() && line.back() == '\r') {
+							line.pop_back();
+						}
+						result += line.empty() ? ">\n" : "> " + line + "\n";
+					}
+					result += "\n";
+					last_was_inline = false;
+					i = scope_end;
+					continue;
+				}
+			}
+		}
+
+		// A caption's children are its content, so render the scope it opens and
+		// mark the result. Position is the producer's choice -- a figure caption
+		// follows its content, a disclosure summary precedes its body -- so this
+		// renders in place and imposes no order of its own.
+		if (kind == Vocab::KIND_BLOCK && element_type == Vocab::TYPE_CAPTION && depth < MAX_DUCK_BLOCK_NESTING) {
+			idx_t scope_end = SkipElementScope(list_children, i, end);
+			string inner = RenderDuckBlockRange(list_children, i + 1, scope_end, depth + 1);
+			StringUtil::Trim(inner);
+			if (!inner.empty()) {
+				if (last_was_inline) {
+					result += "\n\n";
+				}
+				// Emphasis cannot span a paragraph break, so only a single-block
+				// caption gets marked; a multi-block one is emitted as it stands.
+				if (inner.find("\n\n") == string::npos) {
+					result += "*" + inner + "*";
+				} else {
+					result += inner;
+				}
+				result += "\n\n";
+			}
+			last_was_inline = false;
+			i = scope_end;
+			continue;
+		}
+
+		// An element with no content of its own carries it as kind='inline'
+		// children at level+1 -- a paragraph whose text is a run of inlines, a
+		// bold whose text nests one level deeper. Walking those flat rendered the
+		// marker's empty content as an element in its own right, which put a blank
+		// paragraph ahead of the text and closed "**" around nothing.
+		idx_t scope_end = SkipElementScope(list_children, i, end);
+		bool consumed_children = false;
+		if (content.empty() && scope_end > i + 1 && depth < MAX_DUCK_BLOCK_NESTING &&
+		    DuckBlockKind(list_children[i + 1]) == Vocab::KIND_INLINE) {
+			content = RenderDuckBlockRange(list_children, i + 1, scope_end, depth + 1);
+			consumed_children = true;
+		}
+
+		bool is_inline = (kind == Vocab::KIND_INLINE);
 
 		// Handle inline-to-block transition: add paragraph break
 		if (last_was_inline && !is_inline) {
 			result += "\n\n";
 		}
 
-		result += RenderDuckBlockToMarkdown(kind, element_type, content, level, encoding, attributes);
+		result +=
+		    DuckBlockFunctions::RenderDuckBlockToMarkdown(kind, element_type, content, level, encoding, attributes);
 		last_was_inline = is_inline;
+		i = consumed_children ? scope_end : i + 1;
 	}
 
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Document metadata -> YAML frontmatter
+//===--------------------------------------------------------------------===//
+
+// Every scalar is double-quoted. It costs a little noise and buys the guarantee
+// that a value out of an untrusted document -- one containing a newline and a
+// `---`, say -- cannot forge frontmatter structure around itself.
+static string YamlQuote(const string &text) {
+	string out = "\"";
+	for (unsigned char c : text) {
+		switch (c) {
+		case '"':
+			out += "\\\"";
+			break;
+		case '\\':
+			out += "\\\\";
+			break;
+		case '\n':
+			out += "\\n";
+			break;
+		case '\r':
+			out += "\\r";
+			break;
+		case '\t':
+			out += "\\t";
+			break;
+		default:
+			if (c < 0x20) {
+				out += ' ';
+			} else {
+				out += static_cast<char>(c);
+			}
+		}
+	}
+	out += "\"";
+	return out;
+}
+
+static string YamlKey(const string &key) {
+	if (key.empty()) {
+		return YamlQuote(key);
+	}
+	for (size_t i = 0; i < key.size(); i++) {
+		const unsigned char c = key[i];
+		const bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' ||
+		                (i > 0 && ((c >= '0' && c <= '9') || c == '-' || c == '.'));
+		if (!ok) {
+			return YamlQuote(key);
+		}
+	}
+	return key;
+}
+
+// A YAML literal block scalar, for metadata whose value is block content.
+static string YamlBlockScalar(const string &text, int indent) {
+	string out = "|\n";
+	const string pad(indent + 2, ' ');
+	std::istringstream iss(text);
+	string line;
+	while (std::getline(iss, line)) {
+		if (!line.empty() && line.back() == '\r') {
+			line.pop_back();
+		}
+		out += pad + line + "\n";
+	}
+	return out;
+}
+
+// Emit the YAML for the kind='value' scope opening at `i`, which nests by level
+// exactly as block containers do. Returns the index just past that scope.
+static idx_t RenderMetaValue(const vector<Value> &children, idx_t i, idx_t end, int indent, bool in_sequence,
+                             string &out) {
+	const idx_t scope_end = SkipElementScope(children, i, end);
+	auto &fields = StructValue::GetChildren(children[i]);
+	const string element_type =
+	    fields[Vocab::ELEMENT_TYPE_IDX].IsNull() ? "" : fields[Vocab::ELEMENT_TYPE_IDX].ToString();
+	const string content = fields[Vocab::CONTENT_IDX].IsNull() ? "" : fields[Vocab::CONTENT_IDX].ToString();
+	const string key = DuckBlockFunctions::GetAttribute(fields[Vocab::ATTRIBUTES_IDX], "key");
+
+	// The version marker deliberately carries no key, which is what keeps a
+	// storage/exchange stamp out of the document's own metadata on export.
+	if (element_type == Vocab::VALUE_VERSION) {
+		return scope_end;
+	}
+
+	const string prefix = string(indent, ' ') + (in_sequence ? "- " : "");
+	const string label = key.empty() ? "" : YamlKey(key) + ":";
+
+	if (element_type == Vocab::VALUE_LIST || element_type == Vocab::VALUE_MAP) {
+		out += prefix + (label.empty() ? string("-") : label) + "\n";
+		const bool children_in_sequence = (element_type == Vocab::VALUE_LIST);
+		idx_t j = i + 1;
+		while (j < scope_end) {
+			if (DuckBlockKind(children[j]) != Vocab::KIND_VALUE) {
+				j++;
+				continue;
+			}
+			j = RenderMetaValue(children, j, scope_end, indent + 2, children_in_sequence, out);
+		}
+		return scope_end;
+	}
+
+	string scalar;
+	if (element_type == Vocab::VALUE_BOOL) {
+		// The one value type emitted bare rather than quoted.
+		scalar = (content == "true") ? "true" : "false";
+	} else if (element_type == Vocab::VALUE_INLINES) {
+		string rendered = RenderDuckBlockRange(children, i + 1, scope_end, 0);
+		StringUtil::Trim(rendered);
+		scalar = YamlQuote(rendered);
+	} else if (element_type == Vocab::VALUE_BLOCKS) {
+		string rendered = RenderDuckBlockRange(children, i + 1, scope_end, 0);
+		StringUtil::Trim(rendered);
+		out += prefix + (label.empty() ? string("-") : label) + " " + YamlBlockScalar(rendered, indent);
+		return scope_end;
+	} else {
+		// string, generic, and any value type this build does not know: the content
+		// is the value verbatim.
+		scalar = YamlQuote(content);
+	}
+
+	if (label.empty()) {
+		out += prefix + scalar + "\n";
+	} else {
+		out += prefix + label + " " + scalar + "\n";
+	}
+	return scope_end;
+}
+
+// Build the frontmatter for a document's kind='value' elements. Empty when the
+// document has no metadata.
+static string RenderDocumentFrontmatter(const vector<Value> &children) {
+	string body;
+	for (idx_t i = 0; i < children.size();) {
+		if (DuckBlockKind(children[i]) != Vocab::KIND_VALUE) {
+			i++;
+			continue;
+		}
+		i = RenderMetaValue(children, i, children.size(), 0, false, body);
+	}
+	if (body.empty()) {
+		return "";
+	}
+	return "---\n" + body + "---\n\n";
+}
+
+// True when the list already carries frontmatter of its own, in which case
+// synthesising a second block would produce a document with two.
+static bool HasFrontmatterBlock(const vector<Value> &children) {
+	for (const auto &child : children) {
+		if (DuckBlockKind(child) != Vocab::KIND_BLOCK) {
+			continue;
+		}
+		auto &fields = StructValue::GetChildren(child);
+		const string element_type =
+		    fields[Vocab::ELEMENT_TYPE_IDX].IsNull() ? "" : fields[Vocab::ELEMENT_TYPE_IDX].ToString();
+		if (element_type == Vocab::TYPE_METADATA || element_type == "frontmatter") {
+			return true;
+		}
+	}
+	return false;
+}
+
+string DuckBlockFunctions::RenderDuckBlocksToMarkdown(const Value &blocks_value) {
+	if (blocks_value.IsNull() || blocks_value.type().id() != LogicalTypeId::LIST) {
+		return "";
+	}
+	auto &list_children = ListValue::GetChildren(blocks_value);
+	string result;
+	// Metadata is not body content, but markdown -- alone among the output formats
+	// this vocabulary targets -- has somewhere to put it, so it round-trips as
+	// frontmatter instead of being dropped.
+	if (!HasFrontmatterBlock(list_children)) {
+		result = RenderDocumentFrontmatter(list_children);
+	}
+	result += RenderDuckBlockRange(list_children, 0, list_children.size(), 0);
 	return result;
 }
 
@@ -757,12 +1448,20 @@ void DuckBlockFunctions::RegisterDuckBlockToMdFunction(ExtensionLoader &loader) 
 			    }
 
 			    // duck_block: kind, element_type, content, level, encoding, attributes, element_order
-			    string kind = struct_children[0].IsNull() ? "" : struct_children[0].ToString();
-			    string element_type = struct_children[1].IsNull() ? "" : struct_children[1].ToString();
-			    string content = struct_children[2].IsNull() ? "" : struct_children[2].ToString();
-			    int32_t level = struct_children[3].IsNull() ? 0 : struct_children[3].GetValue<int32_t>();
-			    string encoding = struct_children[4].IsNull() ? "text" : struct_children[4].ToString();
-			    Value attributes = struct_children[5];
+			    string kind =
+			        struct_children[Vocab::KIND_IDX].IsNull() ? "" : struct_children[Vocab::KIND_IDX].ToString();
+			    string element_type = struct_children[Vocab::ELEMENT_TYPE_IDX].IsNull()
+			                              ? ""
+			                              : struct_children[Vocab::ELEMENT_TYPE_IDX].ToString();
+			    string content =
+			        struct_children[Vocab::CONTENT_IDX].IsNull() ? "" : struct_children[Vocab::CONTENT_IDX].ToString();
+			    int32_t level = struct_children[Vocab::LEVEL_IDX].IsNull()
+			                        ? 0
+			                        : struct_children[Vocab::LEVEL_IDX].GetValue<int32_t>();
+			    string encoding = struct_children[Vocab::ENCODING_IDX].IsNull()
+			                          ? "text"
+			                          : struct_children[Vocab::ENCODING_IDX].ToString();
+			    Value attributes = struct_children[Vocab::ATTRIBUTES_IDX];
 
 			    string markdown = RenderDuckBlockToMarkdown(kind, element_type, content, level, encoding, attributes);
 			    result.SetValue(i, Value(markdown));
@@ -867,25 +1566,43 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 				    }
 			    };
 
-			    for (const auto &block_value : list_children) {
+			    for (idx_t i = 0; i < list_children.size();) {
+				    const auto &block_value = list_children[i];
 				    if (block_value.IsNull()) {
+					    i++;
 					    continue;
 				    }
 
 				    auto &struct_children = StructValue::GetChildren(block_value);
-				    if (struct_children.size() < 7) {
+				    if (struct_children.size() < DUCK_BLOCK_FIELD_COUNT) {
+					    i++;
 					    continue;
 				    }
 
 				    // duck_block: kind, element_type, content, level, encoding, attributes, element_order
-				    string kind = struct_children[0].IsNull() ? "" : struct_children[0].ToString();
-				    string element_type = struct_children[1].IsNull() ? "" : struct_children[1].ToString();
-				    string content = struct_children[2].IsNull() ? "" : struct_children[2].ToString();
-				    int32_t level = struct_children[3].IsNull() ? 0 : struct_children[3].GetValue<int32_t>();
-				    string encoding = struct_children[4].IsNull() ? "text" : struct_children[4].ToString();
-				    Value attributes = struct_children[5];
+				    string kind =
+				        struct_children[Vocab::KIND_IDX].IsNull() ? "" : struct_children[Vocab::KIND_IDX].ToString();
 
-				    if (element_type == "heading") {
+				    // Metadata and any future kind are not section content.
+				    if (!IsRenderableKind(kind)) {
+					    i = SkipElementScope(list_children, i, list_children.size());
+					    continue;
+				    }
+				    string element_type = struct_children[Vocab::ELEMENT_TYPE_IDX].IsNull()
+				                              ? ""
+				                              : struct_children[Vocab::ELEMENT_TYPE_IDX].ToString();
+				    string content = struct_children[Vocab::CONTENT_IDX].IsNull()
+				                         ? ""
+				                         : struct_children[Vocab::CONTENT_IDX].ToString();
+				    int32_t level = struct_children[Vocab::LEVEL_IDX].IsNull()
+				                        ? 0
+				                        : struct_children[Vocab::LEVEL_IDX].GetValue<int32_t>();
+				    string encoding = struct_children[Vocab::ENCODING_IDX].IsNull()
+				                          ? "text"
+				                          : struct_children[Vocab::ENCODING_IDX].ToString();
+				    Value attributes = struct_children[Vocab::ATTRIBUTES_IDX];
+
+				    if (element_type == Vocab::TYPE_HEADING) {
 					    // Flush previous section
 					    flush_section();
 
@@ -925,7 +1642,7 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 						    std::replace(current_section_id.begin(), current_section_id.end(), ' ', '-');
 					    }
 					    current_content.clear();
-				    } else if (element_type == "metadata" || element_type == "frontmatter") {
+				    } else if (element_type == Vocab::TYPE_METADATA || element_type == "frontmatter") {
 					    // Metadata becomes level 0 section
 					    flush_section();
 					    current_title = "";
@@ -940,6 +1657,7 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 					    current_content +=
 					        RenderDuckBlockToMarkdown(kind, element_type, content, level, encoding, attributes);
 				    }
+				    i++;
 			    }
 
 			    // Flush final section

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -815,11 +815,22 @@ string DuckBlockFunctions::RenderBlockElementToMarkdown(const string &element_ty
 		result = content + "\n\n";
 	} else if (element_type == Vocab::TYPE_DIV || element_type == Vocab::TYPE_SECTION ||
 	           element_type == Vocab::TYPE_FIGURE || element_type == Vocab::TYPE_CAPTION) {
-		// Containers carry no content of their own; their children follow at level+1
-		// and render themselves. Emitting the (empty) content here produced stray
-		// blank lines. `caption` additionally gets decorated by the list renderer,
-		// which is the only place with access to the children it scopes.
-		result = "";
+		// A container's children are usually its content, and they render
+		// themselves -- so the marker emits nothing and no stray blank line.
+		//
+		// But a container whose only child is a text run carries that text in its
+		// OWN content (spec 6.0), so dropping content unconditionally lost it. The
+		// same rule had list_item dropping the text of every tight item; fixing it
+		// only there left this in four more places, which is why the sentinel
+		// sweep found them and a round trip never could.
+		if (content.empty()) {
+			result = "";
+		} else if (element_type == Vocab::TYPE_CAPTION) {
+			// Marked as a caption, as the scoped form is.
+			result = "*" + content + "*\n\n";
+		} else {
+			result = content + "\n\n";
+		}
 	} else if (element_type == Vocab::TYPE_LINEBLOCK) {
 		// Preserved line breaks. Markdown has no line-block syntax, and a bare
 		// newline inside a paragraph is a soft break that collapses to a space --
@@ -1225,7 +1236,12 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 		// renders in place and imposes no order of its own.
 		if (kind == Vocab::KIND_BLOCK && element_type == Vocab::TYPE_CAPTION && depth < MAX_DUCK_BLOCK_NESTING) {
 			idx_t scope_end = SkipElementScope(list_children, i, end);
-			string inner = RenderDuckBlockRange(list_children, i + 1, scope_end, depth + 1);
+			// Children are the caption's text when it has any; its own content is
+			// its text when it does not. Without the fallback this branch consumed
+			// a childless caption and emitted nothing, which also shadowed the leaf
+			// renderer -- so the text was lost twice over.
+			string inner = scope_end > i + 1 ? RenderDuckBlockRange(list_children, i + 1, scope_end, depth + 1)
+			                                 : DuckBlockContent(list_children[i]);
 			StringUtil::Trim(inner);
 			if (!inner.empty()) {
 				if (last_was_inline) {

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -960,6 +960,24 @@ string DuckBlockFunctions::RenderDuckBlockToMarkdown(const string &kind, const s
 // file_path) may follow, so this is a minimum, not an exact width.
 static constexpr idx_t DUCK_BLOCK_FIELD_COUNT = Vocab::ELEMENT_ORDER_IDX + 1;
 
+// Whether a block renders the content it is given. Three declared block types do
+// not: `hr` and `page_break` are rules with no content slot, and `generic`
+// deliberately emits a naming comment instead of a foreign-format fragment.
+//
+// This matters because a block ABSORBS the inline run that follows it. Absorbing
+// into a type that then discards the result does not merely lose formatting, it
+// DELETES the run: `hr` followed by "Section two" rendered the rule and dropped
+// the sentence. The old COPY path got this right by accident, one element at a
+// time, and routing it through this renderer is what surfaced it.
+//
+// Kept as an explicit set rather than derived, because "does this branch use its
+// argument" is not a question the code can ask itself. The set is verified
+// empirically in scripts/check_conformance.py against EVERY declared type, so a
+// new content-discarding type fails there rather than silently eating a run.
+static bool BlockAbsorbsInlineRun(const string &element_type) {
+	return !(element_type == Vocab::TYPE_HR || element_type == Vocab::TYPE_PAGE || element_type == Vocab::TYPE_GENERIC);
+}
+
 static string DuckBlockKind(const Value &block_value) {
 	if (block_value.IsNull()) {
 		return "";
@@ -1411,11 +1429,15 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 		// both; among inlines the level IS the nesting, so a wrapper there takes
 		// what is deeper than itself.
 		idx_t scope_end;
-		if (kind == Vocab::KIND_BLOCK) {
+		if (kind == Vocab::KIND_BLOCK && BlockAbsorbsInlineRun(element_type)) {
 			scope_end = i + 1;
 			while (scope_end < end && DuckBlockKind(list_children[scope_end]) == Vocab::KIND_INLINE) {
 				scope_end++;
 			}
+		} else if (kind == Vocab::KIND_BLOCK) {
+			// Discards its content, so it takes nothing: the run that follows is
+			// rendered in its own right rather than absorbed and dropped.
+			scope_end = i + 1;
 		} else {
 			scope_end = SkipElementScope(list_children, i, end);
 		}

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1211,11 +1211,28 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 		}
 
 		// An element with no content of its own carries it as kind='inline'
-		// children at level+1 -- a paragraph whose text is a run of inlines, a
-		// bold whose text nests one level deeper. Walking those flat rendered the
-		// marker's empty content as an element in its own right, which put a blank
-		// paragraph ahead of the text and closed "**" around nothing.
-		idx_t scope_end = SkipElementScope(list_children, i, end);
+		// children -- a paragraph whose text is a run of inlines, a bold whose
+		// text nests deeper. Walking those flat rendered the marker's empty
+		// content as an element in its own right, which put a blank paragraph
+		// ahead of the text and closed "**" around nothing.
+		//
+		// Blocks and inlines sit on SEPARATE level scales: the spec puts a
+		// top-level inline at level 1 while a top-level block records NULL. And
+		// producers disagree about where a block's inline run begins -- the
+		// builders and all four panduck readers emit level 1, the Pandoc path
+		// emits 2. So a block takes the whole contiguous inline run that follows
+		// it rather than trusting the level, which is the only rule that reads
+		// both; among inlines the level IS the nesting, so a wrapper there takes
+		// what is deeper than itself.
+		idx_t scope_end;
+		if (kind == Vocab::KIND_BLOCK) {
+			scope_end = i + 1;
+			while (scope_end < end && DuckBlockKind(list_children[scope_end]) == Vocab::KIND_INLINE) {
+				scope_end++;
+			}
+		} else {
+			scope_end = SkipElementScope(list_children, i, end);
+		}
 		bool consumed_children = false;
 		if (content.empty() && scope_end > i + 1 && depth < MAX_DUCK_BLOCK_NESTING &&
 		    DuckBlockKind(list_children[i + 1]) == Vocab::KIND_INLINE) {

--- a/src/include/duck_block_functions.hpp
+++ b/src/include/duck_block_functions.hpp
@@ -48,6 +48,11 @@ public:
 	 */
 	static string RenderDuckBlocksToMarkdown(const Value &blocks_value);
 
+	/**
+	 * @brief Look up a key in a duck_block's attributes MAP, or "" when absent
+	 */
+	static string GetAttribute(const Value &attributes, const string &key);
+
 private:
 	static void RegisterDuckBlockToMdFunction(ExtensionLoader &loader);
 	static void RegisterDuckBlocksToMdFunction(ExtensionLoader &loader);
@@ -60,9 +65,6 @@ private:
 	// Render inline element to markdown
 	static string RenderInlineElementToMarkdown(const string &element_type, const string &content,
 	                                            const Value &attributes);
-
-	// Helper to extract attribute from MAP value
-	static string GetAttribute(const Value &attributes, const string &key);
 
 	// Helper to parse JSON list items
 	static vector<string> ParseJsonListItems(const string &content);

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -26,6 +26,26 @@
 // ---------------------------------------------------------------------------
 // VENDORING THIS FILE
 //
+// WHAT ELSE IS VENDORABLE, and where. `vendor/README.md` upstream is the index; this
+// header is the one vendorable file that does NOT live there, because four extensions
+// already pull it from `src/include/` and moving it to buy tidiness would break their
+// tooling for no gain. The others:
+//
+//     vendor/duck_block_conformance.sql   validity, error detail, declared kind /
+//                                         type / encoding lists -- pure DuckDB SQL
+//     vendor/duck_block_normalize.hpp     the content rule as a transform
+//
+// PATHS MOVE. `duck_block_conformance.sql` lived at `conformance/` until 2026-09-01.
+// A consumer re-syncing by URL got a 404 -- and duckdb_markdown pointed out how that
+// fails: `curl -sS -o file URL` writes GitHub's 404 page INTO the vendored file, and
+// `curl -sSf` leaves the stale copy in place while the consumer believes they
+// re-synced. Either way they keep validating against an old vocabulary and nothing
+// says so.
+//
+// So CHECK THE HTTP STATUS and fail loudly on anything but 200, the same way you
+// would refuse to print OK from an undatable fetch (below). A vendored file that
+// silently did not update is the failure this whole block exists to prevent.
+//
 // Copy it. Do NOT add duck_block_utils as a submodule: the DuckDB extension CI
 // templates check out with submodules: 'recursive' and this repo carries its
 // own duckdb submodule, so a pin drags a ~290 MB nested DuckDB clone into your
@@ -372,6 +392,51 @@ struct DuckBlockVocabulary {
 	static constexpr const char *ENCODING_XML = "xml";
 	static constexpr const char *ENCODING_LATEX = "latex";
 	static constexpr const char *ENCODING_MARKDOWN = "markdown";
+	// TOML is a distinct syntax with no equivalent in the set above. Emitting a
+	// verbatim .toml blob as 'text' discards the one fact a consumer needs in order to
+	// parse it, which is the opposite of what a verbatim blob is for. Asked for by the
+	// panduck session rather than minted by them -- the behaviour the spec asks for.
+	static constexpr const char *ENCODING_TOML = "toml";
+
+	// ========================================================================
+	// Attribute NAMES
+	//
+	// These were bare string literals until 2026-09-01 -- `"role"` appeared in six
+	// places in this repo's own source and in every consumer's, and a drift check that
+	// compares CONSTANTS by name and value could see none of it. A misspelled `"roles"`
+	// produces an element that is valid, conformant, lint-clean and wrong.
+	//
+	// Raised by duckdb_markdown, and the argument is the one that decided
+	// `metadata`+role over minting a `frontmatter` type in the first place: if the ROLE
+	// carries the meaning, the role needs the enforcement the type has.
+	// ========================================================================
+	static constexpr const char *ATTR_ROLE = "role";
+	static constexpr const char *ATTR_KEY = "key";
+	static constexpr const char *ATTR_HEADING_LEVEL = "heading_level";
+	static constexpr const char *ATTR_LIST_TYPE = "list_type";
+	static constexpr const char *ATTR_SOURCE_TYPE = "source_type";
+	static constexpr const char *ATTR_PANDOC_AST = "pandoc_ast";
+
+	// ========================================================================
+	// Role values, per the type that carries them
+	// ========================================================================
+	// `metadata` -- which verbatim blob this is
+	static constexpr const char *ROLE_FRONTMATTER = "frontmatter"; // has a document body after it
+	static constexpr const char *ROLE_DOCUMENT = "document";       // the blob IS the whole document
+
+	// `list_item` in a definition list
+	static constexpr const char *ROLE_TERM = "term";
+	static constexpr const char *ROLE_DEFINITION = "definition";
+
+	// `section` -- which sectioning construct
+	static constexpr const char *ROLE_SECTION = "section";
+	static constexpr const char *ROLE_ARTICLE = "article";
+	static constexpr const char *ROLE_ASIDE = "aside";
+	static constexpr const char *ROLE_NAV = "nav";
+	static constexpr const char *ROLE_HEADER = "header";
+	static constexpr const char *ROLE_FOOTER = "footer";
+	static constexpr const char *ROLE_MAIN = "main";
+	static constexpr const char *ROLE_PAGE = "page";
 };
 
 } // namespace duckdb

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -5,9 +5,9 @@
 //
 //   upstream : teaguesterling/duckdb_duck_block_utils
 //              src/include/duck_block_vocabulary.hpp
-//   commit   : 2c0e565656643f268fb2b8fc21a9cb1c7cee15a1
-//              (2c0e565, 2026-08-31)
-//   spec     : SPEC_VERSION 1.2
+//   commit   : 26bfe05dbea23977a9cad36c81a871e0c859a6b1
+//              (26bfe05, 2026-08-31)
+//   spec     : SPEC_VERSION 2.0
 //
 // Re-sync by copying the file from that repo and updating the three lines
 // above. `make check-vocabulary` fails the build if this copy has drifted
@@ -89,7 +89,12 @@
 //      should report without failing. GAPS is the arm that earns its keep -- it
 //      is what surfaced inline `generic` losing source_type in two extensions
 //      in the same week. Carry an explicit allowlist of intentional gaps, or an
-//      unexplained one and a deliberate one look identical.
+//      unexplained one and a deliberate one look identical. Filter NUMERIC-valued
+//      constants out when selecting the vocabulary by name prefix -- otherwise
+//      KIND_IDX and the other struct field offsets get reported as published-but-
+//      unhandled types, and a check whose first run on a new consumer is a false
+//      positive has already taught that consumer to ignore it. (panduck hit exactly
+//      this while adopting the arm from this recommendation.)
 //
 //      duckdb_markdown has a working implementation of exactly this, which
 //      looks in both a vendored and a submodule location:
@@ -164,7 +169,7 @@ struct DuckBlockVocabulary {
 
 	// The duck_block spec version this build implements. Bump when the vocabulary
 	// changes in a way a consumer could observe.
-	static constexpr const char *SPEC_VERSION = "1.2";
+	static constexpr const char *SPEC_VERSION = "2.0";
 
 	// ========================================================================
 	// Block type names

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -424,6 +424,43 @@ struct DuckBlockVocabulary {
 	static constexpr const char *ROLE_FRONTMATTER = "frontmatter"; // has a document body after it
 	static constexpr const char *ROLE_DOCUMENT = "document";       // the blob IS the whole document
 
+	// ========================================================================
+	// `list_type` values -- the attribute is ATTR_LIST_TYPE
+	//
+	// The KEY got a constant and the VALUES did not, which duckdb_markdown named as the
+	// shape that keeps recurring: "the key gets a constant, the value it is compared
+	// against does not." Their writer branches on `list_type == "definition"` to choose
+	// the definition-list rendering, so a value rename upstream turns every definition
+	// list into a bullet list, silently, with every check green.
+	//
+	// WHY `list_type` AND NOT THE OLDER `attributes['ordered']`. A boolean answers
+	// "ordered or not" and cannot answer "which KIND of list", so it had no way to say
+	// `definition` -- and definition lists arrived the same day the question was
+	// settled, needing zero new element_types because `list_type` could carry them.
+	// A `navlist`, or anything else with list semantics, lands the same way.
+	//
+	// That is the general rule and it is worth more than this instance: WHEN
+	// COLLAPSING TWO NAMES FOR ONE FACT, KEEP THE ONE THAT CAN STILL EXPRESS THE FACT
+	// WHEN IT GROWS. The v1-fidelity argument said keep `ordered`; it optimised for
+	// matching the past and never asked what the next value would need.
+	//
+	// `attributes['ordered']` = 'true'/'false' remains a LEGACY ALIAS. Producers may
+	// emit both -- this one does -- and CONSUMERS MUST TOLERATE IT, because data
+	// written before the rule exists and does not rewrite itself. Read `list_type`
+	// first and fall back.
+	//
+	// Recorded here rather than only in the spec because a consumer reading these
+	// constants is exactly the reader who needs it, and would otherwise not learn the
+	// alias exists at all. (duckeye's point: a reason like this belongs beside the
+	// constant, not only in the thread that produced it.)
+	// ========================================================================
+	static constexpr const char *LIST_TYPE_BULLET = "bullet";
+	static constexpr const char *LIST_TYPE_ORDERED = "ordered";
+	static constexpr const char *LIST_TYPE_DEFINITION = "definition";
+	// The legacy boolean. Declared so a consumer tolerating it names the attribute
+	// rather than spelling it, and so a drift check can see it at all.
+	static constexpr const char *ATTR_ORDERED_LEGACY = "ordered";
+
 	// `list_item` in a definition list
 	static constexpr const char *ROLE_TERM = "term";
 	static constexpr const char *ROLE_DEFINITION = "definition";

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -1,0 +1,261 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// VENDORED COPY -- do not edit. Any change here is drift, by definition.
+//
+//   upstream : teaguesterling/duckdb_duck_block_utils
+//              src/include/duck_block_vocabulary.hpp
+//   commit   : 2c0e565656643f268fb2b8fc21a9cb1c7cee15a1
+//              (2c0e565, 2026-08-31)
+//   spec     : SPEC_VERSION 1.2
+//
+// Re-sync by copying the file from that repo and updating the three lines
+// above. `make check-vocabulary` fails the build if this copy has drifted
+// from upstream by a renamed, removed, or VALUE-CHANGED constant -- a value
+// change compiles clean and is invisible to C++, which is why the check is
+// not optional. See scripts/check_duck_block_vocabulary.py.
+//
+// Vendored rather than submoduled deliberately: duck_block_utils carries its
+// own duckdb submodule, and the extension CI templates check out recursively,
+// so a pin drags a nested DuckDB clone into CI to deliver this one file.
+// ---------------------------------------------------------------------------
+
+// ============================================================================
+// The duck_block vocabulary -- PUBLISHED INTERFACE.
+//
+// Header-only and link-free ON PURPOSE. Sibling extensions (panduck, webbed,
+// duckdb_markdown, sitting_duck) consume this by VENDORING a copy -- see
+// "VENDORING THIS FILE" below for why a copy beats a submodule here, and for
+// the drift check that has to come with it.
+//
+// Nothing here has a definition in a .cpp, so including it costs no linking.
+// The type constructors and Register() live in block_types.hpp, which needs
+// block_types.cpp -- do NOT move them here, or consumers get link errors for
+// functions they never called.
+//
+// Changes to these names are BREAKING for every consumer. Bump SPEC_VERSION
+// and say so. Consumers should assert agreement at test time rather than
+// trusting that their copy is current:
+//
+//     SELECT duck_block_kind_names();        -- ['block', 'inline', 'value']
+//     SELECT duck_block_type_names();        -- every element_type name
+//     SELECT duck_block_spec_version();
+//
+// See docs/duck_blocks_spec.md for what each name means.
+//
+// ---------------------------------------------------------------------------
+// VENDORING THIS FILE
+//
+// Copy it. Do NOT add duck_block_utils as a submodule: the DuckDB extension CI
+// templates check out with submodules: 'recursive' and this repo carries its
+// own duckdb submodule, so a pin drags a ~290 MB nested DuckDB clone into your
+// CI to deliver 12 KB. This file needs none of it -- <cstdint> only.
+//
+// A submodule pin is ALSO a copy. It sits at whatever sha you checked out and
+// never tracks main, so it goes stale exactly as a vendored file does -- and it
+// never complains, whereas a check does. It is additionally bounded by the
+// upstream PUSH cadence, not the commit cadence: an unpushed commit cannot be
+// pinned at all.
+//
+// So vendor, and add a drift check that actually runs. Note first WHY a check
+// is not optional: these constants protect against a RENAME, not against a
+// changed VALUE.
+//
+//     TYPE_PAGE = "page_break"   ->   TYPE_PAGE = "pagebreak"
+//
+// A rename is a compile error at every use site. That value change compiles
+// clean everywhere, and a consumer's writer silently stops matching the type.
+// Nothing in C++ catches it -- not a vendored copy, not a submodule pin. Only
+// a check does. (Found by the duckdb_markdown session, 2026-08-31.)
+//
+//   1. Record the provenance where a reader will find it -- in your copy's
+//      header comment, note the upstream sha and the SPEC_VERSION below.
+//
+//   2. Fail your build when a constant is renamed, removed, or CHANGES VALUE.
+//      Fetch upstream and compare BY NAME AND VALUE -- parse both sides, do
+//      not diff the text:
+//
+//        https://raw.githubusercontent.com/teaguesterling/
+//          duckdb_duck_block_utils/main/src/include/duck_block_vocabulary.hpp
+//
+//      A plain `diff` over this file fires on comment edits and cosmetic churn
+//      -- commit 3957f36 rewrote every idx_t to uint64_t and changed no name
+//      and no value. A check that cries wolf gets muted, and a muted check
+//      catches nothing. Silence on cosmetic change is what keeps it credible.
+//
+//      Worth reporting separately rather than as one pass/fail: DRIFT (renamed,
+//      removed, or value changed) should fail; NEW (published here, absent from
+//      your copy) and GAPS (published, but nothing in your code branches on it)
+//      should report without failing. GAPS is the arm that earns its keep -- it
+//      is what surfaced inline `generic` losing source_type in two extensions
+//      in the same week. Carry an explicit allowlist of intentional gaps, or an
+//      unexplained one and a deliberate one look identical.
+//
+//      duckdb_markdown has a working implementation of exactly this, which
+//      looks in both a vendored and a submodule location:
+//      scripts/check_duck_block_vocabulary.py (`make check-vocabulary`).
+//
+//   3. Assert the RUNTIME vocabulary too, which no file comparison can see --
+//      the installed extension may be older than any header:
+//
+//        SELECT duck_block_type_names();   -- every element_type
+//        SELECT duck_block_kind_names();   -- ['block','inline','value']
+//        SELECT duck_block_spec_version(); -- compare against SPEC_VERSION here
+//
+// (2) catches a stale copy; (3) catches a stale INSTALL. They fail differently
+// and neither subsumes the other.
+// ---------------------------------------------------------------------------
+// ============================================================================
+
+// <cstdint> ONLY. This header deliberately pulls in nothing from DuckDB.
+//
+// It used to include duckdb/common/types.hpp for idx_t, which is `typedef
+// uint64_t idx_t` -- so the include bought nothing but a dependency. And it was
+// an expensive one: it made this file unusable as a standalone copy, forcing
+// consumers toward a submodule -- and the DuckDB extension CI templates check
+// out with submodules: 'recursive' while this repo carries its own duckdb
+// submodule. That meant a 290 MB nested DuckDB clone in every consumer's CI to
+// deliver a 12 KB header.
+//
+// Field indices are uint64_t, which is type-identical to idx_t.
+#include <cstdint>
+
+namespace duckdb {
+
+struct DuckBlockVocabulary {
+	// Field indices for duck_block struct
+	static constexpr uint64_t KIND_IDX = 0;
+	static constexpr uint64_t ELEMENT_TYPE_IDX = 1;
+	static constexpr uint64_t CONTENT_IDX = 2;
+	static constexpr uint64_t LEVEL_IDX = 3;
+	static constexpr uint64_t ENCODING_IDX = 4;
+	static constexpr uint64_t ATTRIBUTES_IDX = 5;
+	static constexpr uint64_t ELEMENT_ORDER_IDX = 6;
+
+	// Additional field indices for duck_block_ext
+	static constexpr uint64_t SOURCE_FORMAT_IDX = 7;
+	static constexpr uint64_t FILE_PATH_IDX = 8;
+
+	// Kind values
+	static constexpr const char *KIND_BLOCK = "block";
+	static constexpr const char *KIND_INLINE = "inline";
+	// Non-prose data attached to a document -- currently its metadata. Consumers that
+	// walk document content filter on KIND_BLOCK and ignore these automatically, which
+	// is what makes the kind additive rather than breaking.
+	static constexpr const char *KIND_VALUE = "value";
+
+	// ========================================================================
+	// Value type names (kind = 'value')
+	// ========================================================================
+	// Model Pandoc's recursive MetaValue tree. `list` and `map` nest their children
+	// via `level`, exactly as `div` and `figure` do; `inlines` and `blocks` carry
+	// ordinary kind='inline'/'block' children. The map key, where there is one, is in
+	// attributes['key'].
+	static constexpr const char *VALUE_STRING = "string";
+	static constexpr const char *VALUE_BOOL = "bool";
+	static constexpr const char *VALUE_LIST = "list";
+	static constexpr const char *VALUE_MAP = "map";
+	static constexpr const char *VALUE_INLINES = "inlines";
+	static constexpr const char *VALUE_BLOCKS = "blocks";
+	// Stream metadata, not document metadata: records which duck_block spec a
+	// persisted or exchanged block list was written against. Carries no
+	// attributes['key'], which is what keeps it out of a document's Pandoc `meta`.
+	static constexpr const char *VALUE_VERSION = "version";
+
+	// The duck_block spec version this build implements. Bump when the vocabulary
+	// changes in a way a consumer could observe.
+	static constexpr const char *SPEC_VERSION = "1.2";
+
+	// ========================================================================
+	// Block type names
+	// ========================================================================
+	static constexpr const char *TYPE_HEADING = "heading";
+	static constexpr const char *TYPE_PARAGRAPH = "paragraph";
+	static constexpr const char *TYPE_CODE = "code";
+	static constexpr const char *TYPE_BLOCKQUOTE = "blockquote";
+	static constexpr const char *TYPE_LIST = "list";
+	static constexpr const char *TYPE_LIST_ITEM = "list_item";
+	static constexpr const char *TYPE_TABLE = "table";
+	static constexpr const char *TYPE_HR = "hr";
+	static constexpr const char *TYPE_METADATA = "metadata";
+	static constexpr const char *TYPE_IMAGE = "image";
+	static constexpr const char *TYPE_RAW = "raw";
+	static constexpr const char *TYPE_DIV = "div";
+	// A SEMANTIC sectioning container, distinct from `div`. HTML's own spec calls
+	// div "an element of last resort", so mapping <section>/<article>/<aside> onto
+	// it would make element_type say something false while the truth hid in an
+	// attribute. Which kind of section lives in attributes['role'] -- section,
+	// article, aside, nav, header, footer, main -- following the convention already
+	// set by heading+heading_level, list+list_type and quoted+quote_type rather
+	// than minting one type per variant.
+	// Pandoc has no Section constructor, so this exports as a Div whose class is
+	// the role; that is pandoc's nearest honest equivalent.
+	static constexpr const char *TYPE_SECTION = "section";
+	// A physical pagination boundary -- a MARKER, not a container. Like `hr` it
+	// carries no content and owns no children; element_order already groups
+	// "blocks between marker N and N+1", so a container would re-nest whole
+	// documents for nothing. The number lives in attributes['page_number'].
+	//
+	// Physical, NOT semantic: a table of contents and a section slicer must
+	// IGNORE pages, which is precisely what they cannot do when a reader fakes
+	// them as headings.
+	static constexpr const char *TYPE_PAGE = "page_break";
+	static constexpr const char *TYPE_LINEBLOCK = "lineblock";
+	static constexpr const char *TYPE_DEFLIST = "deflist";
+	static constexpr const char *TYPE_FIGURE = "figure";
+	// A caption belonging to the container that precedes it. Deliberately general
+	// rather than figure-specific: Pandoc's Table also carries a Caption, and can
+	// adopt this later without another vocabulary change.
+	static constexpr const char *TYPE_CAPTION = "caption";
+	// A structurally-valid element whose type is not in the standard vocabulary.
+	// Distinct from TYPE_RAW, which is literal content in a *named* format; this is a
+	// structured element we cannot name. Format-neutral on purpose: any reader
+	// (pandoc, html, sitting_duck) can use it. The originating type name is preserved
+	// in attributes['source_type']. Shares its string with INLINE_GENERIC; `kind`
+	// disambiguates, as it already does for code/image/raw.
+	static constexpr const char *TYPE_GENERIC = "generic";
+
+	// ========================================================================
+	// Inline type names
+	// ========================================================================
+	// Text and whitespace
+	static constexpr const char *INLINE_TEXT = "text";
+	static constexpr const char *INLINE_SPACE = "space";
+	static constexpr const char *INLINE_SOFTBREAK = "softbreak";
+	static constexpr const char *INLINE_LINEBREAK = "linebreak";
+
+	// Formatting (container types)
+	static constexpr const char *INLINE_BOLD = "bold";
+	static constexpr const char *INLINE_ITALIC = "italic";
+	static constexpr const char *INLINE_STRIKETHROUGH = "strikethrough";
+	static constexpr const char *INLINE_SUPERSCRIPT = "superscript";
+	static constexpr const char *INLINE_SUBSCRIPT = "subscript";
+	static constexpr const char *INLINE_SMALLCAPS = "smallcaps";
+	static constexpr const char *INLINE_UNDERLINE = "underline";
+
+	// Semantic
+	static constexpr const char *INLINE_CODE = "code";
+	static constexpr const char *INLINE_MATH = "math";
+	static constexpr const char *INLINE_LINK = "link";
+	static constexpr const char *INLINE_IMAGE = "image";
+	static constexpr const char *INLINE_QUOTED = "quoted";
+	static constexpr const char *INLINE_CITE = "cite";
+	static constexpr const char *INLINE_NOTE = "note";
+	static constexpr const char *INLINE_SPAN = "span";
+	static constexpr const char *INLINE_RAW = "raw";
+	// Inline counterpart of TYPE_GENERIC -- same string, distinguished by kind.
+	static constexpr const char *INLINE_GENERIC = "generic";
+
+	// ========================================================================
+	// Encoding values
+	// ========================================================================
+	static constexpr const char *ENCODING_TEXT = "text";
+	static constexpr const char *ENCODING_JSON = "json";
+	static constexpr const char *ENCODING_YAML = "yaml";
+	static constexpr const char *ENCODING_HTML = "html";
+	static constexpr const char *ENCODING_XML = "xml";
+	static constexpr const char *ENCODING_LATEX = "latex";
+	static constexpr const char *ENCODING_MARKDOWN = "markdown";
+};
+
+} // namespace duckdb

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -5,9 +5,9 @@
 //
 //   upstream : teaguesterling/duckdb_duck_block_utils
 //              src/include/duck_block_vocabulary.hpp
-//   commit   : 26bfe05dbea23977a9cad36c81a871e0c859a6b1
-//              (26bfe05, 2026-08-31)
-//   spec     : SPEC_VERSION 2.0
+//   commit   : 4c9d4cf12fce59641a18c716ea6e6e5c01e9e701
+//              (4c9d4cf, 2026-08-31)
+//   spec     : SPEC_VERSION 6.0
 //
 // Re-sync by copying the file from that repo and updating the three lines
 // above. `make check-vocabulary` fails the build if this copy has drifted
@@ -75,8 +75,27 @@
 //      Fetch upstream and compare BY NAME AND VALUE -- parse both sides, do
 //      not diff the text:
 //
+//      DO NOT fetch the /main/ raw url directly. raw.githubusercontent.com serves
+//      branch urls from a CDN that is only EVENTUALLY consistent with the branch,
+//      so a check running shortly after an upstream push compares against the
+//      PREVIOUS version, finds no difference, and reports a clean bill of health.
+//      That window is precisely when a drift check matters most, and the failure
+//      is in the reassuring direction, which is the direction nobody re-checks.
+//      (Found by duckdb_markdown, whose check reported "in sync" against a copy
+//      two spec versions old; it only surfaced because a human said otherwise.)
+//
+//      Resolve the branch to a commit sha first, then fetch the SHA-PINNED url,
+//      which is immutable and therefore cannot be stale:
+//
+//        https://api.github.com/repos/teaguesterling/duckdb_duck_block_utils/commits/main
 //        https://raw.githubusercontent.com/teaguesterling/
-//          duckdb_duck_block_utils/main/src/include/duck_block_vocabulary.hpp
+//          duckdb_duck_block_utils/<sha>/src/include/duck_block_vocabulary.hpp
+//
+//      Print the sha alongside the verdict, so the output says what it actually
+//      compared against. And when the sha lookup fails -- rate limit, outage,
+//      offline -- falling back to the branch url is fine, but that path must NEVER
+//      print OK: "no drift seen" from a copy you could not date is not a clean
+//      bill of health, and reporting it as one is the same defect again.
 //
 //      A plain `diff` over this file fires on comment edits and cosmetic churn
 //      -- commit 3957f36 rewrote every idx_t to uint64_t and changed no name
@@ -105,7 +124,9 @@
 //
 //        SELECT duck_block_type_names();   -- every element_type
 //        SELECT duck_block_kind_names();   -- ['block','inline','value']
-//        SELECT duck_block_spec_version(); -- compare against SPEC_VERSION here
+//        SELECT duck_block_spec_version(); -- major equality + minor floor;
+//                                          see SPEC_VERSION below for why not
+//                                          plain equality
 //
 // (2) catches a stale copy; (3) catches a stale INSTALL. They fail differently
 // and neither subsumes the other.
@@ -167,15 +188,93 @@ struct DuckBlockVocabulary {
 	// attributes['key'], which is what keeps it out of a document's Pandoc `meta`.
 	static constexpr const char *VALUE_VERSION = "version";
 
-	// The duck_block spec version this build implements. Bump when the vocabulary
-	// changes in a way a consumer could observe.
-	static constexpr const char *SPEC_VERSION = "2.0";
+	// The duck_block spec version this build implements, as MAJOR.MINOR.
+	//
+	//   MAJOR bumps for a BREAKING change -- a shape or vocabulary change that a
+	//         conforming consumer must migrate for.
+	//   MINOR bumps for an ADDITIVE one -- new types or attributes that existing
+	//         consumers can ignore.
+	//
+	// ASSERT MAJOR EQUALITY AND A MINOR FLOOR, not equality on the whole string.
+	// Equality goes red on every release including ones that cannot affect you,
+	// and a check that cries wolf gets muted:
+	//
+	//     major(duck_block_spec_version()) == 2   AND   minor(...) >= <what you need>
+	//
+	// (Asked by panduck, who noticed the guidance said "compare against
+	// SPEC_VERSION" without saying compare HOW, and whose readers are untouched by
+	// 2.0 apart from lists.)
+	//
+	// HONEST HISTORY, because the numbers only mean something if they were applied
+	// consistently and one of these was not:
+	//
+	//   1.1 -> 1.2  list and blockquote became structural. BREAKING -- it broke
+	//               duckdb_markdown's writer in three places. It should have been
+	//               2.0 and the minor bump was wrong. A consumer pinning "major 1"
+	//               would have been broken by a release the numbering promised was
+	//               safe.
+	//   1.2 -> 2.0  one shape per BLOCK element_type. Breaking, numbered correctly.
+	//   2.0 -> 3.0  every element carries an EXPLICIT level; no NULLs, one scale for
+	//               blocks and inlines, and `level` is never semantic. Breaking.
+	//               The NULL-at-top-level convention 1.x and 2.0 documented was
+	//               never approved -- see docs/duck_blocks_spec.md.
+	//   3.0 -> 4.0  `plain` added: Pandoc's Plain constructor, which this reader had
+	//               been collapsing onto `paragraph`, losing the tight vs loose list
+	//               distinction. BREAKING by this contract's own rule -- a consumer
+	//               rendering `paragraph` now receives `plain` for a tight list item
+	//               -- so a MAJOR bump even though the vocabulary change is additive.
+	//               Also makes `list_type` canonical, `ordered` a legacy alias.
+	//   4.0 -> 5.0  `table` emits the NATIVE {headers,rows} schema, with the full
+	//               Pandoc tuple preserved in attributes['pandoc_ast'] so nothing is
+	//               lost; definition lists become `list` with list_type='definition'
+	//               rather than the opaque `deflist`. Both previously serialised
+	//               structure into a field consumers read verbatim: tables rendered
+	//               as NOTHING and deflists rendered their own AST, and both poisoned
+	//               search. Breaking -- a consumer parsing either JSON must migrate.
+	//
+	//   5.0 -> 6.0  `plain` is NARROWED to text that has nowhere else to live. A
+	//               container whose only child is a text run carries that text in its
+	//               own `content` -- v1's content rule, unchanged since v1.0 -- so
+	//               `<li>text</li>` is `list_item(content='text')`, not
+	//               `list_item > plain('text')`. 5.0 shipped the second, which meant a
+	//               container with a single text child had TWO legal shapes depending
+	//               on which producer built it, and removing that ambiguity is the
+	//               thing every version since 2.0 has been for.
+	//
+	//               `plain` still exists and is still required, in exactly two places:
+	//                 * beside block siblings -- `section > plain('Lead') + heading`,
+	//                   where the container's content cannot hold the run because the
+	//                   run is not the only child;
+	//                 * at the TOP LEVEL, where the document root has no content field.
+	//
+	//               Tight-vs-loose list items are NOT lost by this and need no
+	//               attribute: content on the item is Pandoc's `Plain` (tight), a
+	//               `paragraph` child is `Para` (loose). Measured on the exporter
+	//               before the change, not assumed.
+	//
+	//               Breaking for a consumer that walks for a `plain` child; a consumer
+	//               that already read the container's `content` -- which the rule has
+	//               required since v1 -- needs no change.
+	//
+	// The rule above is what will be followed from here.
+	static constexpr const char *SPEC_VERSION = "6.0";
 
 	// ========================================================================
 	// Block type names
 	// ========================================================================
 	static constexpr const char *TYPE_HEADING = "heading";
 	static constexpr const char *TYPE_PARAGRAPH = "paragraph";
+	// A block-level text run with NO paragraph semantics -- Pandoc's `Plain`, and
+	// HTML text that is not wrapped in a <p>: `<li>text</li>`, `<td>text</td>`,
+	// `<dd>text</dd>`, `<figcaption>text</figcaption>`.
+	//
+	// This existed in Pandoc all along and this reader collapsed it onto
+	// `paragraph`, which is how the TIGHT vs LOOSE list distinction was being lost
+	// -- and lost independently in webbed, by a different mechanism, with neither
+	// reader aware. Modelling it as its own type rather than an attribute keeps the
+	// mapping honest: it is a constructor we were failing to represent, not a
+	// variation we were failing to annotate.
+	static constexpr const char *TYPE_PLAIN = "plain";
 	static constexpr const char *TYPE_CODE = "code";
 	static constexpr const char *TYPE_BLOCKQUOTE = "blockquote";
 	static constexpr const char *TYPE_LIST = "list";

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -1,25 +1,5 @@
 #pragma once
 
-// ---------------------------------------------------------------------------
-// VENDORED COPY -- do not edit. Any change here is drift, by definition.
-//
-//   upstream : teaguesterling/duckdb_duck_block_utils
-//              src/include/duck_block_vocabulary.hpp
-//   commit   : 010f36f4d4a577bb0970a208e2c4d6a7386ceff9
-//              (010f36f, 2026-08-31)
-//   spec     : SPEC_VERSION 6.1
-//
-// Re-sync by copying the file from that repo and updating the three lines
-// above. `make check-vocabulary` fails the build if this copy has drifted
-// from upstream by a renamed, removed, or VALUE-CHANGED constant -- a value
-// change compiles clean and is invisible to C++, which is why the check is
-// not optional. See scripts/check_duck_block_vocabulary.py.
-//
-// Vendored rather than submoduled deliberately: duck_block_utils carries its
-// own duckdb submodule, and the extension CI templates check out recursively,
-// so a pin drags a nested DuckDB clone into CI to deliver this one file.
-// ---------------------------------------------------------------------------
-
 // ============================================================================
 // The duck_block vocabulary -- PUBLISHED INTERFACE.
 //
@@ -269,8 +249,27 @@ struct DuckBlockVocabulary {
 	//               that drift. Nothing is removed or renamed -- a consumer on 6.0 is
 	//               unaffected.
 	//
+	//   6.1 -> 6.2  ADDITIVE, three clarifications that were load-bearing and unstated.
+	//               `metadata` gains attributes['role'], with 'frontmatter' declared --
+	//               one type plus a role rather than minting `frontmatter` as its own
+	//               element_type, which is this vocabulary's own rule applied to a case
+	//               three producers had each guessed differently.
+	//
+	//               Value elements after the blocks is now a CONTRACT, not the
+	//               "convenience" the spec called it: two producers asked where they go,
+	//               which is a question a convenience cannot answer. With it, the rule
+	//               that a consumer must end an inline run at any NON-INLINE element --
+	//               getting that wrong made this repo's exporter emit a document whose
+	//               body had been replaced by its title.
+	//
+	//               A document with NO blocks -- a .toml file read as pure metadata --
+	//               is conformant, and stated rather than left to be inferred from
+	//               nothing objecting.
+	//
+	//               Nothing renamed, nothing removed; a consumer on 6.1 is unaffected.
+	//
 	// The rule above is what will be followed from here.
-	static constexpr const char *SPEC_VERSION = "6.1";
+	static constexpr const char *SPEC_VERSION = "6.2";
 
 	// ========================================================================
 	// Block type names

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -5,9 +5,9 @@
 //
 //   upstream : teaguesterling/duckdb_duck_block_utils
 //              src/include/duck_block_vocabulary.hpp
-//   commit   : 4c9d4cf12fce59641a18c716ea6e6e5c01e9e701
-//              (4c9d4cf, 2026-08-31)
-//   spec     : SPEC_VERSION 6.0
+//   commit   : 010f36f4d4a577bb0970a208e2c4d6a7386ceff9
+//              (010f36f, 2026-08-31)
+//   spec     : SPEC_VERSION 6.1
 //
 // Re-sync by copying the file from that repo and updating the three lines
 // above. `make check-vocabulary` fails the build if this copy has drifted
@@ -256,8 +256,21 @@ struct DuckBlockVocabulary {
 	//               that already read the container's `content` -- which the rule has
 	//               required since v1 -- needs no change.
 	//
+	//   6.0 -> 6.1  ADDITIVE. `duck_blocks_normalize(blocks)` applies 6.0's content
+	//               rule to a finished block vector, so a producer can emit the naive
+	//               shape and fix it up afterwards instead of implementing the rule.
+	//
+	//               Needed because the rule is SIBLING-DEPENDENT: whether a text run
+	//               becomes its container's content or stays a `plain` depends on what
+	//               FOLLOWS it, which a streaming reader does not know when it reaches
+	//               the run. Raised by the panduck session, whose EPUB and LaTeX
+	//               readers both emit as they walk; it is true of any streaming reader
+	//               of any format, so the answer should not be four private lookaheads
+	//               that drift. Nothing is removed or renamed -- a consumer on 6.0 is
+	//               unaffected.
+	//
 	// The rule above is what will be followed from here.
-	static constexpr const char *SPEC_VERSION = "6.0";
+	static constexpr const char *SPEC_VERSION = "6.1";
 
 	// ========================================================================
 	// Block type names

--- a/src/include/markdown_copy.hpp
+++ b/src/include/markdown_copy.hpp
@@ -79,8 +79,12 @@ struct WriteMarkdownGlobalState : public GlobalFunctionData {
 struct WriteMarkdownLocalState : public LocalFunctionData {
 	//! Local buffer for accumulating output
 	string buffer;
-	//! Track if the last element was inline (for proper block/inline transitions)
-	bool last_was_inline = false;
+	//! Blocks mode: the elements seen so far, rendered as ONE list in Combine.
+	//! Not rendered per row: a block absorbs the inline run that follows it, and
+	//! a row-at-a-time renderer has already emitted the block's trailing newlines
+	//! before it can see whether inlines follow. Accumulating across the local
+	//! state also keeps a run intact when it spans two DataChunks.
+	vector<Value> elements;
 };
 
 //===--------------------------------------------------------------------===//
@@ -149,23 +153,11 @@ private:
 	                            const WriteMarkdownBindData &bind_data);
 
 	//===--------------------------------------------------------------------===//
-	// Blocks Mode Helpers
-	//===--------------------------------------------------------------------===//
-
-	//! Render a single element from flattened duck_block representation
-	//! Dispatches to RenderBlockElement or RenderInlineElement based on kind
-	static string RenderElement(const string &kind, const string &element_type, const string &content, int32_t level,
-	                            const string &encoding, const Value &attributes,
-	                            const WriteMarkdownBindData &bind_data);
-
-	//! Render a block element (with trailing newlines)
-	static string RenderBlockElement(const string &element_type, const string &content, int32_t level,
-	                                 const string &encoding, const Value &attributes,
-	                                 const WriteMarkdownBindData &bind_data);
-
-	//! Render an inline element (no trailing newlines)
-	static string RenderInlineElement(const string &element_type, const string &content, const Value &attributes,
-	                                  const WriteMarkdownBindData &bind_data);
+	// Blocks Mode
+	//
+	// No render helpers here: blocks mode uses the SHARED duck_block renderer
+	// (DuckBlockFunctions::RenderDuckBlocksToMarkdown), called once per local
+	// state in Combine. Sink only rebuilds each row into a duck_block struct.
 };
 
 } // namespace duckdb

--- a/src/include/markdown_utils.hpp
+++ b/src/include/markdown_utils.hpp
@@ -124,11 +124,16 @@ std::string ExtractSection(const std::string &markdown_str, const std::string &s
 //===--------------------------------------------------------------------===//
 
 struct MarkdownBlock {
-	std::string kind = "block"; // 'block' or 'inline' (structured inline children)
-	std::string block_type;     // heading, paragraph, code, blockquote, list, table, image, hr, html, raw, frontmatter
-	std::string content;        // Primary content ("" for containers with structured children)
-	int32_t level;              // Heading level (1-6), nesting depth, or 0
-	std::string encoding;       // text, json, yaml, base64
+	// 'block' or 'inline' (structured inline children). These are the only two
+	// this reader produces; the vocabulary's third kind, 'value', carries
+	// document metadata and has no emission path here. Not a definition of the
+	// valid set -- a writer that treats "not inline" as "block" renders metadata
+	// as body prose, which is what that reading cost this extension.
+	std::string kind = "block";
+	std::string block_type; // heading, paragraph, code, blockquote, list, table, image, hr, html, raw, frontmatter
+	std::string content;    // Primary content ("" for containers with structured children)
+	int32_t level;          // Heading level (1-6), nesting depth, or 0
+	std::string encoding;   // text, json, yaml, base64
 	std::map<std::string, std::string> attributes; // language, id, class, etc.
 	int32_t block_order;                           // Optional ordering for table storage
 };

--- a/src/markdown_copy.cpp
+++ b/src/markdown_copy.cpp
@@ -1,4 +1,5 @@
 #include "markdown_copy.hpp"
+#include "duck_block_vocabulary.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -6,6 +7,8 @@
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 
 namespace duckdb {
+
+using Vocab = DuckBlockVocabulary;
 
 //===--------------------------------------------------------------------===//
 // WriteMarkdownBindData
@@ -667,7 +670,7 @@ string MarkdownCopyFunction::RenderBlockElement(const string &element_type, cons
 		// ATX heading with level
 		// Per spec: heading_level attribute takes priority, fall back to level field
 		int32_t heading_level = 1;
-		string heading_level_attr = GetAttribute(attributes, "heading_level");
+		string heading_level_attr = GetAttribute(attributes, Vocab::ATTR_HEADING_LEVEL);
 		if (!heading_level_attr.empty()) {
 			try {
 				heading_level = std::stoi(heading_level_attr);

--- a/src/markdown_copy.cpp
+++ b/src/markdown_copy.cpp
@@ -1,5 +1,7 @@
 #include "markdown_copy.hpp"
 #include "duck_block_vocabulary.hpp"
+#include "duck_block_functions.hpp"
+#include "markdown_types.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -322,17 +324,19 @@ void MarkdownCopyFunction::Sink(ExecutionContext &context, FunctionData &bind_da
 				content = content_val.ToString();
 			}
 
-			// Get level (optional)
-			int32_t level = -1;
+			// Get level (optional). NULL is PRESERVED rather than defaulted: the
+			// shared renderer reads an absent level as the top level, and a
+			// sentinel like -1 would be read as a real depth and compare wrong.
+			Value level = Value(LogicalType::INTEGER);
 			if (bind_data.level_col_idx != DConstants::INVALID_INDEX) {
 				auto level_val = input.data[bind_data.level_col_idx].GetValue(row_idx);
 				if (!level_val.IsNull()) {
-					level = level_val.GetValue<int32_t>();
+					level = Value::INTEGER(level_val.GetValue<int32_t>());
 				}
 			}
 
 			// Get encoding (optional)
-			string encoding = "text";
+			string encoding = Vocab::ENCODING_TEXT;
 			if (bind_data.encoding_col_idx != DConstants::INVALID_INDEX) {
 				auto encoding_val = input.data[bind_data.encoding_col_idx].GetValue(row_idx);
 				if (!encoding_val.IsNull()) {
@@ -340,25 +344,29 @@ void MarkdownCopyFunction::Sink(ExecutionContext &context, FunctionData &bind_da
 				}
 			}
 
-			// Get attributes (optional)
-			Value attributes;
+			// Get attributes (optional). TYPED null when absent -- an untyped one
+			// makes the struct's type differ row to row, and the list below would
+			// then fail to build rather than degrade.
+			Value attributes = Value(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
 			if (bind_data.attributes_col_idx != DConstants::INVALID_INDEX) {
-				attributes = input.data[bind_data.attributes_col_idx].GetValue(row_idx);
+				auto attributes_val = input.data[bind_data.attributes_col_idx].GetValue(row_idx);
+				if (!attributes_val.IsNull()) {
+					attributes = attributes_val;
+				}
 			}
 
-			// Determine if this element is inline
-			bool is_inline = (kind == "inline");
-
-			// Handle transitions between inline and block elements
-			if (lstate.last_was_inline && !is_inline) {
-				// Transitioning from inline to block: add paragraph break
-				lstate.buffer += "\n\n";
-			}
-
-			lstate.buffer += RenderElement(kind, element_type, content, level, encoding, attributes, bind_data);
-
-			// Track state for next element
-			lstate.last_was_inline = is_inline;
+			// Rebuild the duck_block and hand it to the SHARED renderer in Combine.
+			// element_order is NULL because this mode never bound the column: order
+			// here is row order, which is what the renderer's walk uses anyway.
+			child_list_t<Value> fields;
+			fields.emplace_back("kind", Value(kind));
+			fields.emplace_back("element_type", Value(element_type));
+			fields.emplace_back("content", Value(content));
+			fields.emplace_back("level", level);
+			fields.emplace_back("encoding", Value(encoding));
+			fields.emplace_back("attributes", attributes);
+			fields.emplace_back("element_order", Value(LogicalType::INTEGER));
+			lstate.elements.push_back(Value::STRUCT(std::move(fields)));
 		}
 	}
 }
@@ -372,6 +380,16 @@ void MarkdownCopyFunction::Combine(ExecutionContext &context, FunctionData &bind
 	auto &bind_data = bind_data_p.Cast<WriteMarkdownBindData>();
 	auto &gstate = gstate_p.Cast<WriteMarkdownGlobalState>();
 	auto &lstate = lstate_p.Cast<WriteMarkdownLocalState>();
+
+	if (!lstate.elements.empty()) {
+		// ONE renderer for duck_blocks, shared with duck_blocks_to_md. This path
+		// used to have its own row-at-a-time walk, which could not absorb inline
+		// runs and rendered `# H` + empty paragraph + inlines with two spurious
+		// blank lines between heading and body.
+		lstate.buffer += DuckBlockFunctions::RenderDuckBlocksToMarkdown(
+		    Value::LIST(MarkdownTypes::DuckBlockType(), std::move(lstate.elements)));
+		lstate.elements.clear();
+	}
 
 	if (lstate.buffer.empty()) {
 		return;
@@ -556,370 +574,18 @@ string MarkdownCopyFunction::RenderSection(int32_t level, const string &title, c
 	return result;
 }
 
-//===--------------------------------------------------------------------===//
-// Blocks Mode Helpers
-//===--------------------------------------------------------------------===//
-
-// Helper to get attribute from MAP value
-static string GetAttribute(const Value &attributes, const string &key) {
-	if (attributes.IsNull() || attributes.type().id() != LogicalTypeId::MAP) {
-		return "";
-	}
-	auto &map_children = MapValue::GetChildren(attributes);
-	for (const auto &entry : map_children) {
-		auto &entry_children = StructValue::GetChildren(entry);
-		if (entry_children.size() == 2 && !entry_children[0].IsNull()) {
-			if (entry_children[0].ToString() == key && !entry_children[1].IsNull()) {
-				return entry_children[1].ToString();
-			}
-		}
-	}
-	return "";
-}
-
-string MarkdownCopyFunction::RenderInlineElement(const string &element_type, const string &content,
-                                                 const Value &attributes, const WriteMarkdownBindData &bind_data) {
-	// Inline elements render WITHOUT trailing newlines
-	if (element_type == "link") {
-		// [text](href "title")
-		string href = GetAttribute(attributes, "href");
-		string title = GetAttribute(attributes, "title");
-		string result = "[" + content + "](" + href;
-		if (!title.empty()) {
-			result += " \"" + title + "\"";
-		}
-		result += ")";
-		return result;
-	} else if (element_type == "image") {
-		// ![alt](src "title")
-		string src = GetAttribute(attributes, "src");
-		string title = GetAttribute(attributes, "title");
-		string result = "![" + content + "](" + src;
-		if (!title.empty()) {
-			result += " \"" + title + "\"";
-		}
-		result += ")";
-		return result;
-	} else if (element_type == "bold" || element_type == "strong") {
-		return "**" + content + "**";
-	} else if (element_type == "italic" || element_type == "emphasis" || element_type == "em") {
-		return "*" + content + "*";
-	} else if (element_type == "code") {
-		// Handle content containing backticks
-		if (content.find('`') != string::npos) {
-			return "`` " + content + " ``";
-		}
-		return "`" + content + "`";
-	} else if (element_type == "text") {
-		return content;
-	} else if (element_type == "space") {
-		return " ";
-	} else if (element_type == "softbreak") {
-		return "\n";
-	} else if (element_type == "linebreak" || element_type == "br") {
-		return "  \n";
-	} else if (element_type == "strikethrough" || element_type == "del") {
-		return "~~" + content + "~~";
-	} else if (element_type == "superscript" || element_type == "sup") {
-		return "^" + content + "^";
-	} else if (element_type == "subscript" || element_type == "sub") {
-		return "~" + content + "~";
-	} else if (element_type == "underline") {
-		return "<u>" + content + "</u>";
-	} else if (element_type == "smallcaps") {
-		return "<span style=\"font-variant: small-caps\">" + content + "</span>";
-	} else if (element_type == "math") {
-		string display = GetAttribute(attributes, "display");
-		if (display == "block") {
-			return "$$" + content + "$$";
-		}
-		return "$" + content + "$";
-	} else if (element_type == "raw") {
-		return content;
-	} else if (element_type == "quoted") {
-		string quote_type = GetAttribute(attributes, "quote_type");
-		if (quote_type == "single") {
-			return "'" + content + "'";
-		}
-		return "\"" + content + "\"";
-	} else if (element_type == "cite") {
-		string key = GetAttribute(attributes, "key");
-		if (!key.empty()) {
-			return "[@" + key + "]";
-		}
-		return content;
-	} else if (element_type == "note") {
-		return "[^" + content + "]";
-	} else if (element_type == "span") {
-		return content;
-	} else {
-		// Unknown inline type - output as plain text
-		return content;
-	}
-}
-
-string MarkdownCopyFunction::RenderBlockElement(const string &element_type, const string &content, int32_t level,
-                                                const string &encoding, const Value &attributes,
-                                                const WriteMarkdownBindData &bind_data) {
-	string result;
-
-	if (element_type == "frontmatter" || element_type == "metadata") {
-		// YAML frontmatter
-		result = "---\n" + content + "\n---\n\n";
-	} else if (element_type == "heading") {
-		// ATX heading with level
-		// Per spec: heading_level attribute takes priority, fall back to level field
-		int32_t heading_level = 1;
-		string heading_level_attr = GetAttribute(attributes, Vocab::ATTR_HEADING_LEVEL);
-		if (!heading_level_attr.empty()) {
-			try {
-				heading_level = std::stoi(heading_level_attr);
-			} catch (...) {
-				heading_level = 1;
-			}
-		} else if (level > 0 && level <= 6) {
-			heading_level = level;
-		}
-		// Clamp to valid range
-		if (heading_level < 1)
-			heading_level = 1;
-		if (heading_level > 6)
-			heading_level = 6;
-		result = string(heading_level, '#') + " " + content + "\n\n";
-	} else if (element_type == "paragraph") {
-		// Plain paragraph
-		result = content + "\n\n";
-	} else if (element_type == "code") {
-		// Fenced code block
-		string language = GetAttribute(attributes, "language");
-		result = "```" + language + "\n" + content + "\n```\n\n";
-	} else if (element_type == "blockquote") {
-		// Block quote - add > prefix to each line
-		string quoted;
-		std::istringstream iss(content);
-		std::string line;
-		while (std::getline(iss, line)) {
-			quoted += "> " + line + "\n";
-		}
-		result = quoted + "\n";
-	} else if (element_type == "list") {
-		// List - content is JSON encoded, need to decode
-		// For now, output as-is if not JSON or parse if JSON
-		if (encoding == "json" && content.length() > 2 && content[0] == '[') {
-			// Simple JSON array parsing for list items
-			// Format: ["item1", "item2", ...]
-			bool ordered = GetAttribute(attributes, "ordered") == "true";
-			int start = 1;
-			string start_str = GetAttribute(attributes, "start");
-			if (!start_str.empty()) {
-				try {
-					start = std::stoi(start_str);
-				} catch (...) {
-				}
-			}
-
-			// Parse JSON array (simple implementation)
-			string items_str = content.substr(1, content.length() - 2); // Remove [ ]
-			vector<string> items;
-			string current_item;
-			bool in_string = false;
-			bool escape_next = false;
-
-			for (size_t i = 0; i < items_str.length(); i++) {
-				char c = items_str[i];
-				if (escape_next) {
-					if (c == 'n')
-						current_item += '\n';
-					else if (c == 't')
-						current_item += '\t';
-					else if (c == 'r')
-						current_item += '\r';
-					else
-						current_item += c;
-					escape_next = false;
-				} else if (c == '\\') {
-					escape_next = true;
-				} else if (c == '"') {
-					if (in_string) {
-						items.push_back(current_item);
-						current_item.clear();
-					}
-					in_string = !in_string;
-				} else if (in_string) {
-					current_item += c;
-				}
-			}
-
-			// Render list items
-			int item_num = start;
-			for (const auto &item : items) {
-				if (ordered) {
-					result += std::to_string(item_num++) + ". " + item + "\n";
-				} else {
-					result += "- " + item + "\n";
-				}
-			}
-			result += "\n";
-		} else {
-			// Fallback: output content directly
-			result = content + "\n\n";
-		}
-	} else if (element_type == "table") {
-		// Table - content is JSON encoded as {"headers": [...], "rows": [[...], ...]}
-		if (encoding == "json" && content.find("\"headers\"") != string::npos) {
-			// Parse JSON table format
-			vector<string> headers;
-			vector<vector<string>> rows;
-
-			// Simple JSON parsing for table structure
-			// Find headers array
-			size_t headers_start = content.find("\"headers\":");
-			if (headers_start != string::npos) {
-				size_t arr_start = content.find('[', headers_start);
-				size_t arr_end = content.find(']', arr_start);
-				if (arr_start != string::npos && arr_end != string::npos) {
-					string headers_str = content.substr(arr_start + 1, arr_end - arr_start - 1);
-					// Parse header items
-					bool in_string = false;
-					bool escape_next = false;
-					string current;
-					for (char c : headers_str) {
-						if (escape_next) {
-							current += c;
-							escape_next = false;
-						} else if (c == '\\') {
-							escape_next = true;
-						} else if (c == '"') {
-							if (in_string) {
-								headers.push_back(current);
-								current.clear();
-							}
-							in_string = !in_string;
-						} else if (in_string) {
-							current += c;
-						}
-					}
-				}
-			}
-
-			// Find rows array
-			size_t rows_start = content.find("\"rows\":");
-			if (rows_start != string::npos) {
-				size_t outer_start = content.find('[', rows_start);
-				if (outer_start != string::npos) {
-					// Parse each row
-					size_t pos = outer_start + 1;
-					while (pos < content.size()) {
-						size_t row_start = content.find('[', pos);
-						if (row_start == string::npos)
-							break;
-						size_t row_end = content.find(']', row_start);
-						if (row_end == string::npos)
-							break;
-
-						string row_str = content.substr(row_start + 1, row_end - row_start - 1);
-						vector<string> row;
-						bool in_string = false;
-						bool escape_next = false;
-						string current;
-						for (char c : row_str) {
-							if (escape_next) {
-								current += c;
-								escape_next = false;
-							} else if (c == '\\') {
-								escape_next = true;
-							} else if (c == '"') {
-								if (in_string) {
-									row.push_back(current);
-									current.clear();
-								}
-								in_string = !in_string;
-							} else if (in_string) {
-								current += c;
-							}
-						}
-						if (!row.empty()) {
-							rows.push_back(row);
-						}
-						pos = row_end + 1;
-					}
-				}
-			}
-
-			// Render as markdown table
-			if (!headers.empty()) {
-				result = "|";
-				for (const auto &h : headers) {
-					result += " " + h + " |";
-				}
-				result += "\n|";
-				for (size_t i = 0; i < headers.size(); i++) {
-					result += "---|";
-				}
-				result += "\n";
-				for (const auto &row : rows) {
-					result += "|";
-					for (const auto &cell : row) {
-						result += " " + cell + " |";
-					}
-					result += "\n";
-				}
-				result += "\n";
-			} else {
-				result = content + "\n\n";
-			}
-		} else {
-			result = content + "\n\n";
-		}
-	} else if (element_type == "hr") {
-		// Horizontal rule
-		result = "---\n\n";
-	} else if (element_type == "image") {
-		// Image: ![alt](src "title")
-		string src = GetAttribute(attributes, "src");
-		string alt = GetAttribute(attributes, "alt");
-		// Fall back to content as alt text if alt attribute is empty
-		if (alt.empty() && !content.empty()) {
-			alt = content;
-		}
-		string title = GetAttribute(attributes, "title");
-		result = "![" + alt + "](" + src;
-		if (!title.empty()) {
-			result += " \"" + title + "\"";
-		}
-		result += ")\n\n";
-	} else if (element_type == "html" || element_type == "raw" || element_type == "md:html_block") {
-		// Raw HTML
-		result = content + "\n\n";
-	} else {
-		// Unknown block type - output content as-is
-		result = content + "\n\n";
-	}
-
-	return result;
-}
-
-string MarkdownCopyFunction::RenderElement(const string &kind, const string &element_type, const string &content,
-                                           int32_t level, const string &encoding, const Value &attributes,
-                                           const WriteMarkdownBindData &bind_data) {
-	if (kind == "inline") {
-		// Inline elements render without trailing newlines
-		return RenderInlineElement(element_type, content, attributes, bind_data);
-	} else if (kind == "block") {
-		// Block elements render with trailing newlines
-		return RenderBlockElement(element_type, content, level, encoding, attributes, bind_data);
-	} else {
-		// Unknown kind - try to guess based on element_type
-		// Block types
-		if (element_type == "heading" || element_type == "paragraph" || element_type == "blockquote" ||
-		    element_type == "list" || element_type == "table" || element_type == "hr" || element_type == "metadata" ||
-		    element_type == "frontmatter" || element_type == "code" || element_type == "image" ||
-		    element_type == "raw" || element_type == "html" || element_type == "md:html_block") {
-			return RenderBlockElement(element_type, content, level, encoding, attributes, bind_data);
-		}
-		// Assume inline otherwise
-		return RenderInlineElement(element_type, content, attributes, bind_data);
-	}
-}
+// The blocks-mode renderer that lived here -- RenderInlineElement,
+// RenderBlockElement and RenderElement, ~340 lines -- is GONE. It was a second
+// implementation of duck_block rendering, and it had drifted: rendering one
+// element at a time, it could not absorb a block's inline run, so a paragraph
+// with NULL content and its inline children came out as separate blocks with
+// spurious blank lines between them. Sink now rebuilds the duck_block and
+// Combine calls DuckBlockFunctions::RenderDuckBlocksToMarkdown -- the same
+// renderer duck_blocks_to_md uses.
+//
+// Worth recording what deleting it FOUND: routing this path through the shared
+// renderer immediately failed a test this path had always passed, because the
+// shared renderer deleted the inline run after an `hr`. Two renderers meant each
+// bug was invisible to the tests that would have caught it in the other.
 
 } // namespace duckdb

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1298,9 +1298,18 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 			block.encoding = "json";
 
 			cmark_list_type list_type = cmark_node_get_list_type(child);
-			block.attributes["ordered"] = (list_type == CMARK_ORDERED_LIST) ? "true" : "false";
+			const bool is_ordered = (list_type == CMARK_ORDERED_LIST);
+			// BOTH, canonical first. `list_type` is the vocabulary attribute;
+			// `ordered` is the legacy boolean the spec says producers should keep
+			// emitting because data written before the rule does not rewrite
+			// itself. Until now this reader emitted ONLY the legacy one, so a
+			// consumer reading just the canonical attribute -- which is what new
+			// code and this repo's own writer read first -- saw an untyped list
+			// and worked only by falling back.
+			block.attributes[Vocab::ATTR_LIST_TYPE] = is_ordered ? Vocab::LIST_TYPE_ORDERED : Vocab::LIST_TYPE_BULLET;
+			block.attributes[Vocab::ATTR_ORDERED_LEGACY] = is_ordered ? "true" : "false";
 
-			if (list_type == CMARK_ORDERED_LIST) {
+			if (is_ordered) {
 				int start = cmark_node_get_list_start(child);
 				block.attributes["start"] = std::to_string(start);
 			}

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1107,34 +1107,29 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 	auto fm_match = FindFrontmatter(markdown_str);
 	std::string frontmatter = fm_match.found ? markdown_str.substr(fm_match.body_start, fm_match.body_len) : "";
 	if (!frontmatter.empty()) {
-		// OPEN. Which level a duck_block frontmatter row should carry.
+		// LEVEL 1, ruled by duck_block_utils at 2771e9e (they coordinate the spec;
+		// Teague routed the question there). `level` is depth, and 1 means NOT
+		// NESTED -- it is not a claim of depth inside something. A frontmatter blob
+		// sits at the top level of its document exactly as the first paragraph
+		// does, so 1 is what it shares with every other top-level element. There is
+		// nothing shallower than the top, so 0 has no referent, and the validator
+		// rejects it.
 		//
-		// MEASURED 2026-09-01, duck_block spec 6.1, and the answer moved twice
-		// while this note was being written -- which is why it records the
-		// measurements rather than a conclusion.
+		// This was held open as a breaking change to documented public API. That
+		// turned out to be wrong, and it is worth recording why so it is not
+		// re-litigated. MEASURED 2026-09-01, all three supposed dependents:
 		//
-		//   this reader                      level 0
-		//   duck_blocks_validate             rejects it: "level 0 is below 1"
-		//   duck_block_metadata(), earlier   level 0   <- what this matched
-		//   duck_block_metadata(), now       level 1   <- upstream fixed its
-		//                                                 builder (1c69c2f)
+		//   read_markdown_sections   level 0-6 is heading RANK, a DIFFERENT column
+		//                            on a different function -- unaffected, still 0
+		//   COPY document mode       "level = 0 as frontmatter" is that mode's own
+		//                            convention over (level, title, content)
+		//   duck_block writer        keys on element_type, not level: `metadata`
+		//                            renders as frontmatter at 0 and at 1 alike
 		//
-		// So level 0 was not invention here: it agreed with the registered
-		// builder of the repo that owns the format, whose own validator rejected
-		// it, and whose spec table documented the bug accurately. That half is
-		// theirs and is fixed. What remains is genuinely this extension's
-		// question.
-		//
-		// This extension's SECTION convention uses 0 for frontmatter and 1-6 for
-		// headings. It is correct, documented, and load-bearing: README.md's
-		// COPY TO example renders a level-0 row as a frontmatter block, verified
-		// by running it verbatim. The duck_block convention is structural depth,
-		// minimum 1. Making read_markdown_blocks emit 1 is a breaking change to
-		// a documented public API, so it is a decision rather than a defect to
-		// patch at the point of emission.
-		//
-		// The type name is SETTLED as of spec 6.2: `metadata` + role='frontmatter'.
-		// What remains open here is the LEVEL alone.
+		// So nothing documented reads this column's 0. The block reader's `level`
+		// was ALREADY pure depth -- every top-level element carries 1 and heading
+		// rank lives in attributes['heading_level'] -- and frontmatter was the one
+		// row that disagreed with its own column.
 		MarkdownBlock fm_block;
 		// `metadata` + role='frontmatter', declared in spec 6.2. `frontmatter` was
 		// never a vocabulary type -- one type plus a role attribute is the spec's
@@ -1145,7 +1140,7 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		fm_block.block_type = Vocab::TYPE_METADATA;
 		fm_block.attributes[Vocab::ATTR_ROLE] = Vocab::ROLE_FRONTMATTER;
 		fm_block.content = frontmatter;
-		fm_block.level = 0;
+		fm_block.level = 1;
 		fm_block.encoding = fm_match.delimiter == '+' ? Vocab::ENCODING_TOML : Vocab::ENCODING_YAML;
 		fm_block.block_order = block_order++;
 		blocks.push_back(fm_block);

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1074,29 +1074,36 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 	// Check for frontmatter first
 	std::string frontmatter = ExtractRawFrontmatter(markdown_str);
 	if (!frontmatter.empty()) {
-		// OPEN, MEASURED 2026-09-01 against duck_block spec 6.1. Two level
-		// conventions meet here and disagree.
+		// OPEN. Which level a duck_block frontmatter row should carry.
 		//
-		// This extension's SECTION convention uses level 0 for frontmatter and
-		// 1-6 for headings. That is correct, documented, and load-bearing: the
-		// COPY TO example in README.md renders level 0 as a frontmatter block,
-		// verified by running it verbatim.
+		// MEASURED 2026-09-01, duck_block spec 6.1, and the answer moved twice
+		// while this note was being written -- which is why it records the
+		// measurements rather than a conclusion.
 		//
-		// The duck_block convention is structural DEPTH, minimum 1, since spec
-		// 3.0. So these rows are rejected by the canonical validator:
+		//   this reader                      level 0
+		//   duck_blocks_validate             rejects it: "level 0 is below 1"
+		//   duck_block_metadata(), earlier   level 0   <- what this matched
+		//   duck_block_metadata(), now       level 1   <- upstream fixed its
+		//                                                 builder (1c69c2f)
 		//
-		//   duck_blocks_validate -> {"valid":false,"errors":[{"field":"level",
-		//     "message":"level 0 is below 1; top level is 1"}]}
+		// So level 0 was not invention here: it agreed with the registered
+		// builder of the repo that owns the format, whose own validator rejected
+		// it, and whose spec table documented the bug accurately. That half is
+		// theirs and is fixed. What remains is genuinely this extension's
+		// question.
 		//
-		// Not changed here: `read_markdown_blocks` emitting level 1 instead
-		// would be a breaking change to a documented public API, and the two
-		// conventions are separately correct in their own worlds. What is
-		// unresolved is which one wins where they meet -- that is a decision,
-		// not a defect to quietly patch at the point of emission.
+		// This extension's SECTION convention uses 0 for frontmatter and 1-6 for
+		// headings. It is correct, documented, and load-bearing: README.md's
+		// COPY TO example renders a level-0 row as a frontmatter block, verified
+		// by running it verbatim. The duck_block convention is structural depth,
+		// minimum 1. Making read_markdown_blocks emit 1 is a breaking change to
+		// a documented public API, so it is a decision rather than a defect to
+		// patch at the point of emission.
 		//
-		// `block_type = "frontmatter"` is likewise outside the vocabulary, whose
-		// canonical name is `metadata`. The validator ACCEPTS it, so it is the
-		// lesser of the two.
+		// `block_type = "frontmatter"` is a separate and clearer divergence: the
+		// declared element_type is `metadata`, and `frontmatter` is in no
+		// vocabulary. The validator accepts it, so nothing objects today. Worth
+		// aligning whenever the level question resolves.
 		MarkdownBlock fm_block;
 		fm_block.block_type = "frontmatter";
 		fm_block.content = frontmatter;

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1058,6 +1058,29 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 	// Check for frontmatter first
 	std::string frontmatter = ExtractRawFrontmatter(markdown_str);
 	if (!frontmatter.empty()) {
+		// OPEN, MEASURED 2026-09-01 against duck_block spec 6.1. Two level
+		// conventions meet here and disagree.
+		//
+		// This extension's SECTION convention uses level 0 for frontmatter and
+		// 1-6 for headings. That is correct, documented, and load-bearing: the
+		// COPY TO example in README.md renders level 0 as a frontmatter block,
+		// verified by running it verbatim.
+		//
+		// The duck_block convention is structural DEPTH, minimum 1, since spec
+		// 3.0. So these rows are rejected by the canonical validator:
+		//
+		//   duck_blocks_validate -> {"valid":false,"errors":[{"field":"level",
+		//     "message":"level 0 is below 1; top level is 1"}]}
+		//
+		// Not changed here: `read_markdown_blocks` emitting level 1 instead
+		// would be a breaking change to a documented public API, and the two
+		// conventions are separately correct in their own worlds. What is
+		// unresolved is which one wins where they meet -- that is a decision,
+		// not a defect to quietly patch at the point of emission.
+		//
+		// `block_type = "frontmatter"` is likewise outside the vocabulary, whose
+		// canonical name is `metadata`. The validator ACCEPTS it, so it is the
+		// lesser of the two.
 		MarkdownBlock fm_block;
 		fm_block.block_type = "frontmatter";
 		fm_block.content = frontmatter;

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -33,12 +33,13 @@ namespace markdown_utils {
 // not help. Every scanner below runs in O(n) with bounded stack usage.
 //===--------------------------------------------------------------------===//
 
-// Result of locating a leading YAML-style frontmatter block.
+// Result of locating a leading frontmatter block.
 struct FrontmatterMatch {
 	bool found = false;
 	size_t body_start = 0;  // offset of first byte of the frontmatter body
 	size_t body_len = 0;    // length of the body (delimiters excluded)
-	size_t after_close = 0; // offset just past the closing "---"
+	size_t after_close = 0; // offset just past the closing delimiter
+	char delimiter = '-';   // '-' for YAML (---), '+' for TOML (+++)
 };
 
 // A leading UTF-8 BOM (EF BB BF) is an encoding marker, not content. cmark
@@ -54,15 +55,24 @@ static size_t SkipBOM(const std::string &s) {
 	return 0;
 }
 
-// Faithful linear replacement for R"(^---\r?\n([\s\S]*?)\r?\n---)".
-// Requires the string to begin with "---" then \r?\n, then finds the earliest
-// following "\r?\n---". Returns the body between the delimiters. O(n), no
-// recursion.
-static FrontmatterMatch FindFrontmatter(const std::string &s) {
+// Faithful linear replacement for R"(^(---|\+\+\+)\r?\n([\s\S]*?)\r?\n\1)".
+// Requires the string to begin with the delimiter then \r?\n, then finds the
+// earliest following "\r?\n" + delimiter. Returns the body between them. O(n),
+// no recursion.
+//
+// `+++` is TOML frontmatter, which Hugo emits by default. It was not recognised
+// until 2026-09-01, and the failure was not a missing feature -- it was silent
+// CORRUPTION. Unrecognised, the fence fell through to cmark as ordinary prose,
+// where softbreak-renders-as-space is correct, so a round-trip flattened
+//     +++\ntitle = "x"\ntags = ["a"]\n+++
+// into one line. TOML is line-oriented, so the result is no longer parseable by
+// anything: the fields are not merely misfiled, they are unrecoverable.
+static FrontmatterMatch FindFrontmatterDelimited(const std::string &s, char d) {
 	FrontmatterMatch m;
-	// Opening delimiter: an optional BOM, then "---" then \r?\n
+	m.delimiter = d;
+	// Opening delimiter: an optional BOM, then the fence then \r?\n
 	const size_t b = SkipBOM(s);
-	if (s.size() < b + 4 || s[b] != '-' || s[b + 1] != '-' || s[b + 2] != '-') {
+	if (s.size() < b + 4 || s[b] != d || s[b + 1] != d || s[b + 2] != d) {
 		return m;
 	}
 	size_t p = b + 3;
@@ -75,9 +85,9 @@ static FrontmatterMatch FindFrontmatter(const std::string &s) {
 	p++; // start of body
 	size_t body_start = p;
 
-	// Closing delimiter: earliest '\n' immediately followed by "---".
+	// Closing delimiter: earliest '\n' immediately followed by the same fence.
 	while (p < s.size()) {
-		if (s[p] == '\n' && p + 4 <= s.size() && s[p + 1] == '-' && s[p + 2] == '-' && s[p + 3] == '-') {
+		if (s[p] == '\n' && p + 4 <= s.size() && s[p + 1] == d && s[p + 2] == d && s[p + 3] == d) {
 			size_t body_end = p; // at the '\n'
 			// The delimiter is \r?\n, so drop a trailing '\r' from the body.
 			if (body_end > body_start && s[body_end - 1] == '\r') {
@@ -86,12 +96,22 @@ static FrontmatterMatch FindFrontmatter(const std::string &s) {
 			m.found = true;
 			m.body_start = body_start;
 			m.body_len = body_end - body_start;
-			m.after_close = p + 4; // just past the closing "---"
+			m.after_close = p + 4; // just past the closing fence
 			return m;
 		}
 		p++;
 	}
 	return m;
+}
+
+// YAML first: `---` is by far the common case, and a document cannot open with
+// both fences, so the order is a cost question rather than a precedence one.
+static FrontmatterMatch FindFrontmatter(const std::string &s) {
+	auto m = FindFrontmatterDelimited(s, '-');
+	if (m.found) {
+		return m;
+	}
+	return FindFrontmatterDelimited(s, '+');
 }
 
 // JSON-escape a string per RFC 8259 for `encoding='json'` block content: the named short
@@ -250,13 +270,18 @@ MarkdownMetadata ExtractMetadata(const std::string &markdown_str) {
 	// (see FindFrontmatter) instead of a backtracking std::regex.
 	auto fm = FindFrontmatter(markdown_str);
 	if (fm.found) {
-		std::string yaml_content = markdown_str.substr(fm.body_start, fm.body_len);
+		std::string fm_content = markdown_str.substr(fm.body_start, fm.body_len);
 
-		// Basic YAML parsing for common fields (placeholder)
-		std::istringstream stream(yaml_content);
+		// Line-split key/value, NOT a parser -- see README. The separator follows
+		// the fence: YAML writes `key: value`, TOML writes `key = value`. Splitting
+		// TOML on ':' matched nothing and returned an empty map, which reads as
+		// "this document has no metadata" rather than "this reader does not split
+		// this dialect".
+		const char separator = (fm.delimiter == '+') ? '=' : ':';
+		std::istringstream stream(fm_content);
 		std::string line;
 		while (std::getline(stream, line)) {
-			auto colon_pos = line.find(':');
+			auto colon_pos = line.find(separator);
 			if (colon_pos != std::string::npos) {
 				std::string key = line.substr(0, colon_pos);
 				std::string value = line.substr(colon_pos + 1);
@@ -1074,8 +1099,13 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 
 	int32_t block_order = 1;
 
-	// Check for frontmatter first
-	std::string frontmatter = ExtractRawFrontmatter(markdown_str);
+	// Check for frontmatter first. The MATCH is used rather than the extracted
+	// string because the fence determines the encoding: `---` is YAML, `+++` is
+	// TOML. Reporting TOML as 'yaml' would be a worse failure than the flattening
+	// this replaced -- it would hand a consumer bytes that parse cleanly as the
+	// wrong format rather than failing loudly.
+	auto fm_match = FindFrontmatter(markdown_str);
+	std::string frontmatter = fm_match.found ? markdown_str.substr(fm_match.body_start, fm_match.body_len) : "";
 	if (!frontmatter.empty()) {
 		// OPEN. Which level a duck_block frontmatter row should carry.
 		//
@@ -1116,7 +1146,7 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		fm_block.attributes[Vocab::ATTR_ROLE] = Vocab::ROLE_FRONTMATTER;
 		fm_block.content = frontmatter;
 		fm_block.level = 0;
-		fm_block.encoding = "yaml";
+		fm_block.encoding = fm_match.delimiter == '+' ? Vocab::ENCODING_TOML : Vocab::ENCODING_YAML;
 		fm_block.block_order = block_order++;
 		blocks.push_back(fm_block);
 	}

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1,4 +1,5 @@
 #include "markdown_utils.hpp"
+#include <mutex>
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception.hpp"
 #include <algorithm>
@@ -140,6 +141,21 @@ static std::string EscapeJSONString(const std::string &s) {
 // TrimWhitespace stays: frontmatter parsing, wikilinks, tags and code-fence
 // info strings all still use it.
 
+// cmark-gfm's core-extension registration is NOT thread-safe: it allocates node
+// flag bits from a global counter, and two threads entering it at once fail with
+// "flag initialization error in cmark_register_node_flag". It was called on every
+// parse, from three sites, unguarded -- and DuckDB parallelises across rows, so a
+// query parsing several documents raced. Measured at 4 failures in 12 runs of a
+// nine-row query: intermittent, so it passed every single-document test forever.
+//
+// Registering exactly once, before any parse can proceed, is what cmark-gfm's own
+// documentation requires. std::call_once also gives the memory barrier, so a
+// thread that observes registration as done observes the registrations too.
+static void EnsureCmarkExtensionsRegistered() {
+	static std::once_flag cmark_extensions_once;
+	std::call_once(cmark_extensions_once, [] { cmark_gfm_core_extensions_ensure_registered(); });
+}
+
 //===--------------------------------------------------------------------===//
 // Core Conversion Functions
 //===--------------------------------------------------------------------===//
@@ -150,7 +166,7 @@ std::string MarkdownToHTML(const std::string &markdown_str, MarkdownFlavor flavo
 	}
 
 	// Initialize cmark-gfm
-	cmark_gfm_core_extensions_ensure_registered();
+	EnsureCmarkExtensionsRegistered();
 
 	// Parse options based on flavor
 	int options = CMARK_OPT_DEFAULT;
@@ -1094,7 +1110,7 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 	std::string body = StripFrontmatter(markdown_str);
 
 	// Parse with cmark-gfm (with extensions for tables)
-	cmark_gfm_core_extensions_ensure_registered(); // Must be called before finding extensions
+	EnsureCmarkExtensionsRegistered();
 	cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
 
 	// Enable GFM extensions
@@ -1585,7 +1601,7 @@ std::vector<MarkdownTable> ExtractTables(const std::string &markdown_str) {
 	// The document is parsed whole, without stripping frontmatter, so
 	// line_number is an absolute line in the input -- matching ExtractLinks and
 	// ExtractImages, which also use cmark's native line tracking.
-	cmark_gfm_core_extensions_ensure_registered();
+	EnsureCmarkExtensionsRegistered();
 	cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
 	if (!parser) {
 		return tables;

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1,4 +1,5 @@
 #include "markdown_utils.hpp"
+#include "duck_block_vocabulary.hpp"
 #include <mutex>
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception.hpp"
@@ -15,6 +16,8 @@
 #include <cmark-gfm-core-extensions.h>
 
 namespace duckdb {
+
+using Vocab = DuckBlockVocabulary;
 
 namespace markdown_utils {
 
@@ -1109,8 +1112,8 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		// keeps what the old name carried: the TYPE says which of the two metadata
 		// homes this is (a verbatim blob, not the kind='value' tree), the ROLE says
 		// which source construct it came from.
-		fm_block.block_type = "metadata";
-		fm_block.attributes["role"] = "frontmatter";
+		fm_block.block_type = Vocab::TYPE_METADATA;
+		fm_block.attributes[Vocab::ATTR_ROLE] = Vocab::ROLE_FRONTMATTER;
 		fm_block.content = frontmatter;
 		fm_block.level = 0;
 		fm_block.encoding = "yaml";

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1100,10 +1100,22 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		// a documented public API, so it is a decision rather than a defect to
 		// patch at the point of emission.
 		//
-		// `block_type = "frontmatter"` is a separate and clearer divergence: the
-		// declared element_type is `metadata`, and `frontmatter` is in no
-		// vocabulary. The validator accepts it, so nothing objects today. Worth
-		// aligning whenever the level question resolves.
+		// `block_type = "frontmatter"` is a separate and clearer divergence, and
+		// unlike the level it has no competing local requirement -- the declared
+		// element_type is `metadata`, nothing here needs the name `frontmatter`,
+		// and this writer already accepts both.
+		//
+		// It is also no longer unobjected-to. That was true when first recorded
+		// and stopped being true the same hour, upstream having closed the hole
+		// where any string passed validation:
+		//
+		//   duck_blocks_lint, MEASURED 2026-09-01, spec 6.1
+		//   "element_type 'frontmatter' is not in the vocabulary
+		//    (duck_block_type_names())"
+		//
+		// So the remaining reason to keep it is compatibility alone: it is the
+		// documented output of read_markdown_blocks and eight test sites use it.
+		// That is still a decision, but a narrower one than the level.
 		MarkdownBlock fm_block;
 		fm_block.block_type = "frontmatter";
 		fm_block.content = frontmatter;

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1116,6 +1116,9 @@ static void WalkInlines(cmark_node *container, int level, int32_t &order, std::v
 // silent truncation into a hard error, trading one wrong answer for another.
 static constexpr int MAX_LIST_NESTING = 1000;
 
+static void EmitBlockChildren(cmark_node *container, int level, int32_t &order, std::vector<MarkdownBlock> &out,
+                              bool structured_inlines, int depth);
+
 static void EmitListStructural(cmark_node *list_node, int level, int32_t &order, std::vector<MarkdownBlock> &out,
                                bool structured_inlines, int depth = 0) {
 	if (depth > MAX_LIST_NESTING) {
@@ -1149,34 +1152,88 @@ static void EmitListStructural(cmark_node *list_node, int level, int32_t &order,
 		ib.block_order = order++;
 		out.push_back(ib);
 
-		for (cmark_node *ic = cmark_node_first_child(item); ic; ic = cmark_node_next(ic)) {
-			if (cmark_node_get_type(ic) == CMARK_NODE_LIST) {
-				EmitListStructural(ic, level + 2, order, out, structured_inlines, depth + 1);
-				continue;
+		EmitBlockChildren(item, level + 2, order, out, structured_inlines, depth + 1);
+	}
+}
+
+// A container's BLOCK children, emitted as blocks rather than flattened to text.
+//
+// The old blockquote path ran GetInlineText over the whole container, which
+// concatenated its children with NO separator:
+//
+//   > quoted para          content: "quoted parasecond para"
+//   >
+//   > second para          -- words run together across the boundary
+//
+//   > - one                renders: "> onetwo"
+//   > - two                -- the list is destroyed outright
+//
+// Shared with list items so a list inside a quote and a quote inside a list are
+// handled by the same code rather than by two walks that can disagree.
+static void EmitBlockChildren(cmark_node *container, int level, int32_t &order, std::vector<MarkdownBlock> &out,
+                              bool structured_inlines, int depth) {
+	if (depth > MAX_LIST_NESTING) {
+		throw InvalidInputException("Markdown block nesting exceeds maximum supported depth (%d)", MAX_LIST_NESTING);
+	}
+	for (cmark_node *c = cmark_node_first_child(container); c; c = cmark_node_next(c)) {
+		const cmark_node_type t = cmark_node_get_type(c);
+		if (t == CMARK_NODE_LIST) {
+			EmitListStructural(c, level, order, out, structured_inlines, depth + 1);
+			continue;
+		}
+		if (t == CMARK_NODE_BLOCK_QUOTE) {
+			MarkdownBlock qb;
+			qb.block_type = Vocab::TYPE_BLOCKQUOTE;
+			qb.level = level;
+			qb.encoding = Vocab::ENCODING_TEXT;
+			qb.content = "";
+			qb.block_order = order++;
+			out.push_back(qb);
+			EmitBlockChildren(c, level + 1, order, out, structured_inlines, depth + 1);
+			continue;
+		}
+
+		MarkdownBlock b;
+		b.level = level;
+		b.encoding = Vocab::ENCODING_TEXT;
+		b.block_order = order++;
+		bool walk = false;
+		if (t == CMARK_NODE_HEADING) {
+			b.block_type = Vocab::TYPE_HEADING;
+			b.content = GetInlineText(c);
+			b.attributes[Vocab::ATTR_HEADING_LEVEL] = std::to_string(cmark_node_get_heading_level(c));
+		} else if (t == CMARK_NODE_CODE_BLOCK) {
+			b.block_type = Vocab::TYPE_CODE;
+			const char *lit = cmark_node_get_literal(c);
+			b.content = lit ? lit : "";
+			while (!b.content.empty() && b.content.back() == '\n') {
+				b.content.pop_back();
 			}
-			MarkdownBlock pb;
-			pb.block_type = Vocab::TYPE_PARAGRAPH;
-			pb.level = level + 2;
-			pb.encoding = Vocab::ENCODING_TEXT;
-			pb.block_order = order++;
-			bool walk = false;
+			const char *info = cmark_node_get_fence_info(c);
+			if (info && strlen(info) > 0) {
+				std::string info_str(info);
+				const size_t sp = info_str.find(' ');
+				b.attributes["language"] = sp == std::string::npos ? info_str : info_str.substr(0, sp);
+			}
+		} else if (t == CMARK_NODE_THEMATIC_BREAK) {
+			b.block_type = Vocab::TYPE_HR;
+			b.content = "";
+		} else {
+			// Paragraph, and anything else that carries inline content.
+			b.block_type = Vocab::TYPE_PARAGRAPH;
 			std::string simple;
-			if (structured_inlines && cmark_node_get_type(ic) == CMARK_NODE_PARAGRAPH) {
-				if (SingleTextChild(ic, simple)) {
-					pb.content = simple;
-				} else {
-					pb.content = "";
-					walk = true;
-				}
+			if (structured_inlines && t == CMARK_NODE_PARAGRAPH && !SingleTextChild(c, simple)) {
+				b.content = "";
+				walk = true;
+			} else if (structured_inlines && t == CMARK_NODE_PARAGRAPH) {
+				b.content = simple;
 			} else {
-				// Not a paragraph (a code block, a quote): keep its text rather
-				// than dropping the child, which is what the old walk did.
-				pb.content = GetInlineText(ic);
+				b.content = GetInlineText(c);
 			}
-			out.push_back(pb);
-			if (walk) {
-				WalkInlines(ic, pb.level + 1, order, out);
-			}
+		}
+		out.push_back(b);
+		if (walk) {
+			WalkInlines(c, b.level + 1, order, out);
 		}
 	}
 }
@@ -1352,8 +1409,21 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 					emit_inlines = true;
 				}
 			} else if (structured_inlines) {
-				// Multi-block blockquote: flatten to plain text (no markdown syntax).
-				block.content = GetInlineText(child);
+				// More than one block child, or a child that is not a paragraph:
+				// emit them as BLOCKS. Flattening with GetInlineText concatenated
+				// them with no separator ("quoted para" + "second para" came back
+				// as "quoted parasecond para") and destroyed a nested list outright.
+				block.content = "";
+				block_order = block.block_order;
+				MarkdownBlock qb;
+				qb.block_type = Vocab::TYPE_BLOCKQUOTE;
+				qb.level = block.level;
+				qb.encoding = Vocab::ENCODING_TEXT;
+				qb.content = "";
+				qb.block_order = block_order++;
+				blocks.push_back(qb);
+				EmitBlockChildren(child, qb.level + 1, block_order, blocks, structured_inlines, 0);
+				emitted_directly = true;
 			} else {
 				// Legacy path: render blockquote content back to markdown, strip '>'.
 				char *md = cmark_render_commonmark(child, CMARK_OPT_DEFAULT, 0);

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1090,6 +1090,97 @@ static void WalkInlines(cmark_node *container, int level, int32_t &order, std::v
 	}
 }
 
+// A list, emitted STRUCTURALLY: list -> list_item -> the item's own blocks.
+//
+// This replaced a JSON array of item strings, which was not merely a shape the
+// vocabulary dislikes -- it DESTROYED content. The old code carried the comment
+// "Nested list - skip for now, just get first text", and it meant exactly that:
+//
+//   - outer            ->   content ["outer", "second"]
+//     - inner one           inner one and inner two GONE
+//     - inner two
+//   - second
+//
+// and because each item was flattened with GetInlineText, `**bold**` came back
+// as bold, `code` lost its backticks, and a second paragraph in an item vanished.
+// Every check missed it because every list any of them tested was FLAT and
+// one paragraph deep.
+//
+// Levels descend one at a time, which the conformance rules require: list at L,
+// list_item at L+1, the item's paragraph at L+2, that paragraph's inlines at L+3.
+// A nested list is just a block child of its item, so it recurses at L+2.
+// Matches MAX_INLINE_DEPTH rather than the writer's absorption guard: this file's
+// convention is a limit high enough that pathological-but-real input parses, with
+// a clear error past it -- 1000 blockquotes and 200 nested emphasis are pinned as
+// NOT throwing. A lower limit here would have turned a 500-deep list from a
+// silent truncation into a hard error, trading one wrong answer for another.
+static constexpr int MAX_LIST_NESTING = 1000;
+
+static void EmitListStructural(cmark_node *list_node, int level, int32_t &order, std::vector<MarkdownBlock> &out,
+                               bool structured_inlines, int depth = 0) {
+	if (depth > MAX_LIST_NESTING) {
+		throw InvalidInputException("Markdown list nesting exceeds maximum supported depth (%d)", MAX_LIST_NESTING);
+	}
+
+	const bool is_ordered = cmark_node_get_list_type(list_node) == CMARK_ORDERED_LIST;
+
+	MarkdownBlock lb;
+	lb.block_type = Vocab::TYPE_LIST;
+	lb.level = level;
+	lb.encoding = Vocab::ENCODING_TEXT;
+	lb.content = "";
+	lb.block_order = order++;
+	lb.attributes[Vocab::ATTR_LIST_TYPE] = is_ordered ? Vocab::LIST_TYPE_ORDERED : Vocab::LIST_TYPE_BULLET;
+	lb.attributes[Vocab::ATTR_ORDERED_LEGACY] = is_ordered ? "true" : "false";
+	if (is_ordered) {
+		lb.attributes["start"] = std::to_string(cmark_node_get_list_start(list_node));
+	}
+	out.push_back(lb);
+
+	for (cmark_node *item = cmark_node_first_child(list_node); item; item = cmark_node_next(item)) {
+		if (cmark_node_get_type(item) != CMARK_NODE_ITEM) {
+			continue;
+		}
+		MarkdownBlock ib;
+		ib.block_type = Vocab::TYPE_LIST_ITEM;
+		ib.level = level + 1;
+		ib.encoding = Vocab::ENCODING_TEXT;
+		ib.content = "";
+		ib.block_order = order++;
+		out.push_back(ib);
+
+		for (cmark_node *ic = cmark_node_first_child(item); ic; ic = cmark_node_next(ic)) {
+			if (cmark_node_get_type(ic) == CMARK_NODE_LIST) {
+				EmitListStructural(ic, level + 2, order, out, structured_inlines, depth + 1);
+				continue;
+			}
+			MarkdownBlock pb;
+			pb.block_type = Vocab::TYPE_PARAGRAPH;
+			pb.level = level + 2;
+			pb.encoding = Vocab::ENCODING_TEXT;
+			pb.block_order = order++;
+			bool walk = false;
+			std::string simple;
+			if (structured_inlines && cmark_node_get_type(ic) == CMARK_NODE_PARAGRAPH) {
+				if (SingleTextChild(ic, simple)) {
+					pb.content = simple;
+				} else {
+					pb.content = "";
+					walk = true;
+				}
+			} else {
+				// Not a paragraph (a code block, a quote): keep its text rather
+				// than dropping the child, which is what the old walk did.
+				pb.content = GetInlineText(ic);
+			}
+			out.push_back(pb);
+			if (walk) {
+				WalkInlines(ic, pb.level + 1, order, out);
+			}
+		}
+	}
+}
+
 std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool structured_inlines) {
 	std::vector<MarkdownBlock> blocks;
 
@@ -1177,6 +1268,7 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		block.level = 1; // Document-level blocks have level=1
 		block.block_order = block_order++;
 		bool emit_inlines = false;            // structured inline children follow this block
+		bool emitted_directly = false;        // the case pushed its own elements (lists)
 		cmark_node *inline_container = child; // node whose inline children to walk
 
 		switch (node_type) {
@@ -1293,64 +1385,11 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		}
 
 		case CMARK_NODE_LIST: {
-			block.block_type = "list";
-			block.level = 1;
-			block.encoding = "json";
-
-			cmark_list_type list_type = cmark_node_get_list_type(child);
-			const bool is_ordered = (list_type == CMARK_ORDERED_LIST);
-			// BOTH, canonical first. `list_type` is the vocabulary attribute;
-			// `ordered` is the legacy boolean the spec says producers should keep
-			// emitting because data written before the rule does not rewrite
-			// itself. Until now this reader emitted ONLY the legacy one, so a
-			// consumer reading just the canonical attribute -- which is what new
-			// code and this repo's own writer read first -- saw an untyped list
-			// and worked only by falling back.
-			block.attributes[Vocab::ATTR_LIST_TYPE] = is_ordered ? Vocab::LIST_TYPE_ORDERED : Vocab::LIST_TYPE_BULLET;
-			block.attributes[Vocab::ATTR_ORDERED_LEGACY] = is_ordered ? "true" : "false";
-
-			if (is_ordered) {
-				int start = cmark_node_get_list_start(child);
-				block.attributes["start"] = std::to_string(start);
-			}
-
-			// Build JSON array of list items
-			std::string json = "[";
-			bool first = true;
-			cmark_node *item = cmark_node_first_child(child);
-			while (item) {
-				if (cmark_node_get_type(item) == CMARK_NODE_ITEM) {
-					if (!first)
-						json += ", ";
-					first = false;
-
-					// Get text content of list item (from first paragraph child)
-					std::string item_text;
-					cmark_node *item_child = cmark_node_first_child(item);
-					while (item_child) {
-						if (cmark_node_get_type(item_child) == CMARK_NODE_PARAGRAPH) {
-							item_text = GetInlineText(item_child);
-							break;
-						} else if (cmark_node_get_type(item_child) == CMARK_NODE_LIST) {
-							// Nested list - skip for now, just get first text
-							break;
-						} else {
-							// Try to get inline text directly
-							std::string txt = GetInlineText(item_child);
-							if (!txt.empty()) {
-								item_text = txt;
-								break;
-							}
-						}
-						item_child = cmark_node_next(item_child);
-					}
-
-					json += "\"" + EscapeJSONString(item_text) + "\"";
-				}
-				item = cmark_node_next(item);
-			}
-			json += "]";
-			block.content = json;
+			// Rewind the order this iteration pre-allocated: the emitter numbers
+			// every element it produces, starting with the list itself.
+			block_order = block.block_order;
+			EmitListStructural(child, block.level, block_order, blocks, structured_inlines);
+			emitted_directly = true;
 			break;
 		}
 
@@ -1447,6 +1486,10 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		}
 		}
 
+		if (emitted_directly) {
+			child = cmark_node_next(child);
+			continue;
+		}
 		blocks.push_back(block);
 		if (emit_inlines) {
 			WalkInlines(inline_container, block.level + 1, block_order, blocks);

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1100,24 +1100,17 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		// a documented public API, so it is a decision rather than a defect to
 		// patch at the point of emission.
 		//
-		// `block_type = "frontmatter"` is a separate and clearer divergence, and
-		// unlike the level it has no competing local requirement -- the declared
-		// element_type is `metadata`, nothing here needs the name `frontmatter`,
-		// and this writer already accepts both.
-		//
-		// It is also no longer unobjected-to. That was true when first recorded
-		// and stopped being true the same hour, upstream having closed the hole
-		// where any string passed validation:
-		//
-		//   duck_blocks_lint, MEASURED 2026-09-01, spec 6.1
-		//   "element_type 'frontmatter' is not in the vocabulary
-		//    (duck_block_type_names())"
-		//
-		// So the remaining reason to keep it is compatibility alone: it is the
-		// documented output of read_markdown_blocks and eight test sites use it.
-		// That is still a decision, but a narrower one than the level.
+		// The type name is SETTLED as of spec 6.2: `metadata` + role='frontmatter'.
+		// What remains open here is the LEVEL alone.
 		MarkdownBlock fm_block;
-		fm_block.block_type = "frontmatter";
+		// `metadata` + role='frontmatter', declared in spec 6.2. `frontmatter` was
+		// never a vocabulary type -- one type plus a role attribute is the spec's
+		// own stated principle, "rather than minting a type per variant", and it
+		// keeps what the old name carried: the TYPE says which of the two metadata
+		// homes this is (a verbatim blob, not the kind='value' tree), the ROLE says
+		// which source construct it came from.
+		fm_block.block_type = "metadata";
+		fm_block.attributes["role"] = "frontmatter";
 		fm_block.content = frontmatter;
 		fm_block.level = 0;
 		fm_block.encoding = "yaml";

--- a/test/data/blockquote_multi.md
+++ b/test/data/blockquote_multi.md
@@ -1,0 +1,3 @@
+> quoted para
+>
+> second para

--- a/test/sql/duck_block_container_children.test
+++ b/test/sql/duck_block_container_children.test
@@ -1,0 +1,73 @@
+# name: test/sql/duck_block_container_children.test
+# description: containers with BLOCK children keep their children, separated
+# group: [sql]
+
+require markdown
+
+# The direction that was never covered: this repo's READER through this repo's
+# writer. check_against_producer.py sends duck_block_utils' output through the
+# writer, which is a different path and was always correct; the conformance rules
+# check validity and advisory shape, and neither can see two paragraphs run
+# together. So a multi-paragraph blockquote was flattened by a text extractor
+# into "quoted parasecond para" with nothing objecting.
+#
+# Asserted as the ABSENCE of the concatenation as well as the presence of the
+# words: "quoted parasecond para" contains both "quoted" and "second", so a
+# words-survive assertion passes on the destroyed output. The separator is the
+# property, so the separator is what gets pinned.
+
+# Two paragraphs in a blockquote stay two paragraphs
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'> quoted para\n>\n> second para\n')) NOT LIKE '%parasecond%';
+----
+true
+
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'> quoted para\n>\n> second para\n')) = E'> quoted para\n>\n> second para\n\n';
+----
+true
+
+# A list inside a blockquote survives as a list, not as run-together text
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'> - one\n> - two\n')) NOT LIKE '%onetwo%';
+----
+true
+
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'> - one\n> - two\n')) = E'> - one\n> - two\n\n';
+----
+true
+
+# Inline formatting inside a quoted paragraph survives
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'> has **bold** text\n')) = E'> has **bold** text\n\n';
+----
+true
+
+# A heading inside a blockquote is a block child, not flattened prose
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'> # Quoted heading\n>\n> body\n')) NOT LIKE '%headingbody%';
+----
+true
+
+# The blockquote itself carries no content of its own once it has block children
+query I
+SELECT coalesce(content, '') = ''
+FROM read_markdown_blocks('test/data/blockquote_multi.md') WHERE element_type = 'blockquote';
+----
+true
+
+# ...and its children are there, one level deeper
+query I
+SELECT string_agg(content, '|' ORDER BY element_order)
+FROM read_markdown_blocks('test/data/blockquote_multi.md') WHERE element_type = 'paragraph';
+----
+quoted para|second para
+
+# Round-trip is stable, not merely lossless on the first pass
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(
+         duck_blocks_to_md(parse_markdown_to_duck_blocks(e'> quoted para\n>\n> second para\n'))))
+     = duck_blocks_to_md(parse_markdown_to_duck_blocks(e'> quoted para\n>\n> second para\n'));
+----
+true

--- a/test/sql/duck_block_containers.test
+++ b/test/sql/duck_block_containers.test
@@ -18,7 +18,10 @@ SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL,
 ----
 true
 
-# A figure whose level is NULL still scopes its caption (producers emit NULL here)
+# A figure whose level is NULL still scopes its caption. Producers emitted NULL
+# here when this was written; since spec 3.0 gave every element an explicit
+# level a figure carries 1, measured. Kept as a DEFENSIVE case for data
+# written before that, not as a description of what anything emits now.
 query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'id': 'fig1'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'CAP', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) LIKE '%*CAP*%';
 ----

--- a/test/sql/duck_block_containers.test
+++ b/test/sql/duck_block_containers.test
@@ -1,0 +1,174 @@
+# name: test/sql/duck_block_containers.test
+# description: Container and structural block types (figure, caption, section, div, generic, lineblock, deflist)
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# Regression: these element_types had no renderer, so they fell through to the
+# "unknown block" branch and emitted their (empty) content plus a blank line.
+# Structure vanished and a caption became indistinguishable from body prose.
+#
+# Shapes are verbatim pandoc_ast_to_blocks() output from duck_block_utils.
+# =============================================================================
+
+# A figure renders its content, then its caption, marked as a caption
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{'id': 'fig1'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'CAP', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'BODY\n\n*CAP*\n\n';
+----
+true
+
+# A figure whose level is NULL still scopes its caption (producers emit NULL here)
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'id': 'fig1'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'CAP', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) LIKE '%*CAP*%';
+----
+true
+
+# A caption above its content (a <details>/<summary> label) works the same way
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'Summary', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'Body', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'*Summary*\n\nBody\n\n';
+----
+true
+
+# Container markers themselves emit nothing -- no stray blank lines
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'section', content: NULL, level: 1, encoding: 'text', attributes: MAP{'role': 'aside'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'A', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'A\n\n';
+----
+true
+
+# A multi-block caption is emitted unwrapped rather than in broken emphasis
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'caption', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'One', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'Two', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'One\n\nTwo\n\n';
+----
+true
+
+# generic is a backstop against silent loss: keep source_type, drop the raw JSON
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'generic', content: '{"t":"Weird","c":[]}', level: NULL, encoding: 'json', attributes: MAP{'source_type': 'Weird'}, element_order: 0}]) = E'<!-- unsupported block: Weird -->\n\n';
+----
+true
+
+# generic with no source_type still announces itself
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'generic', content: '{}', level: NULL, encoding: 'json', attributes: MAP{}, element_order: 0}]) LIKE '<!-- unsupported block%';
+----
+true
+
+# generic source_type cannot break out of the comment
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'generic', content: '{}', level: NULL, encoding: 'json', attributes: MAP{'source_type': 'a --> b'}, element_order: 0}]) NOT LIKE '%-->%b%-->%';
+----
+true
+
+# lineblock preserves its line breaks as markdown hard breaks
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'lineblock', content: E'L1\nL2', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'L1  \nL2\n\n';
+----
+true
+
+# deflist renders as a definition list, not as raw JSON
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'deflist', content: '[[[{"t":"Str","c":"Term"}],[[{"t":"Para","c":[{"t":"Str","c":"Def"}]}]]]]', level: NULL, encoding: 'json', attributes: MAP{}, element_order: 0}]) = E'Term\n: Def\n\n';
+----
+true
+
+# deflist with several terms and several definitions per term
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'deflist', content: '[[[{"t":"Str","c":"A"}],[[{"t":"Para","c":[{"t":"Str","c":"a1"}]}],[{"t":"Para","c":[{"t":"Str","c":"a2"}]}]]],[[{"t":"Str","c":"B"}],[[{"t":"Para","c":[{"t":"Str","c":"b1"}]}]]]]', level: NULL, encoding: 'json', attributes: MAP{}, element_order: 0}]) = E'A\n: a1\n: a2\n\nB\n: b1\n\n';
+----
+true
+
+# Unparseable deflist content falls back rather than disappearing
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'deflist', content: 'not json', level: NULL, encoding: 'json', attributes: MAP{}, element_order: 0}]) LIKE '%not json%';
+----
+true
+
+# Container types are also inert inside duck_blocks_to_sections
+query I
+SELECT list_contains([x.content FOR x IN duck_blocks_to_sections([{kind: 'block', element_type: 'heading', content: 'H', level: NULL, encoding: 'text', attributes: MAP{'heading_level': '1'}, element_order: 0}, {kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}])], E'BODY\n\n');
+----
+true
+
+# page_break is a marker with no content: markdown has no page-break syntax, so
+# it leaves a greppable trace rather than a stray blank line or a rule (a `---`
+# mid-document would read as a thematic break, or as frontmatter delimiters).
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'A', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'page_break', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'page_number': '2'}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'B', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'A\n\n<!-- page break: 2 -->\n\nB\n\n';
+----
+true
+
+# ...and without a page_number
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'page_break', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'<!-- page break -->\n\n';
+----
+true
+
+# A page break never becomes a section: it is physical, not semantic
+query I
+SELECT len(duck_blocks_to_sections([{kind: 'block', element_type: 'heading', content: 'H', level: NULL, encoding: 'text', attributes: MAP{'heading_level': '1'}, element_order: 0}, {kind: 'block', element_type: 'page_break', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'B', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 2}])) = 1;
+----
+true
+
+# Inline `generic` is the inline counterpart of the block backstop, but its text
+# lives in its children rather than in content, so the children carry it through
+# and only the wrapper identity is dropped -- as with `span`. A comment here
+# would interrupt the prose it sits inside.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'generic', content: NULL, level: 2, encoding: 'text', attributes: MAP{'source_type': 'Ruby'}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'kept', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'a kept\n\n';
+----
+true
+
+# Producers emit blockquote content as a Pandoc block array (encoding 'json'),
+# not only as text -- verified against both the released duck_block_utils binary
+# and its current main. Rendering that verbatim put raw AST behind '> '.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: '[{"t":"Para","c":[{"t":"Str","c":"q"}]}]', level: NULL, encoding: 'json', attributes: MAP{}, element_order: 0}]) = E'> q\n\n';
+----
+true
+
+# Several blocks inside one quote keep their paragraph breaks
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: '[{"t":"Para","c":[{"t":"Str","c":"one"}]},{"t":"Para","c":[{"t":"Str","c":"two"}]}]', level: NULL, encoding: 'json', attributes: MAP{}, element_order: 0}]) = E'> one\n> \n> two\n\n';
+----
+true
+
+# Plain-text blockquote content is untouched
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: 'A quote', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'> A quote\n\n';
+----
+true
+
+# Unparseable json content falls back rather than vanishing
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: 'not json', level: NULL, encoding: 'json', attributes: MAP{}, element_order: 0}]) LIKE '%not json%';
+----
+true
+
+# Pandoc list JSON. BulletList is [[block,...],...]; OrderedList wraps that in
+# [[start,style,delim],[[block,...],...]]. Neither is the ["a","b"] shape the
+# json list parser read, so a real producer's list rendered as NOTHING -- the
+# items were silently dropped. Verified against shipped and main.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '[[{"t":"Para","c":[{"t":"Str","c":"alpha"}]}],[{"t":"Para","c":[{"t":"Str","c":"beta"}]}]]', level: NULL, encoding: 'json', attributes: MAP{'list_type': 'bullet'}, element_order: 0}]) = E'- alpha\n- beta\n\n';
+----
+true
+
+# Ordered lists come through list_type, not the legacy `ordered` attribute, and
+# carry their first number inside the JSON rather than in a `start` attribute.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '[[3,{"t":"Decimal"},{"t":"Period"}],[[{"t":"Para","c":[{"t":"Str","c":"x"}]}],[{"t":"Para","c":[{"t":"Str","c":"y"}]}]]]', level: NULL, encoding: 'json', attributes: MAP{'list_type': 'ordered'}, element_order: 0}]) = E'3. x\n4. y\n\n';
+----
+true
+
+# The legacy string-array form still renders exactly as before
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["Item 1", "Item 2"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'false'}, element_order: 0}]) = E'- Item 1\n- Item 2\n\n';
+----
+true
+
+# An explicit start attribute still wins for the legacy form
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'true', 'start': '5'}, element_order: 0}]) = E'5. a\n\n';
+----
+true

--- a/test/sql/duck_block_containers.test
+++ b/test/sql/duck_block_containers.test
@@ -20,7 +20,7 @@ true
 
 # A figure whose level is NULL still scopes its caption. Producers emitted NULL
 # here when this was written; since spec 3.0 gave every element an explicit
-# level a figure carries 1, measured. Kept as a DEFENSIVE case for data
+# level a figure carries 1 (MEASURED 2026-08-31, spec 6.1). Kept as a DEFENSIVE case for data
 # written before that, not as a description of what anything emits now.
 query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'id': 'fig1'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'CAP', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) LIKE '%*CAP*%';

--- a/test/sql/duck_block_frontmatter.test
+++ b/test/sql/duck_block_frontmatter.test
@@ -1,0 +1,83 @@
+# name: test/sql/duck_block_frontmatter.test
+# description: kind='value' document metadata round-trips as YAML frontmatter
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# Markdown is the one output format with a natural home for document metadata,
+# so kind='value' elements are emitted as frontmatter rather than dropped.
+# Shapes are verbatim pandoc_ast_to_blocks() output from duck_block_utils.
+# =============================================================================
+
+# MetaInlines: a title becomes a frontmatter key, never body prose
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 1}, {kind: 'inline', element_type: 'text', content: 'T', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'---\ntitle: "T"\n---\n\nBody\n\n';
+----
+true
+
+# Inline formatting inside a metadata value survives as markdown
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 0}, {kind: 'inline', element_type: 'bold', content: 'B', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'---\ntitle: "**B**"\n---\n\n';
+----
+true
+
+# MetaBool
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'bool', content: 'true', level: 1, encoding: 'text', attributes: MAP{'key': 'draft'}, element_order: 0}]) = E'---\ndraft: true\n---\n\n';
+----
+true
+
+# MetaString
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'string', content: 'v', level: 1, encoding: 'text', attributes: MAP{'key': 'lang'}, element_order: 0}]) = E'---\nlang: "v"\n---\n\n';
+----
+true
+
+# MetaList
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'tags'}, element_order: 0}, {kind: 'value', element_type: 'string', content: 'a', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'value', element_type: 'string', content: 'b', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'---\ntags:\n  - "a"\n  - "b"\n---\n\n';
+----
+true
+
+# MetaMap
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'map', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'author'}, element_order: 0}, {kind: 'value', element_type: 'string', content: 'N', level: 2, encoding: 'text', attributes: MAP{'key': 'name'}, element_order: 1}]) = E'---\nauthor:\n  name: "N"\n---\n\n';
+----
+true
+
+# MetaBlocks becomes a literal block scalar, and does not reach the body
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'blocks', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'abstract'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'ABS', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'---\nabstract: |\n  ABS\n---\n\n';
+----
+true
+
+# The version marker carries no key and stays out of the document's metadata
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'version', content: '0.4.0', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'Body\n\n';
+----
+true
+
+# Values are quoted, so a value cannot forge frontmatter structure
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'string', content: E'x"\n---\ninjected: 1', level: 1, encoding: 'text', attributes: MAP{'key': 'k'}, element_order: 0}]) = E'---\nk: "x\\"\\n---\\ninjected: 1"\n---\n\n';
+----
+true
+
+# An existing frontmatter block wins; no second frontmatter is synthesised
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'metadata', content: 'title: existing', level: 0, encoding: 'yaml', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'string', content: 'other', level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 1}]) = E'---\ntitle: existing\n---\n\n';
+----
+true
+
+# A document with no metadata gains no frontmatter
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'Body\n\n';
+----
+true
+
+# Metadata does not leak into sections either, which have no frontmatter slot
+query I
+SELECT (duck_blocks_to_sections([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 1}, {kind: 'inline', element_type: 'text', content: 'LEAKED', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}])[1].content)::VARCHAR NOT LIKE '%LEAKED%';
+----
+true

--- a/test/sql/duck_block_inline_children.test
+++ b/test/sql/duck_block_inline_children.test
@@ -43,10 +43,25 @@ SELECT duck_blocks_to_md([{kind: 'block', element_type: 'heading', content: NULL
 ----
 true
 
-# An element at level 1 beside one at NULL is its sibling, not its child --
-# NULL is depth 1, not depth 0.
+# Blocks and inlines are on separate level scales. The spec's Level Field
+# Semantics puts a top-level INLINE at level 1, while a top-level block records
+# NULL -- so a level-1 inline after a NULL block is that block's content, not a
+# sibling. The builders and all four panduck readers emit this shape; the Pandoc
+# path emits the same run at level 2. Both have to read.
 query I
-SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'Sibling', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'\n\nSibling';
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'b', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'a **b**\n\n';
+----
+true
+
+# The same document in the Pandoc path's convention, one level deeper
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'b', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'a **b**\n\n';
+----
+true
+
+# A spec-conformant heading, its title at inline level 1
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'heading', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'heading_level': '2'}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'Title', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'## Title\n\n';
 ----
 true
 

--- a/test/sql/duck_block_inline_children.test
+++ b/test/sql/duck_block_inline_children.test
@@ -46,8 +46,9 @@ true
 # Blocks and inlines are on separate level scales. The spec's Level Field
 # Semantics puts a top-level INLINE at level 1, while a top-level block records
 # NULL -- so a level-1 inline after a NULL block is that block's content, not a
-# sibling. The builders emit this shape (measured); panduck reported the same of
-# its four readers, which is RELAYED and not verified here. The Pandoc
+# sibling. The builders emit this shape (MEASURED 2026-08-31, duck_block_utils
+# spec 6.1). panduck reported the same of its four readers; that is
+# RELAYED 2026-08-31 and was never verified here. The Pandoc
 # path emits the same run at level 2. Both have to read.
 query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'b', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'a **b**\n\n';

--- a/test/sql/duck_block_inline_children.test
+++ b/test/sql/duck_block_inline_children.test
@@ -1,0 +1,76 @@
+# name: test/sql/duck_block_inline_children.test
+# description: Elements whose content is a run of kind='inline' children
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# An element with no content of its own carries it as kind='inline' children at
+# level+1. The writer walked the list flat, so it rendered the marker's empty
+# content and then the children as a separate run: a paragraph became a blank
+# line followed by its own text, and a bold with a nested child rendered as
+# '****Doc' -- the wrapper closed around nothing.
+# =============================================================================
+
+# A paragraph's inline children are its text, not a following run
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks('Hello **world**.')) = E'Hello **world**.\n\n';
+----
+true
+
+# A nested inline container wraps its children, not the empty string
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'My', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'space', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'bold', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'inline', element_type: 'text', content: 'Doc', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'My **Doc**\n\n';
+----
+true
+
+# Emphasis nested inside emphasis
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'bold', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'italic', content: NULL, level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'x', level: 4, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'***x***\n\n';
+----
+true
+
+# A link's label comes from its children
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'link', content: NULL, level: 2, encoding: 'text', attributes: MAP{'href': 'http://e.com'}, element_order: 1}, {kind: 'inline', element_type: 'text', content: 'here', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'[here](http://e.com)\n\n';
+----
+true
+
+# A heading's inline children are its title. `level` is nesting DEPTH, so a
+# top-level element is at depth 1 and records NULL; its children are at 2.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'heading', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'heading_level': '2'}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'Title', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'## Title\n\n';
+----
+true
+
+# An element at level 1 beside one at NULL is its sibling, not its child --
+# NULL is depth 1, not depth 0.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'Sibling', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'\n\nSibling';
+----
+true
+
+# A formatted top-level paragraph does not reach across into the metadata that
+# follows it: its scope ends at the value marker, which sits at level 1.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'Hi', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'T', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'---\ntitle: "T"\n---\n\nHi\n\n';
+----
+true
+
+# A figure's image reaches the document without a blank paragraph before it
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'id': 'fig1'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'image', content: 'alt', level: 3, encoding: 'text', attributes: MAP{'src': 'a.png'}, element_order: 2}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'Fig one.', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'![alt](a.png)\n\n*Fig one.*\n\n';
+----
+true
+
+# An element that has its own content keeps it; children do not override it
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'flat', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'child', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE 'flat%';
+----
+true
+
+# Metadata values built from nested inlines render as one scalar
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'My', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'space', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'bold', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'inline', element_type: 'text', content: 'Doc', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'---\ntitle: "My **Doc**"\n---\n\n';
+----
+true

--- a/test/sql/duck_block_inline_children.test
+++ b/test/sql/duck_block_inline_children.test
@@ -46,7 +46,8 @@ true
 # Blocks and inlines are on separate level scales. The spec's Level Field
 # Semantics puts a top-level INLINE at level 1, while a top-level block records
 # NULL -- so a level-1 inline after a NULL block is that block's content, not a
-# sibling. The builders and all four panduck readers emit this shape; the Pandoc
+# sibling. The builders emit this shape (measured); panduck reported the same of
+# its four readers, which is RELAYED and not verified here. The Pandoc
 # path emits the same run at level 2. Both have to read.
 query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'b', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'a **b**\n\n';

--- a/test/sql/duck_block_list_type.test
+++ b/test/sql/duck_block_list_type.test
@@ -1,0 +1,88 @@
+# name: test/sql/duck_block_list_type.test
+# description: list_type is the canonical attribute; `ordered` is the tolerated legacy alias
+# group: [sql]
+
+require markdown
+
+# The writer has always read `list_type` first. Until 2026-09-01 this READER
+# emitted only the legacy `ordered` boolean and never the canonical attribute, so
+# a consumer reading just `list_type` -- new code, and this repo's own writer --
+# saw an untyped list and worked only because the fallback existed. Nothing
+# failed when `list_type` was added to every list, because nothing asserted what
+# the reader emits. These do.
+
+# PRODUCER: a bullet list carries the canonical attribute AND the legacy alias
+query II
+SELECT e.attributes['list_type'], e.attributes['ordered']
+FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'- a\n- b\n')) AS e)
+WHERE e.element_type = 'list';
+----
+bullet	false
+
+# PRODUCER: an ordered list, with its start preserved
+query III
+SELECT e.attributes['list_type'], e.attributes['ordered'], e.attributes['start']
+FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'3. x\n4. y\n')) AS e)
+WHERE e.element_type = 'list';
+----
+ordered	true	3
+
+# CONSUMER: canonical wins when the two DISAGREE. This is the whole point of
+# having a canonical attribute -- without it, which one wins is whichever the
+# code happened to read first.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: 1, encoding: 'json',
+                           attributes: MAP{'list_type': 'ordered', 'ordered': 'false'}, element_order: 0}])
+     = E'1. a\n\n';
+----
+true
+
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: 1, encoding: 'json',
+                           attributes: MAP{'list_type': 'bullet', 'ordered': 'true'}, element_order: 0}])
+     = E'- a\n\n';
+----
+true
+
+# CONSUMER: legacy-only input still renders. Data written before the rule does
+# not rewrite itself, which is why the alias is tolerated rather than dropped.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: 1, encoding: 'json',
+                           attributes: MAP{'ordered': 'true'}, element_order: 0}])
+     = E'1. a\n\n';
+----
+true
+
+# A list with NEITHER attribute is a bullet list, not an error
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: 1, encoding: 'json',
+                           attributes: MAP{}::MAP(VARCHAR, VARCHAR), element_order: 0}])
+     = E'- a\n\n';
+----
+true
+
+# ROUND-TRIP: both list kinds survive, start included
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'- a\n- b\n\n3. x\n4. y\n'))
+     = E'- a\n- b\n\n3. x\n4. y\n\n';
+----
+true
+
+# `definition` is the third list_type, and is not orderedness at all
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0},
+                          {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1},
+                          {kind: 'block', element_type: 'paragraph', content: 'Term', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2},
+                          {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 3},
+                          {kind: 'block', element_type: 'paragraph', content: 'Def', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}])
+     = E'Term\n:   Def\n\n';
+----
+true
+
+# A definition list must NOT be read as ordered just because the legacy alias says so
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: 1, encoding: 'json',
+                           attributes: MAP{'list_type': 'definition', 'ordered': 'true'}, element_order: 0}])
+     NOT LIKE '1.%';
+----
+true

--- a/test/sql/duck_block_sections_agreement.test
+++ b/test/sql/duck_block_sections_agreement.test
@@ -1,0 +1,54 @@
+# name: test/sql/duck_block_sections_agreement.test
+# description: duck_blocks_to_sections must render structure the same way duck_blocks_to_md does
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# AGREEMENT GUARD, after duck_block_utils' renderer/extractor guard.
+#
+# This extension has TWO independent walks over the same block list:
+# duck_blocks_to_md and duck_blocks_to_sections. Every structural fix made
+# today lives in the shared range renderer, which the sections walk did not
+# use -- it rendered element by element. So a structural list came out of the
+# writer as "- LISTWORD" and out of sections as a bullet with no text followed
+# by loose prose. The text survived, which is why a presence-only guard passes
+# and why this needs to compare RENDERING, not merely containment.
+#
+# The invariant: for a document with no headings, the single section's content
+# is exactly what the writer produces.
+# =============================================================================
+
+# Structural list
+query I
+SELECT (duck_blocks_to_sections([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'LISTWORD', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}])[1].content)::VARCHAR
+     = duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'LISTWORD', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}])::VARCHAR;
+----
+true
+
+# Structural blockquote
+query I
+SELECT (duck_blocks_to_sections([{kind: 'block', element_type: 'blockquote', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'QUOTEWORD', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}])[1].content)::VARCHAR
+     = duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'QUOTEWORD', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}])::VARCHAR;
+----
+true
+
+# A block whose text is a run of inline children
+query I
+SELECT (duck_blocks_to_sections([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: 'b', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}])[1].content)::VARCHAR
+     = duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: 'b', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}])::VARCHAR;
+----
+true
+
+# A figure caption, which the writer italicises
+query I
+SELECT (duck_blocks_to_sections([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'CAPWORD', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}])[1].content)::VARCHAR
+     = duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'CAPWORD', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}])::VARCHAR;
+----
+true
+
+# Content under a heading agrees too, and the heading still splits the section
+query I
+SELECT (duck_blocks_to_sections([{kind: 'block', element_type: 'heading', content: 'H', level: NULL, encoding: 'text', attributes: MAP{'heading_level': '1'}, element_order: 0}, {kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 1}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'LISTWORD', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}])[1].content)::VARCHAR = E'- LISTWORD\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -519,3 +519,58 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'section', content: NULL, level: 1, encoding: 'text', attributes: MAP{'role': 'section'}, element_order: 0}, {kind: 'block', element_type: 'plain', content: 'Lead', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'heading', content: 'H', level: 2, encoding: 'text', attributes: MAP{'heading_level': '2'}, element_order: 2}]) = E'Lead\n\n## H\n\n';
 ----
 true
+
+# =============================================================================
+# SENTINEL SWEEP -- every block type, content set, NO attributes, straight to
+# the writer. A round trip cannot find this class: it proves the reader/writer
+# pair is self-consistent, which is not the property anyone wants. Only a probe
+# that skips the reader does. Confirmed in two other codebases before this one.
+#
+# Seven types did not emit their content. Three are cleared, with reasoning,
+# because an unexplained exclusion and a forgotten defect look identical later:
+#
+#   hr, page_break   markers with no text position; `---` and the comment ARE
+#                    the whole element. Content is meaningless for them.
+#   generic          content is a verbatim source fragment, deliberately not
+#                    emitted -- it would put raw AST in the document. The
+#                    source_type comment is what carries it. Pinned above.
+#
+# Four were real: div, section, figure and caption dropped their own content.
+# Spec 6.0's rule is that a container whose only child is a text run carries
+# that text in its OWN content -- the same rule that had list_item dropping
+# text. That was fixed for list_item alone, so this is the same defect
+# surviving in four more places because only the reported instance was fixed.
+# =============================================================================
+
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: 'SENTINEL', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}]) LIKE '%SENTINEL%';
+----
+true
+
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'section', content: 'SENTINEL', level: 1, encoding: 'text', attributes: MAP{'role': 'aside'}, element_order: 0}]) LIKE '%SENTINEL%';
+----
+true
+
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: 'SENTINEL', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}]) LIKE '%SENTINEL%';
+----
+true
+
+# A caption carrying its own text is still marked as a caption
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'caption', content: 'Fig one.', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'*Fig one.*\n\n';
+----
+true
+
+# Containers WITH children are unaffected -- children still win
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'child', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'child\n\n';
+----
+true
+
+# ...including a caption, which keeps rendering its child scope
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'CAP', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'BODY\n\n*CAP*\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -210,3 +210,122 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'plain', content: 'x', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'> x\n\n';
 ----
 true
+
+# =============================================================================
+# CONTAINER TYPE SWEEP.
+#
+# This writer's containers render whatever their child scope produces and never
+# consult a type name; only the leaf renderer switches on type, and its terminal
+# arm emits content. So the set of child types a container preserves is "all of
+# them", including ones this build has never heard of.
+#
+# That property was load-bearing and unasserted. duck_block_utils' container
+# child walk enumerated type names instead, and silently dropped table, deflist
+# and lineblock inside any div/blockquote/figure/caption -- for far longer than
+# the type that exposed it had existed. An enumeration has to be revisited for
+# every new type; a scope walk does not.
+#
+# WHAT THIS ACTUALLY COVERS, stated precisely because a sweep invites the
+# reading that it proves the general claim and it does not:
+#
+#   - each named type below renders inside a container TODAY (per-type
+#     regression cover, one assertion each so a failure names the type)
+#   - the content-preserving terminal arm, which is the half that generalises
+#     to types this build has never heard of
+#
+# `plain` carries that second half on its own: it is the only type here with no
+# branch of its own, so it is the one that fails if the terminal arm ever stops
+# emitting content. Verified by breaking that arm and watching this file fail --
+# a first attempt at that simulation was itself a no-op, because it was inserted
+# after branches that already caught the types it meant to break.
+# =============================================================================
+
+# heading survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'heading', content: 'H', level: 2, encoding: 'text', attributes: MAP{'heading_level': '2'}, element_order: 1}]) LIKE '%## H%';
+----
+true
+
+# paragraph survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'P', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%P%';
+----
+true
+
+# code survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'code', content: 'C', level: 2, encoding: 'text', attributes: MAP{'language': 'py'}, element_order: 1}]) LIKE '%```py%C%';
+----
+true
+
+# blockquote survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'blockquote', content: 'Q', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%> Q%';
+----
+true
+
+# list survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'list', content: '["L"]', level: 2, encoding: 'json', attributes: MAP{'list_type': 'bullet'}, element_order: 1}]) LIKE '%- L%';
+----
+true
+
+# list_item survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'LI', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%- LI%';
+----
+true
+
+# deflist survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'deflist', content: '[[[{"t":"Str","c":"T"}],[[{"t":"Para","c":[{"t":"Str","c":"D"}]}]]]]', level: 2, encoding: 'json', attributes: MAP{}, element_order: 1}]) LIKE '%T%: D%';
+----
+true
+
+# lineblock survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'lineblock', content: 'LB', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%LB%';
+----
+true
+
+# table survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'table', content: '{"headers":["TH"],"rows":[["TD"]]}', level: 2, encoding: 'json', attributes: MAP{}, element_order: 1}]) LIKE '%TH%TD%';
+----
+true
+
+# hr survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'hr', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%---%';
+----
+true
+
+# image survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'image', content: 'IMG', level: 2, encoding: 'text', attributes: MAP{'src': 'i.png'}, element_order: 1}]) LIKE '%![IMG](i.png)%';
+----
+true
+
+# raw survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'raw', content: 'RAW', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%RAW%';
+----
+true
+
+# generic survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'generic', content: NULL, level: 2, encoding: 'json', attributes: MAP{'source_type': 'GEN'}, element_order: 1}]) LIKE '%GEN%';
+----
+true
+
+# page_break survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'page_break', content: NULL, level: 2, encoding: 'text', attributes: MAP{'page_number': '7'}, element_order: 1}]) LIKE '%page break: 7%';
+----
+true
+
+# plain survives inside a container
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'plain', content: 'PL', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%PL%';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -429,25 +429,28 @@ SELECT duck_blocks_to_md([{kind: 'block', element_type: 'table', content: '{"hea
 ----
 true
 
-# DEFINITION LIST: 5.0 drops the `deflist` type and expresses one as a `list`
-# with list_type='definition', its items tagged role='term'/'definition'. This
-# writer renders that as a flat bullet list -- the words survive, the term to
-# definition relationship does not.
+# DEFINITION LIST: 5.0 dropped the `deflist` type and expresses one as a `list`
+# with list_type='definition', items tagged role='term'/'definition'.
 #
-# NOT migrated, deliberately, and this one is worth the reasoning because the
-# fix looks trivial: emit "Term\n: Def" as the existing deflist branch already
-# does. The risk is that a mis-guess renders WORSE than this degradation. If
-# the real shape omits the roles, or nests definitions under terms, keying on
-# role produces "Term\nDef" -- one paragraph, the list gone entirely -- where
-# bullets at least keep two items. A safe degradation beats a guessed
-# structure, so this holds until 5.0 can be run against a real producer.
+# This was RENDERED AS BULLETS for several hours, deliberately: the fix looked
+# trivial, but a mis-guess would have rendered WORSE than the degradation --
+# had the real shape omitted roles, or nested definitions under their terms,
+# keying on role would have produced "Term\nDef", one paragraph with the list
+# gone, where bullets at least kept two items. It was held until the shape
+# could be MEASURED off a live producer rather than read from a description.
+#
+# Now migrated on that measurement, and the caution was warranted: producing
+# the sample turned up three defects upstream, so the shape being guessed at
+# was wrong in three ways at the time it would have been guessed. The loose,
+# multi-block case below is one of them -- a definition emitted only its first
+# block, so "a second block" did not exist to render until it was fixed.
 query I
-SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'Term', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'Def', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'- Term\n- Def\n\n';
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'Term', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'Def', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'Term\n:   Def\n\n';
 ----
 true
 
-# Whatever it renders as, both the term and the definition reach the output --
-# the property that must not regress while the formatting is unmigrated
+# Both the term and the definition reach the output -- the property that had to
+# hold while the formatting was still degraded, and still has to
 query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'Term', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'Def', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) LIKE '%Term%Def%';
 ----
@@ -572,5 +575,50 @@ true
 # ...including a caption, which keeps rendering its child scope
 query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'BODY', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'CAP', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'BODY\n\n*CAP*\n\n';
+----
+true
+
+# =============================================================================
+# DEFINITION LISTS, spec 6.1. Previously degraded to bullets deliberately,
+# because guessing the shape risked rendering worse than the safe fallback.
+# Shape below is a verbatim measurement of the live producer, not a reading of
+# its description -- terms and definitions are SIBLINGS at the same level,
+# paired by order, and one term may own several definitions.
+# =============================================================================
+
+# A term with one tight definition
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'HTTP', level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'list_item', content: 'hypertext transfer protocol', level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 2}]) = E'HTTP\n:   hypertext transfer protocol\n\n';
+----
+true
+
+# One term, TWO separate definitions -- distinct from one definition of two blocks
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'DNS', level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'list_item', content: 'sense one', level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: 'sense two', level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 3}]) = E'DNS\n:   sense one\n:   sense two\n\n';
+----
+true
+
+# A loose definition of two blocks -- continuation indented under the marker
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'TLS', level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'transport layer security', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'a second block', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'TLS\n:   transport layer security\n\n    a second block\n\n';
+----
+true
+
+# Several terms in one list, blank line between groups
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'A', level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'list_item', content: 'a1', level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: 'B', level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 3}, {kind: 'block', element_type: 'list_item', content: 'b1', level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 4}]) = E'A\n:   a1\n\nB\n:   b1\n\n';
+----
+true
+
+# A definition list whose items carry no roles degrades to terms rather than
+# vanishing -- the safe direction if a producer omits them
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'no role', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%no role%';
+----
+true
+
+# Bullet and ordered lists are untouched by the definition path
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'x', level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}]) = E'- x\n\n';
 ----
 true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -143,3 +143,37 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'blockquote', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'q', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'> > q\n\n';
 ----
 true
+
+# `ordered` is canonical for list orderedness (spec v1.0); `list_type` is a
+# later alias from the Pandoc reader. Both producers now emit both, so a
+# consumer must prefer the canonical name rather than whichever it checks first.
+
+# Canonical says no, alias says yes -- canonical wins
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'false', 'list_type': 'ordered'}, element_order: 0}]) = E'- a\n\n';
+----
+true
+
+# Canonical says yes, alias says no -- canonical wins
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'true', 'list_type': 'bullet'}, element_order: 0}]) = E'1. a\n\n';
+----
+true
+
+# Alias alone is still honoured, for producers that emit only it
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'list_type': 'ordered'}, element_order: 0}]) = E'1. a\n\n';
+----
+true
+
+# The structural path reads the canonical name too, not only the alias
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'ordered': 'true', 'start': '2'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'2. a\n\n';
+----
+true
+
+# ...and prefers it over a conflicting alias
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'ordered': 'false', 'list_type': 'ordered'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'- a\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -452,3 +452,42 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'Term', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'Def', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) LIKE '%Term%Def%';
 ----
 true
+
+# =============================================================================
+# A list_item may carry its text DIRECTLY rather than in a paragraph child.
+#
+# Spec 2.0 said a container never carries content of its own, and the
+# structural list path was written to that: it renders each item's child scope
+# and ignores the item's own content. duck_block_utils warned that rule might
+# be pulled back to v1's -- content populated iff there is a single text child
+# -- and the live producer does exactly that, so:
+#
+#   list_item(2) content='tight', no children   ->   "-"     the word was GONE
+#
+# Both shapes have to read. The item's children are its content when it has
+# any; its own content is its content when it does not.
+# =============================================================================
+
+# A content-bearing item keeps its text
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'tight', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'- tight\n\n';
+----
+true
+
+# Two of them, numbered when the list is ordered
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'ordered', 'start': '2'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'one', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'list_item', content: 'two', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'2. one\n3. two\n\n';
+----
+true
+
+# The container shape still works, and children win when both are present
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'child', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'- child\n\n';
+----
+true
+
+# Mixed: one item of each shape in the same list
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'flat', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'nested', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'- flat\n- nested\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -75,3 +75,26 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '', level: NULL, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: '', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'- a\n\n';
 ----
 true
+
+# A top-level block records NULL today, but this writer normalises NULL to
+# depth 1, so an explicit level 1 is indistinguishable from it. That is worth
+# pinning as a property of the walk rather than left as a coincidence: it is
+# what makes the walk indifferent to whether a producer spells top level as
+# NULL or as 1.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'q', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}])
+     = duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'q', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]);
+----
+true
+
+# The same for a list, whose item level is derived from its container's
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'- a\n\n';
+----
+true
+
+# A fully-levelled paragraph with nested inlines, no NULLs anywhere
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'italic', content: NULL, level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'inline', element_type: 'text', content: 'in', level: 4, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'a ***in***\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -329,3 +329,88 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'div', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'plain', content: 'PL', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%PL%';
 ----
 true
+
+# =============================================================================
+# CLASS 1 -- a terminal arm that SKIPS rather than degrades.
+#
+# The structural list walk advanced past any child that was not an item, so a
+# list whose children are not list_items lost all of its content. Found by
+# applying duck_block_utils' sweep catalogue to this writer: "grep every walk
+# for a terminal else doing continue/j++/return rather than degrading".
+#
+# The decision the walk was making is whether a child EXISTS, and that must not
+# be keyed on the child matching a shape we recognise. Losing list structure is
+# a formatting cost; losing the text is a content cost.
+# =============================================================================
+
+# A list child that is not an item still renders
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'STRAY', level: 3, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%STRAY%';
+----
+true
+
+# ...alongside real items, which keep their markers
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'ITEM', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'STRAY', level: 4, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 4}, {kind: 'block', element_type: 'paragraph', content: 'TWO', level: 3, encoding: 'text', attributes: MAP{}, element_order: 5}]) LIKE '%ITEM%STRAY%- TWO%';
+----
+true
+
+# A child type nobody has heard of, directly under a list, is not dropped
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'futuretype', content: 'KEPT', level: 3, encoding: 'text', attributes: MAP{}, element_order: 1}]) LIKE '%KEPT%';
+----
+true
+
+# =============================================================================
+# CLASS 2 -- write-only types, adapted for a writer: render, parse back, render
+# again, and compare. Ten of eleven content-bearing types survive unchanged.
+#
+# NON-DEFECT, RECORDED SO THE SWEEP CANNOT RE-RAISE IT.
+#
+# `deflist` does not survive, and it should not. This writer emits Markdown
+# Extra / Pandoc definition-list syntax:
+#
+#     T
+#     : D
+#
+# and this extension's parser is CommonMark, which has no definition-list
+# syntax at all -- so that re-parses as ONE paragraph with a softbreak, and a
+# softbreak renders as a space, giving "T : D". The words survive; the line
+# structure does not.
+#
+# That is inherent to the target format rather than a defect to fix: a round
+# trip can only restore what the encoding carried, and CommonMark has nowhere
+# to carry "this is a definition list". Encoding it differently would lose the
+# deflist-ness just as completely while also being worse markdown. The same
+# distinction duck_block_utils drew for block `image`, which Pandoc cannot
+# express either -- and where "fixing" the asymmetry destroyed the alt text.
+# =============================================================================
+
+# The words survive the round trip even though the line structure does not
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(duck_blocks_to_md([{kind: 'block', element_type: 'deflist', content: '[[[{"t":"Str","c":"T"}],[[{"t":"Para","c":[{"t":"Str","c":"D"}]}]]]]', level: 1, encoding: 'json', attributes: MAP{}, element_order: 0}])::VARCHAR)) LIKE '%T%D%';
+----
+true
+
+# The first pass is, and stays, real definition-list syntax
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'deflist', content: '[[[{"t":"Str","c":"T"}],[[{"t":"Para","c":[{"t":"Str","c":"D"}]}]]]]', level: 1, encoding: 'json', attributes: MAP{}, element_order: 0}]) = E'T\n: D\n\n';
+----
+true
+
+# Every other content-bearing type round-trips byte-identically
+query I
+SELECT bool_and(rt) FROM (
+  SELECT duck_blocks_to_md([b]) = duck_blocks_to_md(parse_markdown_to_duck_blocks(duck_blocks_to_md([b])::VARCHAR)) AS rt
+  FROM (SELECT unnest([
+    {kind: 'block', element_type: 'heading',    content: 'H',   level: 1, encoding: 'text', attributes: MAP{'heading_level': '2'}, element_order: 0},
+    {kind: 'block', element_type: 'paragraph',  content: 'P',   level: 1, encoding: 'text', attributes: MAP{}, element_order: 0},
+    {kind: 'block', element_type: 'code',       content: 'C',   level: 1, encoding: 'text', attributes: MAP{'language': 'py'}, element_order: 0},
+    {kind: 'block', element_type: 'blockquote', content: 'Q',   level: 1, encoding: 'text', attributes: MAP{}, element_order: 0},
+    {kind: 'block', element_type: 'lineblock',  content: 'LB',  level: 1, encoding: 'text', attributes: MAP{}, element_order: 0},
+    {kind: 'block', element_type: 'hr',         content: NULL,  level: 1, encoding: 'text', attributes: MAP{}, element_order: 0},
+    {kind: 'block', element_type: 'image',      content: 'IMG', level: 1, encoding: 'text', attributes: MAP{'src': 'i.png'}, element_order: 0},
+    {kind: 'block', element_type: 'plain',      content: 'PL',  level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}
+  ]) AS b));
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -61,3 +61,17 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list_item', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'orphan', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'- orphan\n\n';
 ----
 true
+
+# The spec spells "no content of its own" two ways -- the block builders write
+# NULL, the Pandoc reader writes an empty string -- and says to treat both as
+# absent. Every other case here uses NULL, so this pins the other spelling.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: '', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'q', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'> q\n\n';
+----
+true
+
+# ...and for a list, whose container and items are both content-free
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '', level: NULL, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: '', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'- a\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -414,3 +414,41 @@ SELECT bool_and(rt) FROM (
   ]) AS b));
 ----
 true
+
+# =============================================================================
+# SPEC 5.0 shapes, measured against this build and pinned. Neither is migrated:
+# 5.0 is unpublished and cannot be exercised against a real producer here.
+# =============================================================================
+
+# TABLE: 5.0 moves the native {"headers","rows"} schema into content and parks
+# the Pandoc tuple in a `pandoc_ast` attribute. This writer already renders the
+# native schema and ignores attributes it does not know, so a 5.0 table renders
+# correctly with no change -- verified rather than assumed.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'table', content: '{"headers":["A","B"],"rows":[["c1","c2"]]}', level: 1, encoding: 'json', attributes: MAP{'pandoc_ast': '[["",[],[]],[null,[]],[],[],[],[]]'}, element_order: 0}]) = E'| A | B |\n|---|---|\n| c1 | c2 |\n\n';
+----
+true
+
+# DEFINITION LIST: 5.0 drops the `deflist` type and expresses one as a `list`
+# with list_type='definition', its items tagged role='term'/'definition'. This
+# writer renders that as a flat bullet list -- the words survive, the term to
+# definition relationship does not.
+#
+# NOT migrated, deliberately, and this one is worth the reasoning because the
+# fix looks trivial: emit "Term\n: Def" as the existing deflist branch already
+# does. The risk is that a mis-guess renders WORSE than this degradation. If
+# the real shape omits the roles, or nests definitions under terms, keying on
+# role produces "Term\nDef" -- one paragraph, the list gone entirely -- where
+# bullets at least keep two items. A safe degradation beats a guessed
+# structure, so this holds until 5.0 can be run against a real producer.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'Term', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'Def', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'- Term\n- Def\n\n';
+----
+true
+
+# Whatever it renders as, both the term and the definition reach the output --
+# the property that must not regress while the formatting is unmigrated
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'definition'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'Term', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{'role': 'definition'}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'Def', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) LIKE '%Term%Def%';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -144,36 +144,69 @@ SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: N
 ----
 true
 
-# `ordered` is canonical for list orderedness (spec v1.0); `list_type` is a
-# later alias from the Pandoc reader. Both producers now emit both, so a
-# consumer must prefer the canonical name rather than whichever it checks first.
+# `list_type` is CANONICAL for list orderedness; `ordered` is a legacy alias.
+# A boolean cannot grow, and the type set already wants values -- definition and
+# navigation lists -- that `ordered=false` can only say a list is not. Both
+# producers emit both names, so this only decides which wins on disagreement.
+# (This reversed an earlier ruling that `ordered` was canonical; the assertions
+# below are the current rule, not a claim it has always been so.)
 
-# Canonical says no, alias says yes -- canonical wins
+# Alias says not-ordered, canonical says ordered -- canonical wins
 query I
-SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'false', 'list_type': 'ordered'}, element_order: 0}]) = E'- a\n\n';
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'false', 'list_type': 'ordered'}, element_order: 0}]) = E'1. a\n\n';
 ----
 true
 
-# Canonical says yes, alias says no -- canonical wins
+# Alias says ordered, canonical says bullet -- canonical wins
 query I
-SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'true', 'list_type': 'bullet'}, element_order: 0}]) = E'1. a\n\n';
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'true', 'list_type': 'bullet'}, element_order: 0}]) = E'- a\n\n';
 ----
 true
 
-# Alias alone is still honoured, for producers that emit only it
+# The legacy alias alone is still read, for producers that emit only it
 query I
-SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'list_type': 'ordered'}, element_order: 0}]) = E'1. a\n\n';
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'ordered': 'true'}, element_order: 0}]) = E'1. a\n\n';
 ----
 true
 
-# The structural path reads the canonical name too, not only the alias
+# An unrecognised list_type is not "ordered", so it renders as a bullet list
+# rather than numbering something that is neither
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: '["a"]', level: NULL, encoding: 'json', attributes: MAP{'list_type': 'definition'}, element_order: 0}]) = E'- a\n\n';
+----
+true
+
+# The structural path applies the same precedence
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'ordered': 'false', 'list_type': 'ordered', 'start': '2'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'2. a\n\n';
+----
+true
+
+# ...and still reads the legacy alias when the canonical name is absent
 query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'ordered': 'true', 'start': '2'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'2. a\n\n';
 ----
 true
 
-# ...and prefers it over a conflicting alias
+# `plain` is a spec 4.0 block type: a text run with no paragraph semantics,
+# which renders exactly as a paragraph would. It is not in this build's vendored
+# 2.0 vocabulary, so it reaches the unknown-block fallback -- and that fallback
+# emits content, so a tight list item keeps its text. Pinned because the cost of
+# not handling a new block type is CONTENT, not spacing: duck_block_utils lost
+# a tight item's text entirely to a type-name-driven walk.
 query I
-SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'ordered': 'false', 'list_type': 'ordered'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'- a\n\n';
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'plain', content: 'x', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'x\n\n';
+----
+true
+
+# ...inside a tight list item
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'plain', content: 'x', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'- x\n\n';
+----
+true
+
+# ...and inside a container, where a type-name-driven child walk would drop it
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'plain', content: 'x', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'> x\n\n';
 ----
 true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -622,3 +622,34 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'x', level: 2, encoding: 'text', attributes: MAP{'role': 'term'}, element_order: 1}]) = E'- x\n\n';
 ----
 true
+
+# =============================================================================
+# LINE BLOCKS carry their lines two ways. A plain-text line block joins them
+# with newlines in `content`; one containing rich inlines carries them as
+# children, with `linebreak` inlines between the lines -- because flattening
+# rich content to text DESTROYED it upstream (bold vanished, a link left the
+# line empty), which is why that changed.
+#
+# Both reach this writer as content by the time the lineblock branch sees them,
+# since a block absorbs its inline run. But the rich form arrives with the hard
+# breaks ALREADY rendered, so re-adding them produced four trailing spaces
+# rather than two. Still a hard break to a reader, and still wrong.
+# =============================================================================
+
+# Plain text: lines joined with newlines, one hard break each
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'lineblock', content: E'Roses are red\nViolets are blue', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'Roses are red  \nViolets are blue\n\n';
+----
+true
+
+# Rich: the run arrives with its breaks already rendered; exactly two spaces
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'lineblock', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'plain ', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: 'bold', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'linebreak', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'inline', element_type: 'text', content: 'second line', level: 2, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'plain **bold**  \nsecond line\n\n';
+----
+true
+
+# A link in a line block survives, and does not leave the line empty
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'lineblock', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'link', content: 'anchor', level: 2, encoding: 'text', attributes: MAP{'href': 'http://x'}, element_order: 1}, {kind: 'inline', element_type: 'linebreak', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'after', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'[anchor](http://x)  \nafter\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -491,3 +491,31 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'flat', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'nested', level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'- flat\n- nested\n\n';
 ----
 true
+
+# =============================================================================
+# SPEC 6.1: the content rule is SIBLING-DEPENDENT. Whether a text run becomes
+# its container's `content` or stays a `plain` child depends on what FOLLOWS
+# it, which a reader emitting as it walks cannot know when it reaches the run.
+# Upstream exports duck_blocks_normalize() so producers emit the naive shape
+# and fold it afterwards.
+#
+# That is a PRODUCER concern. What matters to this writer is that both shapes
+# render the same, so it never needs to care which one it was handed --
+# verified against the real normalize pass, which folded the first item and
+# left the second `plain` alone because it sits beside block siblings.
+#
+# The equivalence was true incidentally; these assert it.
+# =============================================================================
+
+# The naive shape: every text run as a `plain` child
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'plain', content: 'tight', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}])
+     = duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: 'tight', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]);
+----
+true
+
+# A `plain` beside block siblings is legitimate and survives normalisation
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'section', content: NULL, level: 1, encoding: 'text', attributes: MAP{'role': 'section'}, element_order: 0}, {kind: 'block', element_type: 'plain', content: 'Lead', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'heading', content: 'H', level: 2, encoding: 'text', attributes: MAP{'heading_level': '2'}, element_order: 2}]) = E'Lead\n\n## H\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -98,3 +98,48 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a ', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'bold', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'italic', content: NULL, level: 3, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'inline', element_type: 'text', content: 'in', level: 4, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'a ***in***\n\n';
 ----
 true
+
+# =============================================================================
+# KNOWN HAZARD, pinned deliberately so the fix is a decision and not a surprise.
+#
+# A heading takes its rank from attributes['heading_level'], falling back to the
+# `level` field when that attribute is absent. Under spec <= 2.0 that fallback
+# is a reasonable reading of malformed data: the spec says headings carry NULL
+# in `level`, so a populated one was most likely a producer putting rank there.
+#
+# Spec 3.0 makes `level` explicit structural depth for EVERY element, never
+# semantic. Then this fallback reads a heading's DEPTH as its RANK -- a heading
+# inside two containers becomes h3 regardless of what it is. That is the same
+# class as the over-nested blockquote 3.0 found in webbed.
+#
+# Not changed yet: 3.0 is unpublished and not installable here, the fallback is
+# load-bearing for the headings in doc_inline.test, and conforming to a spec
+# that cannot yet be tested against is how a shape gets chased. These pin what
+# the writer does today so the blast radius is visible when 3.0 lands.
+# =============================================================================
+
+# heading_level is authoritative when present -- unaffected by 3.0 either way
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'heading', content: 'T', level: 3, encoding: 'text', attributes: MAP{'heading_level': '1'}, element_order: 0}]) = E'# T\n\n';
+----
+true
+
+# Without it, `level` is used as rank. Correct under <= 2.0, WRONG under 3.0,
+# where 3 would mean "nested three containers deep", not "h3".
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'heading', content: 'T', level: 3, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'### T\n\n';
+----
+true
+
+# Quote depth, by contrast, is already structural and NOT read from `level`:
+# one blockquote nested inside two sections is one quote, not three.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'section', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'section', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'blockquote', content: NULL, level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'paragraph', content: 'q', level: 4, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'> q\n\n';
+----
+true
+
+# ...and a genuinely nested quote gets its second '>' from the nested element
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'blockquote', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'q', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'> > q\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -653,3 +653,41 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'lineblock', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'link', content: 'anchor', level: 2, encoding: 'text', attributes: MAP{'href': 'http://x'}, element_order: 1}, {kind: 'inline', element_type: 'linebreak', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'after', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'[anchor](http://x)  \nafter\n\n';
 ----
 true
+
+# =============================================================================
+# BREAK CONSTRUCTORS. A hard break and a soft break are distinct, and both were
+# being destroyed upstream -- a hard break came back as a raw newline inside a
+# text run, a soft break vanished entirely -- because the predicate choosing
+# between flat content and inline children counted both as text. A run with a
+# break now carries children, where the distinction can live.
+#
+# Ordinary prose does NOT grow children, which matters as much as the fix: a
+# change that moved every paragraph to inline children would satisfy every
+# round-trip assertion while rewriting every document. Asserted here from this
+# writer's side -- a paragraph with plain content still renders as plain text.
+# =============================================================================
+
+# Hard break: two trailing spaces, the markdown that means a line break
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'alpha', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'linebreak', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'beta', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'alpha  \nbeta\n\n';
+----
+true
+
+# Soft break: a bare newline, which is NOT the same thing
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'alpha', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'softbreak', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'beta', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'alpha\nbeta\n\n';
+----
+true
+
+# The two are distinguishable in the output, which is the whole point
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'linebreak', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'b', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}])
+    <> duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'a', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'softbreak', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'b', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]);
+----
+true
+
+# Ordinary prose keeps flat content and renders as plain text
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'just a plain paragraph here', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'just a plain paragraph here\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -1,0 +1,63 @@
+# name: test/sql/duck_block_structural.test
+# description: Structural list and blockquote containers (duck_block spec 1.2)
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# Spec 1.2 made `list` and `blockquote` structural: the container carries no
+# content, and its blocks follow as children by level. The previous shape
+# packed the whole thing into JSON content, which is still emitted by released
+# producers -- so BOTH forms have to work, and duck_block_containers.test pins
+# the JSON one.
+#
+# Shapes are verbatim pandoc_ast_to_blocks() output from duck_block_utils 1.2.
+# =============================================================================
+
+# Structural bullet list: the item's text lives in its child paragraph
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'alpha', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'beta', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'- alpha\n- beta\n\n';
+----
+true
+
+# Ordered list numbers from the container's start attribute
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'list_type': 'ordered', 'start': '3', 'number_style': 'Decimal', 'number_delim': 'Period'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'one', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'two', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'3. one\n4. two\n\n';
+----
+true
+
+# number_style and number_delim are honoured, so iii) does not come back as 3.
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'list_type': 'ordered', 'start': '3', 'number_style': 'LowerRoman', 'number_delim': 'OneParen'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'one', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'two', level: 3, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'iii) one\niv) two\n\n';
+----
+true
+
+# Upper alpha
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'list_type': 'ordered', 'start': '2', 'number_style': 'UpperAlpha', 'number_delim': 'Period'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'x', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'B. x\n\n';
+----
+true
+
+# A nested list indents under its parent item
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list', content: NULL, level: NULL, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 0}, {kind: 'block', element_type: 'list_item', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'a', level: 3, encoding: 'text', attributes: MAP{}, element_order: 2}, {kind: 'block', element_type: 'list', content: NULL, level: 3, encoding: 'text', attributes: MAP{'list_type': 'bullet'}, element_order: 3}, {kind: 'block', element_type: 'list_item', content: NULL, level: 4, encoding: 'text', attributes: MAP{}, element_order: 4}, {kind: 'block', element_type: 'paragraph', content: 'inner', level: 5, encoding: 'text', attributes: MAP{}, element_order: 5}]) = E'- a\n\n  - inner\n\n';
+----
+true
+
+# Structural blockquote: children are blocks, and the quote marker survives
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'q1', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'q2', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'> q1\n>\n> q2\n\n';
+----
+true
+
+# Content following a structural container is not swallowed by it
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'blockquote', content: NULL, level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'q', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'after', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'> q\n\nafter\n\n';
+----
+true
+
+# A list_item met without its container still renders as a bullet
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'list_item', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'orphan', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}]) = E'- orphan\n\n';
+----
+true

--- a/test/sql/duck_block_structural.test
+++ b/test/sql/duck_block_structural.test
@@ -691,3 +691,53 @@ query I
 SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'just a plain paragraph here', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'just a plain paragraph here\n\n';
 ----
 true
+
+# =============================================================================
+# A FIGURE'S CAPTION IS NOT EMITTED TWICE.
+#
+# `![alt](src)` already carries that text: a reader infers a figure AND its
+# caption from a lone image, so emitting the caption as a separate italic line
+# says it twice -- and re-reading that output produces a figure whose caption
+# is the alt PLUS a stray italic paragraph, so a further copy is added on every
+# pass. Markdown has one slot for that text and this filled two.
+#
+# Suppressed only when the caption is textually the alt, which is the case
+# markdown itself produces. A caption that says something the alt does not is
+# information the image syntax cannot carry, so it is still emitted.
+# =============================================================================
+
+# Caption equal to the alt: the image syntax carries it, so no second copy
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'plain', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'image', content: 'A caption', level: 3, encoding: 'text', attributes: MAP{'alt': 'A caption', 'src': 'img.png'}, element_order: 2}, {kind: 'block', element_type: 'caption', content: 'A caption', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'![A caption](img.png)\n\n';
+----
+true
+
+# A caption saying something the alt does not is still emitted
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'plain', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'image', content: 'alt', level: 3, encoding: 'text', attributes: MAP{'alt': 'alt', 'src': 'i.png'}, element_order: 2}, {kind: 'block', element_type: 'caption', content: 'Figure 1. Something else.', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}]) = E'![alt](i.png)\n\n*Figure 1. Something else.*\n\n';
+----
+true
+
+# A figure with no caption is unaffected
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'plain', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'image', content: 'a', level: 3, encoding: 'text', attributes: MAP{'alt': 'a', 'src': 'i.png'}, element_order: 2}]) = E'![a](i.png)\n\n';
+----
+true
+
+# A caption outside a figure is still marked as a caption
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'caption', content: 'standalone', level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}]) = E'*standalone*\n\n';
+----
+true
+
+# A figure holding a caption but no image keeps the caption
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'body', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'caption', content: 'the caption', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]) = E'body\n\n*the caption*\n\n';
+----
+true
+
+# Content after the figure still renders
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'figure', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'block', element_type: 'plain', content: NULL, level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'image', content: 'a', level: 3, encoding: 'text', attributes: MAP{'alt': 'a', 'src': 'i.png'}, element_order: 2}, {kind: 'block', element_type: 'caption', content: 'a', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'block', element_type: 'paragraph', content: 'after', level: 1, encoding: 'text', attributes: MAP{}, element_order: 4}]) = E'![a](i.png)\n\nafter\n\n';
+----
+true

--- a/test/sql/duck_block_toml_frontmatter.test
+++ b/test/sql/duck_block_toml_frontmatter.test
@@ -1,0 +1,77 @@
+# name: test/sql/duck_block_toml_frontmatter.test
+# description: TOML (+++) frontmatter is recognised, preserved verbatim, and re-fenced as TOML
+# group: [sql]
+
+require markdown
+
+# `+++` is Hugo's default. Until 2026-09-01 it was unrecognised, and the failure
+# was not a missing feature -- the fence fell through to cmark as ordinary prose,
+# where softbreak-renders-as-space is correct, so a round-trip flattened the
+# whole block onto one line. TOML is line-oriented, so the fields were not merely
+# misfiled, they were unrecoverable.
+
+# The block is metadata, verbatim, with the encoding the fence implies
+query IIII
+SELECT e.element_type, e.encoding, e.attributes['role'], replace(e.content, chr(10), '|')
+FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'+++\ntitle = "Hugo"\ntags = ["a"]\n+++\n\nBody.\n')) AS e)
+WHERE e.element_type = 'metadata';
+----
+metadata	toml	frontmatter	title = "Hugo"|tags = ["a"]
+
+# REGRESSION: the body is its own block, and the fence is not in it
+query II
+SELECT e.element_type, e.content
+FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'+++\ntitle = "Hugo"\n+++\n\nBody.\n')) AS e)
+WHERE e.element_type = 'paragraph';
+----
+paragraph	Body.
+
+# REGRESSION: the flattened form must never appear again
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'+++\ntitle = "Hugo"\ntags = ["a"]\n+++\n\nBody.\n'))
+       NOT LIKE '%+++ title%';
+----
+true
+
+# The fence follows the ENCODING. Writing `---` around a TOML body would be worse
+# than not recognising it: the bytes would parse cleanly as the wrong format.
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'+++\ntitle = "Hugo"\n+++\n\nBody.\n'))
+     = e'+++\ntitle = "Hugo"\n+++\n\nBody.\n\n';
+----
+true
+
+# YAML is unaffected -- still `---`, still yaml
+query II
+SELECT e.encoding, duck_blocks_to_md(parse_markdown_to_duck_blocks(e'---\ntitle: Y\n---\n\nBody.\n'))
+     = e'---\ntitle: Y\n---\n\nBody.\n\n'
+FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'---\ntitle: Y\n---\n\nBody.\n')) AS e)
+WHERE e.element_type = 'metadata';
+----
+yaml	true
+
+# A writer given encoding='toml' emits the TOML fence
+query I
+SELECT replace(duck_block_to_md({kind: 'block', element_type: 'metadata', content: 'a = 1', level: 1,
+                         encoding: 'toml', attributes: MAP{'role': 'frontmatter'}, element_order: 0}), chr(10), '|');
+----
++++|a = 1|+++||
+
+# The raw extractor sees it
+query I
+SELECT md_extract_frontmatter(e'+++\ntitle = "Hugo"\n+++\n\nBody.\n');
+----
+title = "Hugo"
+
+# The line-split key/value reader follows the fence: `=` for TOML, `:` for YAML
+query II
+SELECT md_extract_metadata(e'+++\ntitle = "Hugo"\n+++\n\nB.\n')['title'],
+       md_extract_metadata(e'---\ntitle: Yaml\n---\n\nB.\n')['title'];
+----
+Hugo	Yaml
+
+# An unterminated TOML fence is not frontmatter, and must not eat the document
+query I
+SELECT md_extract_frontmatter(e'+++\ntitle = "Hugo"\n\nBody.\n') IS NULL;
+----
+true

--- a/test/sql/duck_block_value_kind.test
+++ b/test/sql/duck_block_value_kind.test
@@ -1,0 +1,72 @@
+# name: test/sql/duck_block_value_kind.test
+# description: kind='value' metadata must never render into the document body
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# Regression: document metadata (kind='value') leaked into the body as prose.
+#
+# Metadata is emitted as frontmatter (see duck_block_frontmatter.test); what
+# these assertions pin down is the separate guarantee that none of it reaches
+# the body, where a reader could not tell a leaked title from real prose. Each
+# strips the frontmatter and checks what is left.
+#
+# Block shapes below are verbatim dumps of pandoc_ast_to_blocks() output from
+# duck_block_utils (feat-doc-query-pipeline), replayed as literals so this test
+# does not depend on that extension being loadable.
+# =============================================================================
+
+# MetaInlines: the value marker and its kind='inline' children are both kept out
+query I
+SELECT regexp_replace(duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 1}, {kind: 'inline', element_type: 'text', content: 'LEAKED', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]), '(?s)^---\n.*?\n---\n\n', '') = E'Body\n\n';
+----
+true
+
+# MetaBlocks: children are kind='block', so only a level-scoped skip excludes them
+query I
+SELECT regexp_replace(duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'blocks', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'abstract'}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'LEAKED', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]), '(?s)^---\n.*?\n---\n\n', '') = E'Body\n\n';
+----
+true
+
+# MetaBool / MetaList / MetaMap: scalar and nested values are all kept out
+query I
+SELECT regexp_replace(duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'bool', content: 'true', level: 1, encoding: 'text', attributes: MAP{'key': 'draft'}, element_order: 1}, {kind: 'value', element_type: 'list', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'tags'}, element_order: 2}, {kind: 'value', element_type: 'string', content: 'LEAKED_A', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}, {kind: 'value', element_type: 'map', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'authors'}, element_order: 4}, {kind: 'value', element_type: 'string', content: 'LEAKED_B', level: 2, encoding: 'text', attributes: MAP{'key': 'name'}, element_order: 5}]), '(?s)^---\n.*?\n---\n\n', '') = E'Body\n\n';
+----
+true
+
+# The version marker carries no key and must not surface at all
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'version', content: '0.4.0', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}]) NOT LIKE '%0.4.0%';
+----
+true
+
+# Body content is still rendered normally alongside metadata
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 1}, {kind: 'inline', element_type: 'text', content: 'T', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]) LIKE '%Body%';
+----
+true
+
+# Content that follows a metadata scope at top level still renders
+query I
+SELECT duck_blocks_to_md([{kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 0}, {kind: 'inline', element_type: 'text', content: 'T', level: 2, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'block', element_type: 'paragraph', content: 'After', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 2}]) LIKE '%After%';
+----
+true
+
+# An unknown future kind must be skipped, not guessed at
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'sidecar', element_type: 'whatever', content: 'LEAKED', level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}]) NOT LIKE '%LEAKED%';
+----
+true
+
+# An unknown future kind takes its children with it
+query I
+SELECT duck_blocks_to_md([{kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 0}, {kind: 'sidecar', element_type: 'whatever', content: NULL, level: 1, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'inline', element_type: 'text', content: 'LEAKED', level: 2, encoding: 'text', attributes: MAP{}, element_order: 2}]) NOT LIKE '%LEAKED%';
+----
+true
+
+# duck_blocks_to_sections has the same walk and the same guarantee
+query I
+SELECT (duck_blocks_to_sections([{kind: 'block', element_type: 'heading', content: 'H', level: NULL, encoding: 'text', attributes: MAP{'heading_level': '1'}, element_order: 0}, {kind: 'block', element_type: 'paragraph', content: 'Body', level: NULL, encoding: 'text', attributes: MAP{}, element_order: 1}, {kind: 'value', element_type: 'inlines', content: NULL, level: 1, encoding: 'text', attributes: MAP{'key': 'title'}, element_order: 2}, {kind: 'inline', element_type: 'text', content: 'LEAKED', level: 2, encoding: 'text', attributes: MAP{}, element_order: 3}])[1].content)::VARCHAR NOT LIKE '%LEAKED%';
+----
+true

--- a/test/sql/markdown_basic.test
+++ b/test/sql/markdown_basic.test
@@ -58,3 +58,30 @@ query I
 SELECT md_extract_links(NULL) IS NULL;
 ----
 true
+
+# =============================================================================
+# Parsing many documents in ONE query exercises the parallel path.
+#
+# cmark-gfm's core-extension registration allocates node-flag bits from a global
+# counter and is not thread-safe. It was called on every parse, unguarded, from
+# three sites -- so a query DuckDB parallelised across rows raced and failed
+# with "flag initialization error in cmark_register_node_flag". Measured at 4
+# failures in 12 runs of a nine-row query, which is why every single-document
+# test passed for the life of the extension.
+#
+# WHAT THIS ASSERTION CAN AND CANNOT DO: it exercises the path, it does not
+# deterministically catch the race -- a scheduling-dependent failure that
+# reproduced a third of the time will pass here most runs even unfixed. The
+# fix's real verification was 40 consecutive runs of the reproducer plus 400
+# documents in one query, ten times, both clean. This is a guard against the
+# path disappearing from coverage, not proof the race is gone.
+# =============================================================================
+query I
+SELECT count(*) FROM (SELECT parse_markdown_to_duck_blocks('# H' || i) AS b FROM range(200) t(i)), unnest(b);
+----
+200
+
+query I
+SELECT count(*) > 0 FROM (SELECT parse_markdown_to_duck_blocks('# H' || i || E'\n\ntext **b**\n') AS b FROM range(100) t(i)), unnest(b);
+----
+true

--- a/test/sql/markdown_blocks.test
+++ b/test/sql/markdown_blocks.test
@@ -57,13 +57,23 @@ print("hello")	python
 # Test: Frontmatter extraction
 # =============================================================================
 
-query III
-SELECT element_type, level, encoding FROM read_markdown_blocks('test/data/blocks_frontmatter.md') WHERE element_type = 'frontmatter';
+# Spec 6.2: the type is `metadata` and the ROLE says which construct it came
+# from. `frontmatter` was never a declared element_type. The level is 0 here and
+# stays 0 -- that is a separate, open decision, not part of the rename.
+query IIII
+SELECT element_type, level, encoding, attributes['role']
+FROM read_markdown_blocks('test/data/blocks_frontmatter.md') WHERE element_type = 'metadata';
 ----
-frontmatter	0	yaml
+metadata	0	yaml	frontmatter
+
+# The old name must NOT come back
+query I
+SELECT count(*) FROM read_markdown_blocks('test/data/blocks_frontmatter.md') WHERE element_type = 'frontmatter';
+----
+0
 
 query I
-SELECT content LIKE '%title: Test Doc%' FROM read_markdown_blocks('test/data/blocks_frontmatter.md') WHERE element_type = 'frontmatter';
+SELECT content LIKE '%title: Test Doc%' FROM read_markdown_blocks('test/data/blocks_frontmatter.md') WHERE element_type = 'metadata';
 ----
 true
 
@@ -248,7 +258,7 @@ COPY (SELECT E'---\ntitle: Only FM\n---\n') TO '__TEST_DIR__/only_fm.md' (FORMAT
 query II
 SELECT element_type, level FROM read_markdown_blocks('__TEST_DIR__/only_fm.md');
 ----
-frontmatter	0
+metadata	0
 
 # =============================================================================
 # Test: Attributes are correctly populated

--- a/test/sql/markdown_blocks.test
+++ b/test/sql/markdown_blocks.test
@@ -58,13 +58,14 @@ print("hello")	python
 # =============================================================================
 
 # Spec 6.2: the type is `metadata` and the ROLE says which construct it came
-# from. `frontmatter` was never a declared element_type. The level is 0 here and
-# stays 0 -- that is a separate, open decision, not part of the rename.
+# from. `frontmatter` was never a declared element_type. Level is 1 = NOT NESTED,
+# ruled upstream at 2771e9e; read_markdown_sections keeps its own 0-6 heading
+# rank on its own column, which is a different measurement.
 query IIII
 SELECT element_type, level, encoding, attributes['role']
 FROM read_markdown_blocks('test/data/blocks_frontmatter.md') WHERE element_type = 'metadata';
 ----
-metadata	0	yaml	frontmatter
+metadata	1	yaml	frontmatter
 
 # The old name must NOT come back
 query I
@@ -258,7 +259,7 @@ COPY (SELECT E'---\ntitle: Only FM\n---\n') TO '__TEST_DIR__/only_fm.md' (FORMAT
 query II
 SELECT element_type, level FROM read_markdown_blocks('__TEST_DIR__/only_fm.md');
 ----
-metadata	0
+metadata	1
 
 # =============================================================================
 # Test: Attributes are correctly populated

--- a/test/sql/markdown_blocks.test
+++ b/test/sql/markdown_blocks.test
@@ -79,13 +79,28 @@ SELECT content LIKE '%title: Test Doc%' FROM read_markdown_blocks('test/data/blo
 true
 
 # =============================================================================
-# Test: List extraction (JSON encoded)
+# Test: List extraction (STRUCTURAL)
 # =============================================================================
 
+# Items are list_item children, not a JSON array in the list's content. The old
+# shape flattened each item with GetInlineText and skipped nested lists outright,
+# so `**bold**` came back as bold and a sublist's items vanished.
 query II
 SELECT element_type, encoding FROM read_markdown_blocks('test/data/blocks_list.md') WHERE element_type = 'list';
 ----
-list	json
+list	text
+
+# list -> list_item -> paragraph, descending one level at a time
+query III
+SELECT element_type, level, content FROM read_markdown_blocks('test/data/blocks_list.md') ORDER BY element_order;
+----
+list	1	NULL
+list_item	2	NULL
+paragraph	3	Item 1
+list_item	2	NULL
+paragraph	3	Item 2
+list_item	2	NULL
+paragraph	3	Item 3
 
 query I
 SELECT attributes['ordered'] FROM read_markdown_blocks('test/data/blocks_list.md') WHERE element_type = 'list';
@@ -167,16 +182,18 @@ block	heading	true	1	text	true	1
 # Test: Complex document with multiple block types
 # =============================================================================
 
+# 11 until lists became structural: a list was one block with its items packed
+# into a JSON string. Each item is now list_item + paragraph.
 query I
 SELECT count(*) FROM read_markdown_blocks('test/data/blocks_nested.md') WHERE kind = 'block';
 ----
-11
+18
 
 # Verify all expected block types are present
 query I
 SELECT count(DISTINCT element_type) FROM read_markdown_blocks('test/data/blocks_nested.md') WHERE kind = 'block';
 ----
-7
+8
 
 # Rich text is emitted as structured kind='inline' children at level 2 (not
 # markdown syntax inside content); the blockquote decomposes into inline rows
@@ -230,7 +247,7 @@ true
 query I
 SELECT count(*) FROM read_markdown_blocks('test/data/blocks_*.md') WHERE kind = 'block';
 ----
-33
+58
 
 query I
 SELECT count(DISTINCT file_path) FROM read_markdown_blocks('test/data/blocks_*.md', include_filepath := true);
@@ -287,18 +304,29 @@ SELECT content FROM read_markdown_blocks('test/data/blocks_basic.md') WHERE elem
 A quote
 
 # =============================================================================
-# Test: List JSON content is valid
+# Test: a list carries NO content -- its items are children
 # =============================================================================
 
+# The inverse of what this used to assert. `content LIKE '["%'` pinned the JSON
+# array that flattened each item and discarded nested lists; a list that carries
+# content at all is now the pre-structural shape, and upstream's advisory rules
+# object to it by name (list_not_structural).
 query I
-SELECT content LIKE '["%' FROM read_markdown_blocks('test/data/blocks_list.md') WHERE element_type = 'list';
+SELECT coalesce(content, '') = '' FROM read_markdown_blocks('test/data/blocks_list.md') WHERE element_type = 'list';
 ----
 true
 
+# ...and the items are where the text went
 query I
-SELECT content LIKE '%"]' FROM read_markdown_blocks('test/data/blocks_list.md') WHERE element_type = 'list';
+SELECT count(*) FROM read_markdown_blocks('test/data/blocks_list.md') WHERE element_type = 'list_item';
 ----
-true
+3
+
+# ...and each item's text is in a paragraph beneath it, not in the list
+query I
+SELECT string_agg(content, '|' ORDER BY element_order) FROM read_markdown_blocks('test/data/blocks_list.md') WHERE element_type = 'paragraph';
+----
+Item 1|Item 2|Item 3
 
 # =============================================================================
 # Test: Unicode and international characters
@@ -309,15 +337,19 @@ SELECT content FROM read_markdown_blocks('test/data/blocks_unicode.md') WHERE el
 ----
 Unicode Test 日本語
 
+# bool_or, not a bare LIKE: list items are paragraphs now, so this document has
+# four of them rather than one.
 query I
-SELECT content LIKE '%émojis%' FROM read_markdown_blocks('test/data/blocks_unicode.md') WHERE element_type = 'paragraph';
+SELECT bool_or(content LIKE '%émojis%') FROM read_markdown_blocks('test/data/blocks_unicode.md') WHERE element_type = 'paragraph';
 ----
 true
 
+# The list's non-ASCII text lives in its items, not in the list's own content
 query I
-SELECT content LIKE '%中文%' FROM read_markdown_blocks('test/data/blocks_unicode.md') WHERE element_type = 'list';
+SELECT string_agg(content, '|' ORDER BY element_order) FROM read_markdown_blocks('test/data/blocks_unicode.md') b
+WHERE b.element_type = 'paragraph' AND b.level > 1;
 ----
-true
+中文|العربية|עברית
 
 # =============================================================================
 # Test: Double round-trip stability

--- a/test/sql/markdown_json_escape.test
+++ b/test/sql/markdown_json_escape.test
@@ -69,15 +69,21 @@ WHERE b.element_type = 'table';
 ----
 {"headers": ["a", "b"], "rows": [["he said \"hi\"", "c:\\tmp"]]}
 
-# The list path escapes the same set (it always did) -- kept so the two paths
-# are pinned side by side and cannot drift apart again.
-query I
-SELECT b.content
+# The list path is no longer a JSON path. Items are list_item children with
+# their text in paragraph content, so control characters need no escaping and
+# are carried VERBATIM -- a tab stays a tab rather than becoming a two-character
+# escape that only a JSON reader can undo. `table` is now the only JSON producer
+# here, which is why the escaping above is pinned on it alone.
+#
+# Rendered visible below only because sqllogictest splits result columns on tab.
+query II
+SELECT b.element_type, replace(replace(b.content, chr(9), '<TAB>'), chr(1), '<SOH>')
 FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
         '- x' || chr(9) || 'y' || chr(10) || '- z' || chr(1) || 'w')) b)
-WHERE b.element_type = 'list';
+WHERE b.element_type = 'paragraph';
 ----
-["x\ty", "z\u0001w"]
+paragraph	x<TAB>y
+paragraph	z<SOH>w
 
 # =============================================================================
 # UNESCAPE side: the mirror-image gap. duck_blocks_to_md has to read those

--- a/test/sql/markdown_malformed_inputs.test
+++ b/test/sql/markdown_malformed_inputs.test
@@ -258,15 +258,17 @@ SELECT length(md_to_html(repeat('> ', 1000) || 'x')) > 0;
 ----
 true
 
-# 500 levels of list nesting is one top-level list block, and round-trips
-# back to markdown without throwing.
+# 500 levels of list nesting. This used to be ONE block: the reader emitted a
+# JSON array of item strings and skipped nested lists entirely, so 499 levels
+# were silently discarded and "1" looked like a tidy answer. Structural emission
+# keeps them -- 3 elements per level -- and still round-trips without throwing.
 query II
 SELECT len(parse_markdown_to_duck_blocks(md)),
        length(duck_blocks_to_md(parse_markdown_to_duck_blocks(md))) > 0
 FROM (SELECT string_agg(repeat('  ', i) || '- i', chr(10) ORDER BY i) AS md
       FROM range(0, 500) t(i));
 ----
-1	true
+1500	true
 
 # 200 nested emphasis delimiters on each side: GetInlineText walks this with a
 # depth guard (MAX_INLINE_DEPTH) rather than recursing without bound.

--- a/test/sql/markdown_tables_edge_cases.test
+++ b/test/sql/markdown_tables_edge_cases.test
@@ -392,11 +392,15 @@ WHERE b.element_type = 'table';
 ----
 {"headers": ["a"], "rows": [["[D](https://duckdb.org)"]]}
 
-# A link in a list item is serialised the same way (the list path shares the
-# inline serialiser).
-query I
-SELECT b.content
+# A link in a list ITEM is no longer serialised at all. It used to be flattened
+# into the list's JSON string as the literal text "see [D](https://duckdb.org)",
+# which a consumer could not tell from prose that happened to contain brackets.
+# Structural lists give it back as a real inline carrying its href, the same as
+# a link anywhere else. Tables still flatten, because a cell has no child slot.
+query III
+SELECT b.kind, b.element_type, coalesce(b.attributes['href'], b.content)
 FROM (SELECT UNNEST(parse_markdown_to_duck_blocks('- see [D](https://duckdb.org)')) b)
-WHERE b.element_type = 'list';
+WHERE b.kind = 'inline';
 ----
-["see [D](https://duckdb.org)"]
+inline	text	see 
+inline	link	https://duckdb.org

--- a/test/sql/readme_integration.test
+++ b/test/sql/readme_integration.test
@@ -88,7 +88,7 @@ heading	DuckDB Markdown Extension
 # Should include headings, paragraphs, and lists at minimum
 query I
 SELECT
-    bool_and(element_type IN ('heading', 'paragraph', 'list', 'code', 'blockquote', 'table', 'hr', 'html', 'frontmatter'))
+    bool_and(element_type IN ('heading', 'paragraph', 'list', 'code', 'blockquote', 'table', 'hr', 'html', 'metadata'))
 FROM read_markdown_blocks('README.md') WHERE kind = 'block';
 ----
 true

--- a/test/sql/readme_integration.test
+++ b/test/sql/readme_integration.test
@@ -99,7 +99,12 @@ SELECT min(element_order) FROM read_markdown_blocks('README.md');
 ----
 1
 
-# All rows should have a valid kind (blocks, plus structured inline children)
+# THIS READER emits only these two kinds -- a property of read_markdown_blocks,
+# NOT a statement of which kinds are valid. The vocabulary also has `value`,
+# for document metadata, which this reader has no path to emit; a consumer
+# asserting `kind IN ('block','inline')` as a CONFORMANCE rule rejects every
+# conforming metadata element, which is how the same two-kind constraint became
+# a defect in the canonical spec and its conformance macro.
 query I
 SELECT bool_and(kind IN ('block', 'inline')) FROM read_markdown_blocks('README.md');
 ----

--- a/test/sql/readme_integration.test
+++ b/test/sql/readme_integration.test
@@ -88,7 +88,7 @@ heading	DuckDB Markdown Extension
 # Should include headings, paragraphs, and lists at minimum
 query I
 SELECT
-    bool_and(element_type IN ('heading', 'paragraph', 'list', 'code', 'blockquote', 'table', 'hr', 'html', 'metadata'))
+    bool_and(element_type IN ('heading', 'paragraph', 'list', 'code', 'blockquote', 'table', 'hr', 'html', 'metadata', 'list_item'))
 FROM read_markdown_blocks('README.md') WHERE kind = 'block';
 ----
 true
@@ -141,8 +141,11 @@ SELECT
 true
 
 # Block count should be reasonable (not empty, not corrupted)
+# The upper bound was 1000 until lists became structural. A list item is now
+# list_item + paragraph + its inlines rather than one string in a JSON array,
+# so README went from under 1000 elements to ~1268. A sanity range, not a pin.
 query I
-SELECT count(*) BETWEEN 10 AND 1000 FROM read_markdown_blocks('README.md');
+SELECT count(*) BETWEEN 10 AND 5000 FROM read_markdown_blocks('README.md');
 ----
 true
 


### PR DESCRIPTION
Started as two reported bugs in `duck_blocks_to_md`. Both were real, and pulling on them found more — several that silently destroyed document content rather than rendering it wrong.

## Content-losing defects

Each of these lost data rather than merely formatting it badly:

- **The metadata leak.** `kind='value'` elements were rendered as body prose in both walks, so a document's title appeared in its text.
- **Lists rendered as nothing.** Structural lists produced empty output; a list also dropped every child that was not an item, and four container types dropped their own content.
- **`hr`/`page_break`/`generic` ate the inline run that followed them.** A block absorbs the run after it, and these three render without using their content — so absorbing *deleted* it. An `hr` followed by a sentence emitted the rule and dropped the sentence. Live in `duck_blocks_to_md`, the documented public function.
- **TOML frontmatter was flattened into unparseable prose.** Hugo's `+++` was unrecognised, fell through to cmark as prose, and a round-trip collapsed the line structure. TOML is line-oriented, so the fields were not misfiled — they were unrecoverable.
- **The COPY blocks-mode renderer had drifted.** It was a second, independent implementation that could not absorb inline runs; README's own example emitted spurious blank lines. Deleted (~340 lines); that path now uses the shared renderer.
- **A figure caption was duplicated** and grew a copy on every pass.
- **cmark extension registration raced**, failing intermittently under parallelism (4 of 12 runs, now 0 of 40).
- **Lists packed their items into a JSON string.** Nested sublists were discarded outright (the source said `// Nested list - skip for now`), inline formatting was flattened — `**bold**` → `bold` — and a second paragraph in an item vanished. 500 levels of nesting came back as *one block*, with a test asserting that `1`. Lists are now structural: `list` → `list_item` → the item's own blocks.
- **A blockquote's block children were concatenated with no separator.** `quoted para` + `second para` came back as `quoted parasecond para`, and a list inside a quote rendered as `> onetwo`. Containers now emit their children as blocks, through an emitter shared with list items.

## Vocabulary alignment

Now at duck_block spec 6.2, tracking a vendored header rather than a submodule.

- Frontmatter emits `element_type='metadata'` with `attributes['role']='frontmatter'` — `frontmatter` was never a declared type. `duck_blocks_to_md` still accepts the old name so stored data keeps rendering.
- Frontmatter `level` is 1 (depth), per the upstream ruling. `read_markdown_sections` keeps its own 0–6 heading-rank column; they are different measurements and README now says so beside both.
- The reader emits the canonical `list_type` alongside the legacy `ordered` boolean. It previously emitted only the legacy one, so consumers reading the canonical attribute worked *only* by falling back.
- All declared attribute, role, list-type and encoding values are constants, not literals.

## Checks

Four, all of which have been observed failing on planted input before being trusted:

- **vocabulary drift** — compares the vendored header against upstream by name *and* value, sha-pinned; refuses to print OK from an unverifiable fetch.
- **conformance** — this reader's output against upstream's canonical SQL rules, including the advisory set and the document-shape rules (unique `element_order`, depth descending one level at a time). Zero warnings across all 17 repo documents. No skip path.
- **producer** — renders live `duck_block_utils` output; both exclusion lists are empty and audit themselves.
- **`make check`** — runs all three, keeps going after a failure, and names each one that failed.

## Corrections made along the way

Worth stating rather than burying, since several were mine:

- I reported "all checks green" for five pushes while the conformance job was failing in CI. It sat in a job with no build, and my own comment on it said "pure SQL, no extension" — the rules are pure SQL, but the reader under test is this extension and the script loads it. Now runs against the published artifact.
- I told two parties that emitting `level=1` was a breaking change to documented public API. It was not; nothing documented read that column's `0`. I asked for a ruling against a cost that did not exist.
- Adding `list_type` to every list changed observable output and **nothing failed** — no test asserted what the reader emits for a list. Covered now.
- A conformance assertion passed vacuously against a build with no TOML support, because unrecognised `+++` becomes valid prose. It now asserts the encoding.
- I told the duck_block spec owner that the producer check was passing on the destroyed blockquote output because it asserts words rather than separators. Wrong: that check runs the producer's blocks through *this writer*, a path that was always correct, and never touches this reader. A missing **direction** hid it, not a coarse assertion. Both are closed now.
- The anti-concatenation check arm shipped broken on its first attempt — it printed the failure but never entered the failure list, so it would have reported the defect and exited green. Caught by control-testing it.
- `docs/doc_block_spec.md` is marked superseded; it carried MUST language that taught the first bug in this list.

## Verification

45 tests / 1713 assertions. Conformance 15/15 with no exceptions — including zero advisory warnings across all 17 repo documents — run in CI against the published artifact with both controls firing. Vocabulary in sync at 91 constants; upstream's independent alignment instrument reports this extension as `ALIGNED` with zero value changes. README's `COPY TO` example verified verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
