### PR TITLE
fix: a heading silently discarded its own inline formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Reads Markdown files and parses them into block-level elements (headings, paragr
 - `include_filepath := false` - Include file_path column in output (alias: `filename`)
 - `extract_extensions := NULL` - Opt-in add-on extractors (see [Optional Add-On Extractors](#optional-add-on-extractors-extract_extensions)). When set, adds per-block `wikilinks` and/or `tags` columns extracted from each block's content.
 
-**Returns:** `(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER, encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER)`. `level` is structural **depth**, minimum 1 — a heading's rank is `attributes['heading_level']`, not `level`. (`read_markdown_sections` has a `level` column too, but that one is heading rank, 0-6.) With `extract_extensions`, the requested add-on columns are appended.
+**Returns:** `(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER, encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER)`. `level` is structural **depth**, minimum 1 — a heading's rank is `attributes['heading_level']`, not `level`. A heading carries both a flattened plain-text title in `content` (what `section_id` and the sections API read) and its formatted text as inline children, so `# **Bold** t` keeps its emphasis instead of collapsing to `# Bold t`. (`read_markdown_sections` has a `level` column too, but that one is heading rank, 0-6.) With `extract_extensions`, the requested add-on columns are appended.
 
 **Note on level vs heading_level:** For headings, the H1-H6 level is stored in `attributes['heading_level']` (preferred). If not present, the `level` field is used as a fallback.
 

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1447,7 +1447,22 @@ static string RenderDuckBlockRange(const vector<Value> &list_children, idx_t beg
 			scope_end = SkipElementScope(list_children, i, end);
 		}
 		bool consumed_children = false;
-		if (content.empty() && scope_end > i + 1 && depth < MAX_DUCK_BLOCK_NESTING &&
+		// A HEADING absorbs its inline run even though it has content of its own:
+		// its content is the flattened title and the children are the formatted
+		// text, so the children win for rendering. Every other element treats
+		// non-empty content as "this element already carries its text".
+		//
+		// DEEPER, not merely following. Requiring the run to be nested below the
+		// heading is what separates "these inlines are my children" from "an
+		// inline run happens to come after me" -- a hand-built list can put a bare
+		// run after a heading, and absorbing it would render the run as the title
+		// and destroy the real one. That is the `hr` defect again: taking a run
+		// that is not yours and discarding your own content with it. Caught by an
+		// existing COPY test rather than by reasoning, which is why this condition
+		// is here and not in the first version.
+		const bool heading_with_children = element_type == Vocab::TYPE_HEADING && i + 1 < end &&
+		                                   DuckBlockLevel(list_children[i + 1]) > DuckBlockLevel(list_children[i]);
+		if ((content.empty() || heading_with_children) && scope_end > i + 1 && depth < MAX_DUCK_BLOCK_NESTING &&
 		    DuckBlockKind(list_children[i + 1]) == Vocab::KIND_INLINE) {
 			content = RenderDuckBlockRange(list_children, i + 1, scope_end, depth + 1);
 			consumed_children = true;

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1332,10 +1332,24 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		case CMARK_NODE_HEADING: {
 			block.block_type = "heading";
 			int heading_level = cmark_node_get_heading_level(child);
-			// Headings keep their title as plain text (title semantics: TOC and
-			// heading extraction want a string). Inline formatting in a heading is
-			// flattened rather than decomposed into structured children.
+			// A heading carries BOTH, and it is the one element where both are
+			// meaningful. `content` stays the flattened title, because that is what
+			// a title IS for -- md_extract_sections, read_markdown_sections and the
+			// section_id slug all want a string, and every existing consumer reads
+			// this field. The inline CHILDREN carry the formatting.
+			//
+			// Until 2026-09-01 only the flattened form existed, so `# **Bold** t`
+			// and `# Bold t` produced byte-identical output and a round trip
+			// rewrote the first as the second. A distinction the source makes,
+			// removed silently and irreversibly -- which the duck_block ruling on
+			// pandoc fidelity leaves forbidden even where enhancement is allowed.
+			// This repo's own README lost the backticks off four API headings.
 			block.content = GetInlineText(child);
+			std::string heading_simple;
+			if (structured_inlines && !SingleTextChild(child, heading_simple)) {
+				emit_inlines = true;
+				inline_container = child;
+			}
 
 			// Store heading level as attribute (H1=1, H2=2, etc.)
 			block.attributes["heading_level"] = std::to_string(heading_level);

--- a/test/sql/duck_block_heading_children.test
+++ b/test/sql/duck_block_heading_children.test
@@ -1,0 +1,75 @@
+# name: test/sql/duck_block_heading_children.test
+# description: a heading carries both a flattened title and its formatted inline children
+# group: [sql]
+
+require markdown
+
+# `# **Bold** t` and `# Bold t` used to produce byte-identical output, so a round
+# trip rewrote the first as the second -- a distinction the source makes, removed
+# silently and irreversibly. This repo's own README lost the backticks off four
+# API headings that way.
+#
+# The fix is ADDITIVE: `content` is still the flattened title, because that is
+# what md_extract_sections, read_markdown_sections and the section_id slug all
+# read. The formatting lives in inline children beside it.
+
+# The formatting survives a round trip
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'# **Bold** title\n')) = E'# **Bold** title\n\n';
+----
+true
+
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(e'## The `fn()` call\n')) = E'## The `fn()` call\n\n';
+----
+true
+
+# A plain heading is unchanged and gains no children
+query II
+SELECT (SELECT count(*) FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'# Plain\n')) AS e) WHERE e.kind = 'inline'),
+       duck_blocks_to_md(parse_markdown_to_duck_blocks(e'# Plain\n')) = E'# Plain\n\n';
+----
+0	true
+
+# CONTENT IS STILL THE FLATTENED TITLE -- every existing consumer reads this
+query I
+SELECT e.content FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'## The `fn()` call\n')) AS e)
+WHERE e.element_type = 'heading';
+----
+The fn() call
+
+# ...and the children carry the structure, one level deeper
+query III
+SELECT e.kind, e.element_type, e.content
+FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'## The `fn()` call\n')) AS e)
+WHERE e.kind = 'inline';
+----
+inline	text	The 
+inline	code	fn()
+inline	text	 call
+
+# Title-string consumers are untouched, formatting or not
+query II
+SELECT s.title, s.section_id FROM (SELECT unnest(md_extract_sections(e'# The `fn()` call\n\nBody.\n')) AS s);
+----
+The fn() call	the-fn-call
+
+# REGRESSION: a heading must absorb only inlines NESTED BELOW it. A bare run that
+# merely FOLLOWS a heading is not its children, and absorbing it would render the
+# run as the title and destroy the real one -- the `hr` defect in another costume.
+# Caught by an existing COPY test, not by reasoning.
+query I
+SELECT duck_blocks_to_md([
+  {kind: 'block', element_type: 'heading', content: 'Real Title', level: 1, encoding: 'text', attributes: MAP{}::MAP(VARCHAR, VARCHAR), element_order: 0},
+  {kind: 'inline', element_type: 'text', content: 'separate prose', level: 1, encoding: 'text', attributes: MAP{}::MAP(VARCHAR, VARCHAR), element_order: 1}])
+     = E'# Real Title\n\nseparate prose';
+----
+true
+
+# Round trip is stable, not merely lossless once
+query I
+SELECT duck_blocks_to_md(parse_markdown_to_duck_blocks(
+         duck_blocks_to_md(parse_markdown_to_duck_blocks(e'### A **bold** and `code` heading\n'))))
+     = duck_blocks_to_md(parse_markdown_to_duck_blocks(e'### A **bold** and `code` heading\n'));
+----
+true


