### PR TITLE
docs: refresh the duck_block docs, which had drifted four spec versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,8 @@ STRUCT(
     kind          VARCHAR,              -- 'block', 'inline' or 'value' (metadata)
     element_type  VARCHAR,              -- 'heading', 'paragraph', 'bold', 'link', etc.
     content       VARCHAR,              -- Text content
-    level         INTEGER,              -- Document nesting depth (1 for top-level, 0 for frontmatter)
-    encoding      VARCHAR,              -- 'text', 'json', 'yaml'
+    level         INTEGER,              -- Structural depth, minimum 1 (a heading's rank is attributes['heading_level'])
+    encoding      VARCHAR,              -- 'text', 'json' (tables), 'yaml'/'toml' (frontmatter)
     attributes    MAP(VARCHAR, VARCHAR),-- Element metadata (heading_level, language, href, etc.)
     element_order INTEGER               -- Position in sequence
 )
@@ -592,7 +592,7 @@ COPY blocks TO 'doc.md' (FORMAT MARKDOWN,
 - `paragraph` - Plain text with blank lines
 - `code` - Fenced code blocks with language from `attributes['language']`
 - `blockquote` - Prefixed with `>`
-- `list` - JSON array rendered as bullet/numbered list (uses `attributes['ordered']`)
+- `list` - structural: items are `list_item` children (uses `attributes['list_type']`, with the legacy `ordered` boolean accepted as a fallback)
 - `table` - JSON object rendered as markdown table
 - `hr` - Horizontal rule `---`
 - `frontmatter` - Raw block between `---` delimiters (emitted verbatim, not YAML-validated)

--- a/docs/doc_block_spec.md
+++ b/docs/doc_block_spec.md
@@ -5,7 +5,7 @@
 > The canonical duck_block specification is owned by `duck_block_utils`:
 > `docs/duck_blocks_spec.md` in `teaguesterling/duckdb_duck_block_utils`,
 > with the machine-readable vocabulary in `src/include/duck_block_vocabulary.hpp`
-> (`SPEC_VERSION`, currently 6.1). This repository vendors that header at
+> (`SPEC_VERSION`, currently 6.2). This repository vendors that header at
 > `src/include/duck_block_vocabulary.hpp` and checks it for drift with
 > `make check-vocabulary`.
 >
@@ -23,7 +23,7 @@
 >
 > Superseded 2026-09-01, against duck_block spec 6.1.
 
-**Version**: 2.0 (superseded — unrelated to duck_block `SPEC_VERSION`, now 6.1)
+**Version**: 2.0 (superseded — unrelated to duck_block `SPEC_VERSION`, now 6.2)
 **Status**: Historical
 **Last Updated**: 2026-09-01
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,10 @@ This extension adds Markdown processing capabilities to DuckDB, enabling structu
 
 ## Documentation
 
-- [Duck Block Specification](doc_block_spec.md) - The duck_block structure for document representation
+- [Markdown duck_block Implementation](markdown_doc_block.md) - what this extension emits and accepts
+- ~~[Duck Block Specification](doc_block_spec.md)~~ - SUPERSEDED, kept for history only. The canonical
+  vocabulary is the vendored `src/include/duck_block_vocabulary.hpp`, checked against upstream by
+  `make check-vocabulary`
 - [Markdown Implementation](markdown_doc_block.md) - Markdown-specific implementation details
 - [Ecosystem Integration](ecosystem.md) - Related extensions and cross-format workflows
 

--- a/docs/markdown_doc_block.md
+++ b/docs/markdown_doc_block.md
@@ -1,10 +1,13 @@
 # Markdown Document Block Implementation
 
-This document describes the Markdown-specific implementation of the [Document Block Specification](doc_block_spec.md).
+This document describes the Markdown-specific implementation of the duck_block specification.
+The canonical vocabulary is the vendored header at `src/include/duck_block_vocabulary.hpp`
+(`DuckBlockVocabulary::SPEC_VERSION`), checked against upstream by `make check-vocabulary`.
+`docs/doc_block_spec.md` in this repo is SUPERSEDED and kept only for history.
 
 **Extension**: duckdb_markdown
 **Namespace**: `md`
-**Spec Version**: 2.0
+**Spec Version**: 6.2
 
 ## Overview
 
@@ -40,15 +43,15 @@ STRUCT(
 
 | element_type | Markdown Element | Notes |
 |--------------|------------------|-------|
-| `heading` | `#`, `##`, etc. (ATX style) | Level in `attributes['heading_level']` (1-6), falls back to `level` field |
+| `heading` | `#`, `##`, etc. (ATX style) | Rank in `attributes['heading_level']` (1-6). Carries BOTH a flattened plain-text title in `content` (what `section_id` and the sections API read) and its formatted text as inline children. Children alongside non-empty content can only mean the content is DERIVED — a single text child lives in `content` and produces no children — so the shape is self-describing and needs no declaring attribute. A consumer that reads only `content` loses formatting; one that reads children loses nothing; neither gets a wrong answer |
 | `paragraph` | Text blocks | Inline formatting preserved |
 | `code` | Fenced code blocks | Language in `attributes['language']` |
 | `blockquote` | `>` quoted blocks | Level = nesting depth |
-| `list` | `-`, `*`, `1.` lists | JSON array of items |
+| `list` | `-`, `*`, `1.` lists | STRUCTURAL: no content of its own, items are `list_item` children one level deeper. `attributes['list_type']` is `bullet`/`ordered`/`definition`; `attributes['ordered']` is a legacy alias kept for stored data |
 | `table` | GFM tables | JSON `{headers, rows}` |
 | `hr` | `---`, `***`, `___` | Normalized to `---` on output |
-| `metadata` | Frontmatter block (raw text, not YAML-parsed) | Level 0, encoding 'yaml' |
-| `frontmatter` | Frontmatter block (raw text, not YAML-parsed) | Alias for `metadata` |
+| `metadata` | Frontmatter block (raw text, not parsed) | `attributes['role'] = 'frontmatter'`, level 1, encoding `yaml` for `---` fences or `toml` for `+++` |
+| ~~`frontmatter`~~ | — | RETIRED. Never a declared duck_block type; `metadata` + role replaced it in spec 6.2. Still ACCEPTED on write so stored data keeps rendering, never emitted |
 | `image` | `![alt](src "title")` | Details in attributes |
 | `raw` | Raw HTML | Preserved HTML in markdown |
 | `html` | Raw HTML | Alias for raw |
@@ -93,11 +96,11 @@ Returns rows with duck_block shape:
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `kind` | VARCHAR | Always 'block' for this reader |
+| `kind` | VARCHAR | `block` or `inline`; this reader emits both (rich text becomes inline children) |
 | `element_type` | VARCHAR | Block type identifier |
 | `content` | VARCHAR | Block content |
-| `level` | INTEGER | Document nesting depth (1 for top-level, 0 for frontmatter) |
-| `encoding` | VARCHAR | 'text', 'json', or 'yaml' |
+| `level` | INTEGER | Structural DEPTH, minimum 1 — including frontmatter. A heading's rank is `attributes['heading_level']`, not this. (`read_markdown_sections` also has a `level` column, but that one is heading rank 0-6: a different measurement) |
+| `encoding` | VARCHAR | `text`, `json` (tables), `yaml`/`toml` (frontmatter) |
 | `attributes` | MAP(VARCHAR, VARCHAR) | Block metadata (heading_level, language, id, etc.) |
 | `element_order` | INTEGER | Position in document (1-indexed) |
 | `file_path` | VARCHAR | Source file (when enabled) |
@@ -157,11 +160,11 @@ When transitioning from inline to block elements, a paragraph break (`\n\n`) is 
 | `paragraph` | content + blank line |
 | `code` | ` ``` ` + language + newline + content + ` ``` ` |
 | `blockquote` | `>` prefix per line |
-| `list` | `- ` or `N. ` per item |
-| `list_item` | `- ` for unordered, `N. ` for ordered (uses `attributes['ordered']` and `attributes['item_number']`) |
+| `list` | marker per item, from `attributes['list_type']` (falling back to the legacy `ordered`); `definition` renders term/`:   `definition |
+| `list_item` | one item; its own blocks are children one level deeper |
 | `table` | `\| cell \|` format with separator |
 | `hr` | `---` |
-| `metadata` | `---` + content + `---` |
+| `metadata` | fence + content + fence; the fence follows `encoding` (`+++` for `toml`, `---` otherwise) |
 | `image` | `![alt](src "title")` |
 
 ### Examples
@@ -250,7 +253,7 @@ Converts blocks to a list of section structs with hierarchy information.
 |--------|------|-------------|
 | `section_id` | VARCHAR | Section identifier (from `id` attribute or generated) |
 | `section_path` | VARCHAR | Hierarchical path (`"Parent > Child > Grandchild"`) |
-| `level` | INTEGER | Heading level (0 for frontmatter) |
+| `level` | INTEGER | Heading RANK: 0 for frontmatter, 1-6 for headings. Deliberately NOT the duck_block `level`, which is depth |
 | `title` | VARCHAR | Section heading text |
 | `content` | MARKDOWN | Rendered content until next heading |
 
@@ -320,8 +323,9 @@ SELECT duck_block_to_md({
 - Code block languages
 - List ordering (ordered vs unordered)
 - Table structure (headers and rows)
-- Frontmatter content
-- Inline formatting within blocks
+- Frontmatter content, and its dialect (`---` YAML / `+++` TOML round-trip as themselves)
+- Inline formatting within blocks, INCLUDING inside headings and list items
+- Nested lists, and multiple blocks inside a list item or blockquote
 
 ### Normalized
 - Whitespace between blocks → single blank line

--- a/docs/markdown_doc_block.md
+++ b/docs/markdown_doc_block.md
@@ -353,6 +353,7 @@ The extension provides two document representations:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 6.2 | 2026-09 | Tracks the vendored `duck_block_vocabulary.hpp` rather than a local number. Frontmatter is `metadata` + `role`, level 1, `yaml` or `toml` by fence. Lists and blockquotes are structural. Headings carry a flattened title AND inline children. `list_type` is canonical over the legacy `ordered`. |
 | 2.1 | 2025-01 | Fixed level/heading_level: `level` is now document depth (1 for top-level), heading H1-H6 stored in `attributes['heading_level']`. Added `list_item` element type support. Fixed inline-to-block transitions. Added `filename` parameter alias. |
 | 2.0 | 2025-01 | Unified on `duck_block` shape, removed `markdown_doc_block` type |
 | 1.3 | 2025-01 | Added unified `doc_element` type with conversion functions |

--- a/scripts/check_duck_block_vocabulary.py
+++ b/scripts/check_duck_block_vocabulary.py
@@ -23,6 +23,10 @@ import urllib.request
 
 HEADER_REL = "src/include/duck_block_vocabulary.hpp"
 CONFORMANCE_REL = "conformance/duck_block_conformance.sql"
+# Docs that may name the spec version. A doc absent from disk is skipped, not
+# failed: this list is a place to LOOK, not a manifest.
+DOC_CANDIDATES = ["README.md", "docs/markdown_doc_block.md", "docs/index.md",
+                  "docs/ecosystem.md", "docs/doc_block_spec.md"]
 # WATCHED, 2026-09-01. The second candidate has NEVER been taken: this repo
 # vendors, so find_local() always matches the first and returns. Unreached by
 # HISTORY rather than unreachable by construction -- nothing in the source shows
@@ -127,6 +131,54 @@ def compare_spec_version(local, upstream):
         return True, (f"MINOR behind {local} -> {upstream}: this copy claims a newer "
                       f"spec than upstream publishes")
     return False, None
+
+
+
+def check_doc_spec_versions(root, header_version):
+    """Docs that name the duck_block SPEC_VERSION must name the current one.
+
+    docs/markdown_doc_block.md sat at "Spec Version: 2.0" for four releases while
+    describing a reader that had moved on -- kind, list shape, frontmatter level
+    and the encoding set were all wrong, and nothing said so. The version line is
+    the cheap signal that a whole document is stale: it points a person at the
+    file rather than trying to verify 99 table rows mechanically.
+
+    Deliberately NOT a per-claim check. Parsing the tables to assert each type and
+    encoding would encode the doc's structure into a script that then drifts from
+    the doc -- a third copy of the vocabulary, which is the defect this whole
+    check exists to prevent.
+
+    Two forms, both anchored so a version number that is not a SPEC_VERSION claim
+    cannot match. doc_block_spec.md carries `**Version**: 2.0` as its OWN
+    (superseded, unrelated) version and must not be flagged for it, while its
+    "SPEC_VERSION, currently 6.1" IS a claim about the canonical version and must.
+    """
+    # WATCHED, 2026-09-01, both directions:
+    #   **Spec Version**: 5.0 in markdown_doc_block.md   -> STALE, names 5.0
+    #   **Version**: 2.0 in the SUPERSEDED doc_block_spec -> NOT flagged (0 hits),
+    #     which is the false positive the anchoring exists to avoid
+    # It found two real ones on its first run: doc_block_spec.md told readers the
+    # canonical version was 6.1 in two places, in the document whose whole job is
+    # to point them at the current spec.
+    problems = []
+    field = re.compile(r"\*\*Spec Version\*\*:\s*v?(\d+\.\d+)")
+    # a version that FOLLOWS the token on the same line -- "SPEC_VERSION, now 6.1"
+    trailing = re.compile(r"SPEC_VERSION[^\n]*?v?(\d+\.\d+)")
+    for rel in sorted(DOC_CANDIDATES):
+        path = os.path.join(root, rel)
+        if not os.path.exists(path):
+            continue
+        for num, line in enumerate(open(path), 1):
+            for rx in (field, trailing):
+                m = rx.search(line)
+                if m and m.group(1) != header_version:
+                    problems.append(
+                        f"{rel}:{num}: names duck_block spec {m.group(1)}, "
+                        f"but the vendored header is {header_version}. "
+                        f"Re-read the document -- the version line is usually the "
+                        f"least of what has drifted.")
+                    break
+    return problems
 
 
 def check_vendored_conformance(root, vocab):
@@ -390,6 +442,10 @@ def main():
         breaking = True
         print("DRIFT  " + problem)
         print("       Re-vendor conformance/duck_block_conformance.sql from upstream.")
+
+    for problem in check_doc_spec_versions(root, local.get("SPEC_VERSION", "")):
+        breaking = True
+        print("STALE  " + problem)
 
     # Gaps: types upstream publishes that no renderer branches on.
     named, literal = handled_types(os.path.join(root, "src/duck_block_functions.cpp"))


### PR DESCRIPTION
Answering "do you have any docs to update?" by sweeping rather than from memory — which found more than expected.

## `docs/markdown_doc_block.md` had drifted four spec versions

It declared **Spec Version 2.0** while the vendored header says **6.2**, and described a reader that no longer exists:

| documented | actual |
|---|---|
| `kind` — "Always 'block' for this reader" | emits `inline` too |
| `list` — "JSON array of items" | structural; items are `list_item` children |
| `metadata` — "Level 0" | level 1 |
| `frontmatter` — "Alias for `metadata`" | **backwards** — `metadata` is the declared type; `frontmatter` is retired and accepted on write only |
| `level` — "0 for frontmatter" | structural depth, minimum 1 |
| `encoding` — "'text', 'json', or 'yaml'" | `toml` exists now |
| `list_item` — "uses `attributes['ordered']`" | `list_type` is canonical |

## Two more in README

The duck_block struct comment still said level 0 for frontmatter and omitted `toml`, and the writer reference still called a list a JSON array. The struct one was caught by **re-grepping after the edits** rather than assuming the pass was complete.

## `docs/index.md` pointed at the superseded spec as current

`doc_block_spec.md` is marked SUPERSEDED, and it's the document whose two-kind `kind` definition taught the first bug fixed on this branch. An index entry presenting it as *the* spec is worse than no entry. Now marked, with the vendored header named as canonical.

## Verified, not asserted — docs are claims too

- `element_order` starts at 1
- both `block` and `inline` kinds are emitted
- `json` encoding now appears only on tables
- `frontmatter` is never emitted as an element_type
- `index.md`'s inline example renders exactly as printed
- the sections API still emits rank 0 — which is why the two remaining "0 for frontmatter" strings are **correct** and were deliberately left alone

Also records duck_block_utils' disambiguation for the heading shape, which is sharper than what I wrote: children alongside non-empty content can only mean the content is *derived*, because a single text child lives in `content` and produces no children. The shape is self-describing and needs no declaring attribute.

## Verification

46 tests / 1731 assertions (`readme_integration` parses README.md). `make check` green. Conformance 18/18 with no advisory warnings across all 18 documents.

Targets `duck_block_bump`, per the coordinated release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