### PR DESCRIPTION
`# **Bold** title` and `# Bold title` produced **byte-identical** output, so a round trip rewrote the first as the second. Same for inline code — this repo's own README has four API headings of the form `#### \`read_markdown(...)\``, and every one came back with the backticks stripped.

A distinction the source makes, removed silently and irreversibly.

## Why this is still a defect under the new fidelity ruling

duck_block's ruling on pandoc fidelity relaxes 1-for-1 faithfulness, but leaves one category forbidden: *silently normalising away a distinction the source makes*. That's the half that applies here. It fails both of the ruling's conditions — it isn't **declared** (nothing in the data says the title was flattened) and isn't **reversible** (the emphasis is simply gone).

duck_block_utils cleared this extension on the two axes they could see — no `kind='value'` emission, no `deflist` path, both of which I'd verified independently. Headings were in neither.

## The fix is additive, which is what makes it safe

`content` **remains the flattened title**. `md_extract_sections`, `read_markdown_sections` and the `section_id` slug all read that field, and all are byte-identical before and after — verified, not assumed:

```
section title: [The fn() call]  id=the-fn-call     ← unchanged
blocks.content: [The fn() call]                    ← unchanged
```

The formatting now *also* exists as inline children beside it. A heading is the one element where both fields are meaningful: it has a title-string role and a rich-content role, and collapsing them into one is what lost the formatting.

The writer already rendered the target shape correctly. It only needed to prefer children over content for headings — which is what it already does for paragraphs.

## An existing test caught my first attempt

The first version absorbed *any* following inline run, so a heading would swallow a bare run that merely came after it — rendering the run as the title and destroying the real one. That's the `hr` defect in another costume: taking a run that isn't yours and discarding your own content with it.

The reader never emits that shape, but a hand-built list can, and `markdown_copy.test` had exactly one. The run must now be nested **below** the heading, which is what separates children from neighbours.

## Verification

46 tests / 1731 assertions. `make check` green across all three checks; conformance 18/18 with no exceptions. Plain headings gain no children; round trip stable over two passes; title consumers byte-identical.

Targets `duck_block_bump`, not `main`, per the coordinated five-repo release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
