### PR TITLE
Build against DuckDB v2.0 as well as the pinned v1.5

### DIFF
--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -232,6 +232,48 @@ inline string CompatNameStr(const Identifier &id) { return id.GetIdentifierName(
 inline CompatName CompatMakeName(string name) { return CompatName(std::move(name)); }
 ```
 
+**Write it WITHOUT `typename`.** `std::remove_reference<decltype(...)>::type::value_type`
+is non-dependent at namespace scope, and `typename` outside a template is only
+legal from C++20. GCC tolerates it; **MSVC does not**, so it breaks the Windows
+leg and nothing else. The same applies to any
+`child_list_t<...>::value_type::first_type`.
+
+**Assert the coupling.** Deriving the type fixes one failure mode and leaves
+another: `CompatName` can resolve to `Identifier` on a DuckDB whose
+`identifier.hpp` this header did not find, so the `Identifier` overload was never
+declared. This holds on both lines and is not a tautology:
+
+```cpp
+static_assert(std::is_same<decltype(CompatNameStr(std::declval<const CompatName &>())), string>::value,
+              "CompatNameStr must accept the derived CompatName on every DuckDB line");
+```
+
+(When it does fire, the failure is a hard error inside the `decltype` —
+*"'CompatNameStr' was not declared in this scope"* — so the message string never
+prints. Right line, right file, but the comment beside it does the explaining.)
+Do **not** assert `is_same<CompatName, string>`: true on the pin, false on main,
+so it hard-fails the v2.0 build. And asserting `CompatName` equals the expression
+that *defines* it can never fire.
+
+#### The same bomb, a second time: `child_list_t` keys
+
+STRUCT/UNION field names are the other boundary that moved, and a
+`CompatMakeIdentifier`-style helper selected by `__has_include` has **exactly the
+same defect**. Verified: `child_list_t`'s key is `std::string` on the pin **and on
+the stable branch tip**, and `Identifier` only on main — so a header probe flips
+the constructed key type while `child_list_t` still wants strings.
+
+Derive it from the same boundary:
+
+```cpp
+using CompatIdentifierKey = child_list_t<LogicalType>::value_type::first_type;
+```
+
+Only **construction** has to choose; *reading* a key can be overloaded
+unconditionally. String **literals** are fine either way — `Identifier` is
+implicitly constructible from `const char *` — so this only bites where a
+**runtime** string becomes a field name.
+
 Then `vector<string> &names` becomes `vector<CompatName> &names` in every bind
 declaration *and* definition, and runtime boundaries use the helpers. Do not add
 an implicit conversion — the explicitness is the upstream change's point.
@@ -402,6 +444,20 @@ BoundFunctionExpression::bind_info (now private)
 object, and `Catalog::GetEntry`, `FunctionBinder::BindScalarFunction` and the
 `FunctionExpression` constructor all take `Identifier` where they took `string`.
 
+Most of these need **no shim at all** — the setters already exist on the pin
+(`SetNullHandling` at `function.hpp:199`, likewise `SetReturnType`,
+`GetReturnType`, `GetStability`, and `BaseExpression::GetAlias`). `varargs` is
+the one member that genuinely needs a branch, because v1.5's `SimpleFunction` has
+a public field and no `SetVarArgs`.
+
+The grep that finds this class is on the **assignment**, not the setter —
+searching for `SetStability|SetNullHandling|SetVarArgs` only finds code that has
+already been fixed:
+
+```
+grep -rnE '\.(null_handling|stability|varargs|bind|serialize) *=' src/
+```
+
 **Do not write these shims from scratch.** `duckdb_yaml`'s
 `src/include/duckdb_compat.hpp` is the most complete in the fleet and already has
 them — `DUCKDB_SCALAR_BIND_PARAMS` / `_CONTEXT` / `_ARGS`, `CompatExprReturnType`,
@@ -534,11 +590,33 @@ INTERNAL Error: Scalar function "to_xml" threw an execution error, but the
 function is not marked as fallible - the function must call SetFallible().
 ```
 
-**No shim.** `SetFallible()` exists identically on the pin
-(`function.hpp:211`, on `BaseScalarFunction`) and on main
-(`scalar_function.hpp:249`) — same name, same zero-argument spelling. A probe
-would take the same branch on both, which is detection that detects nothing.
-Call `f.SetFallible()` directly.
+**Read this before the error message above: v1.5 already has this flag.**
+`BaseScalarFunction::SetFallible()` is at `function.hpp:211` on the pin, and
+`FunctionErrors errors` (defaulting to `CANNOT_ERROR`) already feeds
+`Expression::CanThrow()`. **v2.0 did not add the contract — it added
+enforcement of a contract that already existed and that these extensions have
+been quietly violating on the version they ship.** That reframes the whole
+change: it is not a v2.0 compat chore, it is a latent correctness bug on v1.5
+that v2.0 surfaces.
+
+**A plain function needs no shim; a `FunctionSet` does.** This is the trap, and
+most functions live in sets:
+
+```
+pin:   FunctionSet has `vector<T> functions`         and NO set-level SetFallible
+main:  FunctionSet has SetFallible()                 and `vector<shared_ptr<const T>>`
+```
+
+So neither spelling works on both. Probe for the set-level member:
+
+```cpp
+// true_type  -> set.SetFallible();                              // v2.0 set, or any plain function
+// false_type -> for (auto &f : set.functions) f.SetFallible();  // v1.5 set, members still mutable
+```
+
+A guide that just says "call it directly" leaves **every `ScalarFunctionSet`
+unmarked on the shipping version** — in one repo that was 10 sets against 8 plain
+functions, i.e. most of the surface.
 
 **It is not a no-op on the version you ship — it is unenforced.** The
 distinction matters: v1.5 *has* the flag and *consults* it; it simply does not
@@ -553,11 +631,24 @@ shipped planner **strictly more conservative** around it. That direction is safe
 have been — but it is a real change, so measure it rather than assuming.
 
 **Mark precisely, not defensively.** Because the property is optimizer-visible,
-declaring it on a function that *cannot* throw is itself a behaviour change, not
-free insurance. The reachability question is answerable statically: grep your own
-code for `throw`, then find the transitive callers of any throwing *helper*. In
-one repo three files included a throwing helper's header for an unrelated parser
-and did not reach the throw at all.
+over-marking is a small real pessimisation of the shipped binary, not a free
+hedge.
+
+A one-step `grep throw` **over-marks**. Make it two steps: grep `throw`, then
+check whether an enclosing handler *swallows* it. The tell is a catch-all that
+**returns** rather than rethrows:
+
+```cpp
+catch (...) { return false; }              // NOT fallible -- the throw never escapes
+catch (const InvalidInputException &) { throw; }   // IS fallible
+```
+
+Two functions can look identical until you read the handler. In one repo, 18 of
+21 scalar functions were fallible and the 3 that were not could not be told apart
+by grepping `throw` at all. Also follow the transitive callers of any throwing
+*helper* — and note that including a throwing helper's header proves nothing;
+one repo had three files including such a header for an unrelated parser and
+never reaching the throw.
 
 **Registration shape can block the fix.** `loader.RegisterFunction(ScalarFunction(...))`
 constructs a temporary, so there is no object to call `SetFallible()` on. Hoist

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -135,6 +135,30 @@ inline LogicalType CompatWithAlias(TYPE t, string a) {
 
 markdown's header is written this way, so it is safe to copy into a C++11 repo.
 
+**The `Impl` overloads must be templates.** This is the footgun in the idiom, and
+it fails on the **pinned** build, not on v2.0:
+
+```cpp
+// WRONG -- both bodies are compiled, so the v2.0 branch breaks the v1.5 build
+inline void CompatXImpl(DataChunk &c, idx_t n, std::true_type)  { c.SetChildCardinality(n); }
+inline void CompatXImpl(DataChunk &c, idx_t n, std::false_type) { c.SetCardinality(n); }
+```
+
+Tag dispatch only avoids compiling the untaken branch when that branch is a
+**template that is never instantiated**. As ordinary functions, both bodies are
+compiled and you get *"class duckdb::DataChunk has no member named
+SetChildCardinality"* — from the very shim whose job is to prevent that. Give
+each `Impl` a template parameter (even an unused one) so the untaken overload is
+never instantiated.
+
+**And probe members, not headers, when the question is about a member.** A
+`__has_include("duckdb/common/vector/list_vector.hpp")` that gates a *method*
+choice has the same defect as the `CompatName` bomb: those headers can be
+backported to the stable branch without the method coming along, and then the
+**pinned** build breaks. Use `__has_include` only to decide whether to
+`#include` something — which genuinely is a question about headers — and a
+member probe for everything else.
+
 ## The changes
 
 Sorted by how they announce themselves. **The two that announce themselves not at

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -461,12 +461,19 @@ branch instead.
 Two hazards that cost real time here, both of which produce a *false pass*
 rather than a failure — which is why they are worth stating.
 
-**Give scratch files project-unique names.** Agents sharing one scratch
-directory wrote `build.sh` and `build.log`, and one of them nohup'd a `build.sh`
+**A shared-directory log is a trigger, never evidence.** Agents sharing one
+scratch directory wrote `build.sh` and `build.log`, and one nohup'd a `build.sh`
 that another had overwritten between write and exec. The log came back full of a
-different repo's cmake output and ended in a clean `BUILD_EXIT=0`. It was very
-nearly recorded as "builds green locally" for a project that had never compiled
-at all. Before believing any build log, grep it for your own repo's path.
+different repo's cmake output and ended in a clean `BUILD_EXIT=0` — very nearly
+recorded as "builds green locally" for a project that had never compiled at all.
+
+Use such a file to know *when* something finished, but take the pass/fail claim
+from something only your repo could have produced: a test file name that exists
+nowhere else, a built artifact with your extension's name and a fresh timestamp,
+a function name unique to your source. Best of all, let the result come back
+through the tool result rather than off disk. (Output files the tool itself
+creates for background commands are already collision-safe — they are named per
+invocation. The exposure is only scripts you write into a shared directory.)
 
 **Wait on your own PID, not a `pgrep` pattern.** `pgrep -f 'make release'`
 matches every concurrent build, not yours. It makes a waiter block until the

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -456,6 +456,28 @@ it mixes unrelated reformatting into your port diff and makes the review
 worthless. Check that your branch adds no *new* drift relative to the default
 branch instead.
 
+## If you port several repos at once
+
+Two hazards that cost real time here, both of which produce a *false pass*
+rather than a failure — which is why they are worth stating.
+
+**Give scratch files project-unique names.** Agents sharing one scratch
+directory wrote `build.sh` and `build.log`, and one of them nohup'd a `build.sh`
+that another had overwritten between write and exec. The log came back full of a
+different repo's cmake output and ended in a clean `BUILD_EXIT=0`. It was very
+nearly recorded as "builds green locally" for a project that had never compiled
+at all. Before believing any build log, grep it for your own repo's path.
+
+**Wait on your own PID, not a `pgrep` pattern.** `pgrep -f 'make release'`
+matches every concurrent build, not yours. It makes a waiter block until the
+*last* one finishes, and — worse — can report "gone" while your own build is
+still running. Use `until ! kill -0 $PID 2>/dev/null; do ...; done`.
+
+Also expect memory, not cores, to be the binding constraint: parallel DuckDB
+builds OOM long before they run out of CPU, and an OOM-killed `g++` surfaces as
+`internal compiler error` / `Killed` / `signal 9`, which reads exactly like a
+source bug. Gate on `MemAvailable` and drop to `-j2`.
+
 ## Order of work
 
 1. Grep for every affected site first — the compiler reports only the first few.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -185,6 +185,7 @@ a fully green canary does not clear you of either.
 | 16 | `CreateInfo`/`DropInfo` names → private `QualifiedName` | compile error (storage extensions only) |
 | 17 | result / prepared-statement names are `Identifier` | compile error |
 | 18 | `SetCardinality` → `SetChildCardinality` | compiles; may throw `InternalException` at run time |
+| 19 | single-arrow lambdas rejected by the binder | **SQL, not C++ — no compile signal at all** |
 
 Classes 7 and 13 break at run time on a build that compiles cleanly everywhere.
 Class 11 can compile and misbehave. Class 15 can return **wrong rows** with no
@@ -987,6 +988,46 @@ it throws an `InternalException` if a column is neither flat nor constant and it
 size disagrees, or if the count exceeds a flat vector's capacity, where the old
 call was silent. That fails loudly, so a canary whose Test step exercises those
 paths is real evidence.
+
+### 19. Single-arrow lambdas are a binder ERROR — and it is not C++ at all
+
+The only class here that lives in **SQL**, not in your source. No shim can reach
+it, and a build that is green on both architectures tells you nothing about it.
+
+```
+Binder Error: Deprecated lambda arrow (->) detected. Please transition to the new
+lambda syntax, i.e., lambda x, i: x + i, before DuckDB's next release.
+Use SET lambda_syntax='ENABLE_SINGLE_ARROW' to revert to the deprecated behavior.
+```
+
+The mechanism (`bind_function_expression.cpp`, ~line 209) is worth knowing,
+because it is counter-intuitive: the lambda is bound **successfully first**, and
+*then* thrown on.
+
+```cpp
+bool invalid_syntax = setting != LambdaSyntax::ENABLE_SINGLE_ARROW && syntax_type == SINGLE_ARROW;
+// ... BindLambdaFunction succeeds ...
+if (!lambda_bind_result.HasError()) { if (!invalid_syntax) { return ...; } throw BinderException(msg); }
+```
+
+**The fix is version-agnostic and cheap.** `lambda x: expr` is accepted by the
+pinned v1.5 too, so convert rather than setting the escape-hatch pragma. Verify a
+couple of the converted shapes return identical values on the pin before trusting
+the rest; an unchanged assertion count afterwards is what shows it was a syntax
+change and not a behaviour change.
+
+**Grep for the lambda shape, not for `->`.** A bare `grep ' -> '` is badly
+misleading: `->` is also DuckDB's JSON operator, and it shows up constantly in
+prose. In this repo all 30 hits were **comments**, and none was a lambda — a
+blind conversion would have been pure noise. Anchor on the functions instead:
+
+```
+grep -rnE '(list_transform|list_filter|list_reduce|apply|filter|reduce)\(.*->' test/ src/
+```
+
+**Check shipped SQL, not just tests.** An extension whose `DefaultMacro` body
+contains an arrow lambda fails at **USE** time on v2.0, with no compile signal
+and possibly no test coverage either.
 
 ## Deprecated is not removed — check before you port
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -186,6 +186,7 @@ a fully green canary does not clear you of either.
 | 17 | result / prepared-statement names are `Identifier` | compile error |
 | 18 | `SetCardinality` → `SetChildCardinality` | compiles; may throw `InternalException` at run time |
 | 19 | single-arrow lambdas rejected by the binder | **SQL, not C++ — no compile signal at all** |
+| 20 | `CopyInfo::options` rekeyed to `identifier_map_t` | compile error — **second form has nothing to grep** |
 
 Classes 7 and 13 break at run time on a build that compiles cleanly everywhere.
 Class 11 can compile and misbehave. Class 15 can return **wrong rows** with no
@@ -1029,6 +1030,49 @@ grep -rnE '(list_transform|list_filter|list_reduce|apply|filter|reduce)\(.*->' t
 contains an arrow lambda fails at **USE** time on v2.0, with no compile signal
 and possibly no test coverage either.
 
+### 20. `CopyInfo::options` was rekeyed — and the second failure has nothing to grep for
+
+```
+v1.5:  case_insensitive_map_t<vector<Value>> options;
+v2.0:  identifier_map_t<vector<Value>>       options;
+```
+
+Change 2 already tells you to wrap key *reads* (`CompatNameStr(kv.first)`). That
+catches the obvious error:
+
+```
+cannot convert 'const duckdb::Identifier' to 'const std::string &'
+```
+
+**The second one is the trap.** Any extension that declares its own
+`case_insensitive_map_t<vector<Value>>` local and assigns it into
+`CopyInfo::options` now fails:
+
+```
+no match for 'operator=' between identifier_map_t<vector<Value>>
+                             and case_insensitive_map_t<vector<Value>>
+```
+
+There is no `kv.first` anywhere near it, so every grep in change 2 misses it
+completely. Search for the container type and the struct instead:
+
+```
+grep -rn 'case_insensitive_map_t<vector<Value>>\|CopyInfo\|copied_info' src/
+```
+
+The fix needs no shim and no version branch — **derive the local's type from the
+member it is destined for**, the same move as `CompatName`:
+
+```cpp
+decltype(copied_info.options) csv_copy_options {{"file_extension", {"yaml"}}};
+```
+
+Literal keys need no helper (`Identifier(const char *)` is implicit), so only the
+declaration changes — and it survives the next rekey too.
+
+Note that *registering* options is unaffected: `input.options["my_option"] = ...`
+with a literal key compiles on both lines.
+
 ## Deprecated is not removed — check before you port
 
 Not everything that changed is a hard break, and porting the soft ones costs
@@ -1160,6 +1204,12 @@ covers five (both Linux arches, both macOS arches, Windows/MSVC) plus Wasm. So
 deduction it rejects that GCC and AppleClang accept, for instance — is invisible
 to it. Your MSVC coverage comes from the stable leg only, which is another reason
 not to treat that leg as merely a formality.
+
+**A canary whose Build FAILED tells you nothing about classes 7, 13 or 19** —
+those are runtime contracts, and the Test step never ran. Check that `Test` says
+`success`, not `skipped`. A port reporting "the build is green" from a run whose
+Test step was skipped has verified half of what it thinks it has, and the half it
+skipped is the half no compiler can check.
 
 **A green *build* is not a green canary.** The job runs Build and then Test, and
 community-extensions' `test_against_latest` runs tests too — so it gates on both.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1246,8 +1246,34 @@ Test-failure on `linux_amd64` while `linux_arm64` was green end to end — readi
 the rollup as "the port does not compile" would have sent the next round chasing
 an API problem that did not exist.
 
-**A `linux_amd64` Test failure with `linux_arm64` green may not be yours.** We
-have seen this shape on two unrelated extensions against DuckDB `main`:
+**A `linux_amd64` Test failure with `linux_arm64` green is not diagnostic of
+anything — it tells you to run the A/B, not what the answer is.** At least two
+completely different causes produce that identical shape:
+
+- a **new v2.0 runtime contract** (change 13) enforced by an assertion, and only
+  the amd64 image has assertions on; and
+- a **pre-existing, environment-dependent test** — one repo asserted that CI's
+  submodule checkout had a local branch named `main`, which is true on the native
+  arm64 runner and false in the amd64 docker container. Nothing to do with v2.0
+  at all.
+
+**The instrument that settles it is a canary dispatched on the unported default
+branch.** It needs no local build, costs one run, and is the only thing in this
+whole exercise that produced a *yes/no* answer rather than an inference:
+
+```
+gh workflow run MainDistributionPipeline.yml --ref main     # canary must be gated to allow this
+```
+
+Then compare per-step, per-arch, and compare the *assertion counts and failing
+file:line*, not just the conclusions. In the case above they matched byte for
+byte — same two files, same line 78, same 882/880/2 counts, same "Mismatch on row
+1, column has_main_branch" — which is proof rather than plausibility.
+
+Do not substitute "main's last CI run was green" for this. In that repo main's
+last run was two weeks old, and the test had been broken the whole time.
+
+We have seen the shape on two unrelated extensions against DuckDB `main`:
 
 | repo | ported? | amd64 | arm64 |
 |---|---|---|---|

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -442,6 +442,70 @@ The signature moved *inside* the definition string —
 `DefaultTableMacro` did **not** change, so a repo can be hit by one and not the
 other.
 
+### 13. Fallible scalar functions must say so — a SILENT runtime break
+
+Like change 7, this is a **runtime contract with no compile error and nothing to
+grep for**. v2.0 requires a scalar function that can throw during execution to
+declare it. Throwing from one that has not is an `InternalException`:
+
+```
+INTERNAL Error: Scalar function "to_xml" threw an execution error, but the
+function is not marked as fallible - the function must call SetFallible().
+```
+
+`BaseScalarFunction::SetFallible()` (scalar_function.hpp) takes **no arguments**.
+Call it **before** the function goes into a `FunctionSet` — set members are no
+longer mutable (change 5).
+
+**This is the cause of the amd64/arm64 asymmetry described below.** The contract
+is violated on *both* arches; only the assertion-enabled image reports it. So the
+same commit is green on one leg and red on the other, and the failing test is
+always one that exercises an *error path*.
+
+Confirmed on two unrelated extensions, one of which has **no compat work at all**
+— which is the point: you do not have to port anything to violate a contract that
+is new.
+
+```
+duckdb_webbed  3 of 4 amd64 failures: to_xml, xml_extract_text, xml_wrap_fragment
+duck_hunt      amd64 failure: duck_hunt_load_parser_config   (unported)
+```
+
+The shim is safe and cheap — probe for the member, no-op on v1.5:
+
+```cpp
+template <class FUNC> inline void CompatSetFallible(FUNC &fun);   // see the header
+```
+
+The cost is that it must be applied at every function-construction site, so find
+them by grepping your *own* code for `throw` inside scalar function lambdas.
+
+### 14. `FlatVector::Validity` got the same const split — and hides better
+
+```
+v1.5:  Validity(Vector &)              -> ValidityMask &
+v2.0:  Validity(const Vector &)        -> const ValidityMask &
+       ValidityMutable(Vector &)       -> ValidityMask &
+```
+
+Same copy-on-write distinction as change 3 (`ValidityMutable` un-shares through
+`BufferMutable()`; `Validity` does not).
+
+**Harder to find than change 3**, because the accessor call still compiles:
+`auto &m = FlatVector::Validity(v)` just deduces a const reference. The error
+appears later, at the mutation:
+
+```
+error: passing 'const duckdb::ValidityMask' as 'this' argument discards qualifiers
+```
+
+which names neither `Validity` nor `FlatVector`. So grep for the **mutation**,
+then walk back to where the reference was bound:
+
+```
+grep -rn 'SetInvalid\|SetValid(\|SetAllInvalid\|SetAllValid' src/
+```
+
 ## Deprecated is not removed — check before you port
 
 Not everything that changed is a hard break, and porting the soft ones costs
@@ -472,6 +536,18 @@ identically to the broken cases in a grep, so they are easy to over-port:
   `expr->SetAlias(bound.names[i])` compiles unchanged on both versions.
 - `FunctionSet<T>::name` is still a public member (an `Identifier`). Only
   `functions` became `shared_ptr<const T>` (change 5).
+- **`ConstantVector` did not get a `GetDataMutable`.** It kept a const-overloaded
+  pair instead — `GetData(const Vector &)` returning `const T *` and
+  `GetData(Vector &)` returning `T *` — so `ConstantVector` write sites need no
+  change. Parameterising the shim on the accessor class handles this correctly:
+  the probe is false, it falls back to `GetData`, and `GetData` on a non-const
+  `Vector &` already returns a mutable pointer. Do not "fix" these into a
+  `ConstantVector::GetDataMutable` that does not exist.
+- `named_parameter_map_t` is now `identifier_map_t<Value>`, so `kv.first` in a
+  named-parameter loop is an `Identifier` — and still needs no change.
+  `Identifier` has `operator==` against `const char *`, `const string &` and
+  `Identifier`, and `fn.named_parameters["literal"] = type` still works through
+  the implicit literal constructor.
 
 You can settle any such question in seconds without a CI round and without
 cloning: read the header on `raw.githubusercontent.com/duckdb/duckdb/main/...`.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1245,6 +1245,35 @@ is therefore **not** two independent confirmations — if only amd64 tests, a gr
 arm64 corroborates nothing about runtime. Check which legs actually ran a `Test`
 step before counting them as agreement.
 
+**Match the canary's arch set to what the GATE builds, not to what your repo
+ships.** These are different things, and the difference runs the wrong way.
+
+The gate's platform set comes from the extension's entry in
+`duckdb/community-extensions`, via `build.excluded_platforms` in its
+`description.yml`:
+
+```yaml
+build:
+  excluded_platforms: "windows_amd64_rtools;windows_amd64_mingw"   # if absent: FULL default matrix
+```
+
+That string becomes `COMMUNITY_EXTENSION_EXCLUDE_PLATFORMS` and then
+`exclude_archs` in `build.yml`. **If the key is absent, the gate builds the full
+default matrix — Windows and Wasm included.** Checked across four of these
+extensions, none sets it, so all four are gated on the full matrix while their
+canaries build two Linux legs.
+
+Two consequences:
+
+- A green canary is **weaker evidence than the gate requires**. It is not wrong,
+  it is narrow — and Windows/MSVC is exactly where template-deduction differences
+  live (see the C++ standard section).
+- Do **not** copy your shipping job's `exclude_archs` onto the canary to hide a
+  known-flaky runner. That narrows the canary away from the thing it exists to
+  predict. If a platform genuinely cannot build, exclude it at the *gate* by
+  setting `excluded_platforms` in `description.yml` — a deliberate, visible
+  decision — rather than quietly in the canary.
+
 **The canary covers fewer platforms than the stable leg.** The canary matrix
 generates only `linux_amd64` and `linux_arm64`, while a stable leg typically
 covers five (both Linux arches, both macOS arches, Windows/MSVC) plus Wasm. So

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -184,7 +184,7 @@ a fully green canary does not clear you of either.
 | 10 | `Vector::Reference` gained `count_t` | compile error — **must be `#ifdef`, not `if constexpr`** |
 | 11 | `ScalarFunction` ctor dropped a positional parameter | **may still compile, silently wrong** |
 | 12 | `DefaultMacro` changed shape | compile error |
-| 13 | throwing scalar functions must `SetFallible()` | **RUNTIME, green build, one arch only** |
+| 13 | throwing scalar functions must `SetFallible()` | **RUNTIME, green build — release builds included** |
 | 14 | `FlatVector::Validity` const split | compile error, **at the mutation, not the call** |
 | 15 | filter pushdown reworked | compile errors — **plus silent wrong results** |
 | 16 | `CreateInfo`/`DropInfo` names → private `QualifiedName` | compile error (storage extensions only) |
@@ -783,22 +783,54 @@ Error: Invalid data: URI - must start with 'data:'
 ```
 
 So a `statement error` test matching on a substring of your own message still
-**passes** while the function is mis-declared. The enforcement surfaces only in
-tests that match the whole message, or downstream in whatever the internal error
-cascades into. "Our error-path tests are green, so class 13 is handled" does not
-follow.
+**passes** while the function is mis-declared. "Our error-path tests are green,
+so class 13 is handled" does not follow.
+
+**But there is a cheap way to make those tests discriminating: include the
+exception's TYPE PREFIX.** The internal error is built with
+`error.RawMessage()`, which drops the prefix. So a correctly-declared function
+emits `IO Error: Could not open file for writing`, while the mis-declared one
+emits `... not marked as fallible ... Error: Could not open file for writing` —
+containing the sentence, but never with `IO Error: ` immediately before it.
+Expecting `Invalid Input Error: Pandoc inline nesting exceeds ...` rather than
+the bare sentence therefore distinguishes the two, with no whole-message matching
+or log grepping needed.
+
+Verify such a test **in both directions** — that it fails on a string the build
+never emits, *and* that it fails when the internal-error form is substituted.
+Otherwise you have only shown it passes, not that it discriminates.
 
 **When measuring, make sure your bad input actually throws.** One port's first
 probe used a malformed-looking URL that the parser happily accepted, so the probe
 was vacuous and measured nothing. Test that your input errors before you trust a
 before/after comparison built on it.
 
-**This is the cause of the amd64/arm64 asymmetry described below.** The contract
-is violated on *both* arches; only the assertion-enabled image reports it. So the
-same commit is green on one leg and red on the other, and the failing test is
-always one that exercises an *error path*. Confirmed on two unrelated extensions,
-one of which has **no compat work at all** — which is the point: you do not have
-to port anything to violate a contract that is new.
+**Enforcement is unconditional — this is not a debug-only diagnostic.**
+`BaseScalarFunction::Execute` (`scalar_function.hpp:316`) wraps the call in a
+plain `try`/`catch` with no `#ifdef DEBUG` and no assertion macro:
+
+```cpp
+if (properties.errors != FunctionErrors::CANNOT_ERROR) { callbacks.function(...); return; }
+try { callbacks.function(...); } catch (std::exception &ex) { ThrowNonFallibleFunctionError(Name(), ex); }
+```
+
+Canary legs build `CMAKE_BUILD_TYPE=Release`, and class 13 was still caught
+there. So an undeclared throwing function is a **live defect for any v2.0 user
+who reaches the path**, not something deferrable to a debug build.
+
+*(An earlier version of this guide claimed the asymmetry below was caused by
+assertions being enabled on amd64 only. That was wrong. Whatever produces that
+asymmetry, it is not this mechanism — and see the A/B section: the shape is not
+diagnostic of anything on its own.)*
+
+Note also that only **execution** errors are converted:
+`ThrowNonFallibleFunctionError` rethrows unchanged if
+`!Exception::IsExecutionError(error.Type())`, so a `BinderException` from your
+bind is unaffected.
+
+Confirmed on two unrelated extensions, one of which has **no compat work at
+all** — which is the point: you do not have to port anything to violate a
+contract that is new.
 
 ```
 duckdb_webbed  3 of 4 amd64 failures: to_xml, xml_extract_text, xml_wrap_fragment
@@ -1250,8 +1282,8 @@ an API problem that did not exist.
 anything — it tells you to run the A/B, not what the answer is.** At least two
 completely different causes produce that identical shape:
 
-- a **new v2.0 runtime contract** (change 13) enforced by an assertion, and only
-  the amd64 image has assertions on; and
+- a **new v2.0 runtime contract** (change 13) reached on one leg and not the
+  other; and
 - a **pre-existing, environment-dependent test** — one repo asserted that CI's
   submodule checkout had a local branch named `main`, which is true on the native
   arm64 runner and false in the amd64 docker container. Nothing to do with v2.0
@@ -1322,8 +1354,10 @@ per-failure **source excerpt**, never by proximity — and treat any tidy-lookin
 printed a diff, and a thrown DuckDB exception *does* reach the log (we have an
 `INTERNAL Error: ... not marked as fallible` printed in full from another repo).
 So an empty `FAILED:` argues against both a wrong answer and a thrown error, and
-points at an assertion or crash — consistent with assertions being enabled on the
-`linux_amd64` image and not on `linux_arm64`.
+points at an assertion or a crash. Do **not** extend that to "amd64 has
+assertions on and arm64 does not" — that explanation was asserted here for
+several hours and is not supported: class 13's enforcement, the obvious
+candidate, is unconditional in release builds.
 
 **How to get the message out.** `_extension_distribution.yml` accepts a
 `post_build_command` input, which `ci_phase.py` runs at the end of `build_linux`

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -540,7 +540,10 @@ function is not marked as fallible - the function must call SetFallible().
 would take the same branch on both, which is detection that detects nothing.
 Call `f.SetFallible()` directly.
 
-**It is NOT inert on the version you ship.** On v1.5 `errors` feeds
+**It is not a no-op on the version you ship — it is unenforced.** The
+distinction matters: v1.5 *has* the flag and *consults* it; it simply does not
+enforce the contract. Calling it a no-op invites blanket-marking on the theory
+that the pinned version cannot care, and it can. On v1.5 `errors` feeds
 `BoundFunctionExpression::CanThrow()`, which gates conjunct reordering
 (`expression_heuristics`, `adaptive_filter`), filter pushdown
 (`pushdown_get` / `_projection` / `_outer_join`) and dictionary-expression
@@ -561,6 +564,20 @@ constructs a temporary, so there is no object to call `SetFallible()` on. Hoist
 it to a local (or a small `register_fallible` lambda). This compounds with change
 5: set members are no longer mutable, so the property must be set **before**
 hand-off to a `FunctionSet`.
+
+**Assert the coupling, but assert something that can fail.** A useful guard ties
+the derived name type to its overload set — it holds on both lines, and catches
+`CompatName` resolving to `Identifier` on a DuckDB whose `identifier.hpp` the
+header did not find (so the `Identifier` overload was never declared):
+
+```cpp
+static_assert(std::is_same<decltype(CompatNameStr(std::declval<const CompatName &>())), string>::value,
+              "CompatNameStr must accept the derived CompatName on every DuckDB line");
+```
+
+Do **not** assert `is_same<CompatName, string>` — that is true on the pin and
+false on main, so it hard-fails the v2.0 build. And asserting `CompatName` equals
+the expression it is *defined* by is a tautology that can never fire.
 
 **Scope notes.** Table functions, COPY and casts are outside this contract —
 casts run through `BoundCastInfo`, not `BaseScalarFunction::Execute`. And
@@ -781,12 +798,23 @@ gh run list --workflow MainDistributionPipeline.yml --limit 20 \
    --json databaseId,conclusion,headBranch,createdAt
 ```
 
-**A canary job can sit in `queued` forever.** One run's matrix job was never
-scheduled at all — 70+ minutes queued while all six stable-leg jobs on the same
-`ubuntu-latest` pool started and finished green. `--json status` reads `queued`
-the whole time, so a naive wait loop blocks indefinitely with no signal. Compare
-job-level `startedAt` against its siblings to tell "slow" from "never scheduled",
-and cancel and re-dispatch rather than waiting.
+**A run can sit in `queued` for over an hour, and `--json status` reads
+`queued` the whole time** — so a naive `until status == completed` loop blocks
+indefinitely with no signal at all.
+
+The cause is usually account-wide runner backlog rather than anything about your
+workflow, and it is self-inflicted if you are porting several repos at once: the
+concurrent ports contend for one runner quota. Before concluding a run is stuck,
+check whether *anything* is progressing:
+
+```
+gh api '/repos/OWNER/REPO/actions/runs?status=in_progress' --jq .total_count
+```
+
+Zero means backlog, not a broken job. (An earlier draft of this guide claimed the
+canary leg specifically gets starved while the stable leg runs — that was wrong,
+and it would send you hunting a workflow bug that does not exist. The two legs
+were simply caught by the same backlog at different moments.)
 
 **A green *build* is not a green canary.** The job runs Build and then Test, and
 community-extensions' `test_against_latest` runs tests too — so it gates on both.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1281,7 +1281,24 @@ dispatch on a commit you already pushed, then leave the branch alone
 Runs on *different* SHAs do **not** cancel each other, so a stale earlier run
 also sits in the queue eating runners until you cancel it explicitly. When
 porting several repos at once, that stale-run backlog is self-inflicted and
-worth clearing:
+worth clearing.
+
+**But "superseded SHA" is the wrong test — use "did `src/` change".** A canary on
+an older commit is still perfectly valid evidence if everything since was
+documentation. Cancelling on SHA alone throws away a finished or nearly-finished
+run and costs you a full round; I did exactly that to myself. The check is:
+
+```
+git diff --stat <canary-sha>..HEAD -- src/     # empty => that canary still covers your code
+```
+
+**And once a PR is open, a `workflow_dispatch` re-runs the WHOLE pipeline a
+second time on the same commit** — every stable leg, code-quality job and extra
+matrix — because the `pull_request` run is in a different concurrency group and
+neither cancels the other. That is ~10 redundant jobs to obtain one canary.
+Cheapest order: **dispatch the canary before opening the PR**, and afterwards let
+the `pull_request` run cover the stable half. If you must re-canary after the PR
+exists, accept the double cost and do it once, not per push.
 
 ```
 gh run list --workflow W.yml --branch B --limit 25 --json databaseId,status \

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -362,6 +362,13 @@ DuckDB does this to itself: `src/function/scalar/struct/struct_pack.cpp` calls
 an extension emitting a `struct_pack` with aliased children is relying on
 *upstream's* opt-in rather than its own.
 
+**COPY option keys are a different surface — do not confuse the two.** A COPY
+bind reading `input.info.options` (a map) is untouched by this change; only
+*argument aliases* on bound child expressions are. The two look similar and are
+unrelated, so a repo with COPY options and no alias reads is not affected here.
+The grep that settles it is `GetAlias` / `capture_argument_aliases`, not
+`option`.
+
 If your extension has functions taking `name := value` style arguments, assume
 you are affected and check. A green canary build does not clear you of this —
 only a test that actually passes a named argument does.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -529,13 +529,20 @@ urlpattern alone). `duckdb_webbed`'s header has a
 transitively**. It presents as `'StructVector' has not been declared`, which
 reads like a missing symbol rather than a moved header.
 
+There are **six** of them, and it is easy to include three and be caught later by
+the fourth — `ArrayVector` in particular tends to surface only deep in a file:
+
+```
+duckdb/common/vector/{flat,list,struct,array,constant,dictionary}_vector.hpp
+```
+
 Include them defensively — including in your compat header, which names
 `FlatVector` at namespace scope:
 
 ```cpp
 #if __has_include("duckdb/common/vector/flat_vector.hpp")
 #include "duckdb/common/vector/flat_vector.hpp"
-#endif   // likewise list_vector.hpp, struct_vector.hpp
+#endif   // and the other five
 ```
 
 ### 10. `Vector::Reference(const Value &)` gained a count — and cannot be `if constexpr`
@@ -797,10 +804,13 @@ never bind a reference to `.Name()`.
 
 ### 17. Result and prepared-statement names are `Identifier`
 
-`QueryResult::names` is `vector<Identifier>` on v2.0 (`query_result.hpp:65`), so
-any `result.names[col]` used as a string breaks — result formatters and DDL
-builders are the usual victims. There is also a `GetNames()` accessor returning
-`const vector<Identifier> &`.
+`BaseQueryResult::names` and `types` are **private** on v2.0
+(`query_result.hpp:55` onward), not merely retyped — so `result.names[col]` and
+`result.types[i]` stop compiling outright, whatever you do about the element
+type. Use the public `GetNames()` (`:43`, returning `const vector<Identifier> &`)
+and `GetTypes()` (`:41`). Result formatters and DDL builders are the usual
+victims, and a repo that runs its own internal queries hits this far from any
+bind signature.
 
 `PreparedStatement::named_param_map` is **still a public member** — it did not
 move behind an accessor, its *element type* changed, from

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -95,7 +95,12 @@ leading indicator, not a test.
 Ask DuckDB what its own type is instead (see change 2).
 
 **The same hazard sits on `__has_include("duckdb/common/vector/list_vector.hpp")`**,
-which several headers use to gate `CompatSetOutputCardinality`. That one fails
+which several headers use to gate `CompatSetOutputCardinality`. Note this is a
+statement about the shim's **selector**, not its **semantics** — change 18 says
+leave the `SetChildCardinality` *choice* alone, and that still holds. Fix how the
+branch is chosen; do not change which branch is chosen. The two instructions look
+contradictory and are not, and a literal reading of "leave it alone" would leave
+the bomb in place. That one fails
 *loudly* — a backported header without `SetChildCardinality` is a compile error,
 not a wrong branch — but it still breaks the **shipped** build on a submodule
 bump. Probe the member (`SetChildCardinality`) and let the `__has_include` do
@@ -760,20 +765,6 @@ it to a local (or a small `register_fallible` lambda). This compounds with chang
 5: set members are no longer mutable, so the property must be set **before**
 hand-off to a `FunctionSet`.
 
-**Assert the coupling, but assert something that can fail.** A useful guard ties
-the derived name type to its overload set — it holds on both lines, and catches
-`CompatName` resolving to `Identifier` on a DuckDB whose `identifier.hpp` the
-header did not find (so the `Identifier` overload was never declared):
-
-```cpp
-static_assert(std::is_same<decltype(CompatNameStr(std::declval<const CompatName &>())), string>::value,
-              "CompatNameStr must accept the derived CompatName on every DuckDB line");
-```
-
-Do **not** assert `is_same<CompatName, string>` — that is true on the pin and
-false on main, so it hard-fails the v2.0 build. And asserting `CompatName` equals
-the expression it is *defined* by is a tautology that can never fire.
-
 **Scope notes.** Table functions, COPY and casts are outside this contract —
 casts run through `BoundCastInfo`, not `BaseScalarFunction::Execute`. And
 `PragmaFunction` derives from `SimpleNamedParameterFunction`, not
@@ -1215,6 +1206,13 @@ canary leg specifically gets starved while the stable leg runs — that was wron
 and it would send you hunting a workflow bug that does not exist. The two legs
 were simply caught by the same backlog at different moments.)
 
+**Not every matrix leg runs tests.** The per-arch flags in
+`_extension_distribution.yml` control whether a leg reaches `make test_release`
+at all, so one arch can go green as a *build only*. "arm64 green and amd64 built"
+is therefore **not** two independent confirmations — if only amd64 tests, a green
+arm64 corroborates nothing about runtime. Check which legs actually ran a `Test`
+step before counting them as agreement.
+
 **The canary covers fewer platforms than the stable leg.** The canary matrix
 generates only `linux_amd64` and `linux_arm64`, while a stable leg typically
 covers five (both Linux arches, both macOS arches, Windows/MSVC) plus Wasm. So
@@ -1312,6 +1310,13 @@ post_build_command: './build/release/test/unittest test/sql/foo.test || true'
 ```
 
 Mark it temporary and revert it before proposing the port for merge.
+
+**Replay your fixture setup inside it.** `post_build_command` runs *before* the
+test phase, so any fixture wired into the test target (a `test/Makefile.inc` hook
+on `test_release_internal`, say) does not exist yet. Without replaying setup you
+diagnose a missing-fixture error instead of the real one — the diagnostic lies,
+convincingly. Guard each re-run with `|| true` so the build step still succeeds
+and you get the log either way.
 
 **Reading the failure needs the REST API, not `gh run view`.** Because the canary
 job calls a *reusable* workflow, `gh run view <run> --log-failed` prints nothing

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1052,6 +1052,14 @@ like a slow queue. After dispatching, confirm a `workflow_dispatch` run exists
 before waiting on one, and widen poll intervals when several ports share a
 limit.
 
+**A coordinator watching every repo is usually the biggest consumer.** A status
+sweep across fourteen repos costs two API calls each; on a 90-second loop that is
+~1,100 calls an hour on its own, before any of the ports poll at all. I exhausted
+the limit this way and then could not read *any* run status — every query
+returned 403, which is indistinguishable from "no runs exist" if you are not
+reading the error. Prefer one long-lived waiter per run over repeated sweeps, and
+treat an empty status sweep as suspect until you have checked it is not a 403.
+
 **Push and dispatch on the same commit cancel each other — and the wrong one
 survives.** The `concurrency:` group covers the workflow, the ref *and* the SHA,
 so a `push` run and a `workflow_dispatch` run on the **same commit** share a

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -491,7 +491,7 @@ a full CI round:
 None is a superset. Merge, do not replace — the sources in each repo already call
 that repo's helpers by name.
 
-## You cannot test this locally
+## You cannot test the v2.0 half locally
 
 Your submodule is the stable line, so a local build only proves the v1.5 half.
 The v2.0 half is verified by CI, and the loop is ~20 minutes.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1,0 +1,173 @@
+# Building a DuckDB extension against both v1.5 and v2.0
+
+DuckDB `main` is the **v2.0** line (`v2.0-cyanoptera`). A major release breaks API
+by definition, and `duckdb/community-extensions` builds every release PR against
+it via `build_next.yml`:
+
+```yaml
+on:
+  pull_request:
+    paths-ignore: ['**', '!extensions/*/description.yml']
+jobs:
+  test_against_latest:
+    with:
+      duckdb_version: 'v2.0-cyanoptera'
+```
+
+That trigger fires on exactly a `description.yml` change — i.e. every release PR —
+and **there is no per-extension opt-out**. So an extension that does not build
+against v2.0 has a red check on every release, and in practice that blocks: of the
+last eight PRs merged there, all eight had zero failures on that job.
+
+Your extension still *ships* against the pinned stable DuckDB. The goal is source
+that compiles under both, not a migration.
+
+## Detect features, not versions
+
+A version macro says *when* something changed. A probe says whether it changed
+**here** — which keeps working when a change is backported, reverted, or lands on
+a branch you did not expect.
+
+Two probes cover everything below.
+
+**Header presence**, for a type that is new:
+
+```cpp
+#if __has_include("duckdb/common/identifier.hpp")
+#define DUCKDB_HAS_IDENTIFIER 1
+#include "duckdb/common/identifier.hpp"
+#endif
+```
+
+**Member presence**, for a method that changed shape. `if constexpr` only discards
+the untaken branch inside a template, hence the template parameter:
+
+```cpp
+template <class T, class = void>
+struct CompatHasWithAlias : std::false_type {};
+template <class T>
+struct CompatHasWithAlias<T, decltype(void(std::declval<const T &>().WithAlias(string())))>
+    : std::true_type {};
+
+template <class TYPE = LogicalType>
+inline LogicalType CompatWithAlias(TYPE type, string alias) {
+	if constexpr (CompatHasWithAlias<TYPE>::value) {
+		return type.WithAlias(std::move(alias));   // v2.0: returns a copy
+	} else {
+		type.SetAlias(std::move(alias));           // v1.5: mutates in place
+		return type;
+	}
+}
+```
+
+Probe each change **separately**. Tying several to one macro silently picks the
+wrong branch if they ever land in different releases.
+
+## The three changes
+
+### 1. `LogicalType::SetAlias` → `WithAlias`
+
+`WithAlias` returns a copy rather than mutating a type whose type-info may be
+shared. Use the `CompatWithAlias` shim above.
+
+*Check while you are there:* `SetAlias` was a setter, so calling it twice
+**replaced** the alias rather than adding one. If your code did that, only the
+last call ever took effect.
+
+### 2. `vector<string>` → `vector<Identifier>` in bind signatures
+
+Affects `table_function_bind_t` and `copy_to_bind_t`. `Identifier` compares
+case-insensitively, which is why it exists.
+
+The conversion asymmetry is what makes this cheap:
+
+```cpp
+Identifier(const char *str);       // IMPLICIT — literals are identifiers by intent
+explicit Identifier(const string&); // EXPLICIT — promoting a runtime string is deliberate
+```
+
+So `names.emplace_back("file_path")` compiles unchanged on both. **Only the
+signatures move**, plus the few places a *runtime* string crosses the boundary:
+
+```cpp
+#ifdef DUCKDB_HAS_IDENTIFIER
+using CompatName = Identifier;
+inline string CompatNameStr(const Identifier &id) { return id.GetIdentifierName(); }
+inline Identifier CompatMakeName(string n) { return Identifier(std::move(n)); }
+#else
+using CompatName = string;
+inline string CompatNameStr(const string &n) { return n; }
+inline string CompatMakeName(string n) { return n; }
+#endif
+```
+
+Then `vector<string> &names` becomes `vector<CompatName> &names` in every bind
+declaration *and* definition, and runtime boundaries use the helpers. Do not add
+an implicit conversion — the explicitness is the upstream change's point.
+
+Grep for **all** of them before starting; the compiler stops at the first few:
+
+```
+grep -rn 'vector<string> &names\|vector<string> &return_names' src/
+```
+
+### 3. `UnaryExecutor::ExecuteWithNulls` — removed
+
+There is no drop-in shim, because the replacement has a different shape: v2.0's
+`Execute` adds nulls when the lambda returns `optional<RESULT_TYPE>`.
+
+If your function used `ExecuteWithNulls` only to map NULL to a value rather than
+to *produce* nulls, an explicit loop is simpler and version-agnostic:
+
+```cpp
+UnifiedVectorFormat vdata;
+CompatToUnifiedFormat(input, count, vdata);   // v2.0 dropped the count parameter
+const auto in = UnifiedVectorFormat::GetData<string_t>(vdata);
+result.SetVectorType(VectorType::FLAT_VECTOR);
+auto out = FlatVector::GetData<bool>(result);
+for (idx_t i = 0; i < count; i++) {
+    const auto idx = vdata.sel->get_index(i);
+    out[i] = vdata.validity.RowIsValid(idx) && !in[idx].GetString().empty();
+}
+```
+
+**Verify the old and new against each other**, because this is the change most
+likely to alter behaviour quietly. Comparing ours showed the original lambda's
+`RowIsValid` branch was *dead*: DuckDB's default null handling propagates above
+the function, so a null input produced NULL either way and the branch never
+decided anything.
+
+## You cannot test this locally
+
+Your submodule is the stable line, so a local build only proves the v1.5 half.
+The v2.0 half is verified by CI, and the loop is ~20 minutes.
+
+Keep a canary job that builds against `main` and can be run on demand:
+
+```yaml
+duckdb-next-build:
+  if: github.event_name == 'workflow_dispatch'
+  uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+  with:
+    duckdb_version: main
+    ci_tools_version: main
+```
+
+Then `gh workflow run <workflow>.yml --ref <your-branch>` drives the port.
+
+Two notes on that job. Restricting it to `workflow_dispatch` (or pushes to main)
+matters: a push and a `pull_request` both fire on the same commit, and a PR's check
+rollup includes both — so an unrestricted canary shows red on every PR. And use
+`if:` rather than `continue-on-error:`, because a job calling a **reusable
+workflow** accepts only a fixed set of keys; adding `continue-on-error` makes the
+whole workflow fail to parse, scheduling zero jobs.
+
+## Order of work
+
+1. Grep for every affected site first — the compiler reports only the first few.
+2. Add the compat header; port one change at a time.
+3. After each, build against the pinned DuckDB and run the full suite. Behaviour
+   on the version you actually ship must not move.
+4. Dispatch the canary to check the other half.
+5. Repeat. Expect more errors after the first batch clears — the v2.0 build stops
+   at the first failing translation unit, so the error list is a floor, not a total.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -63,12 +63,16 @@ inline LogicalType CompatWithAlias(TYPE type, string alias) {
 Probe each change **separately**. Tying several to one macro silently picks the
 wrong branch if they ever land in different releases.
 
-## The three changes
+## The changes
 
 ### 1. `LogicalType::SetAlias` → `WithAlias`
 
 `WithAlias` returns a copy rather than mutating a type whose type-info may be
 shared. Use the `CompatWithAlias` shim above.
+
+`SetAlias` is **removed**, not deprecated — on main the compiler says
+"`struct duckdb::LogicalType` has no member named `SetAlias`; did you mean
+`GetAlias`?". There is no grace period to plan around.
 
 *Check while you are there:* `SetAlias` was a setter, so calling it twice
 **replaced** the alias rather than adding one. If your code did that, only the
@@ -105,13 +109,38 @@ Then `vector<string> &names` becomes `vector<CompatName> &names` in every bind
 declaration *and* definition, and runtime boundaries use the helpers. Do not add
 an implicit conversion — the explicitness is the upstream change's point.
 
-Grep for **all** of them before starting; the compiler stops at the first few:
+It is not only bind parameters. COPY **option keys** are identifiers too, so
+`option.first` needs the same helper. Grep for all of it before starting — and
+note that the compiler will not show you the whole list:
 
 ```
 grep -rn 'vector<string> &names\|vector<string> &return_names' src/
+grep -rn 'option\.first\|names\[' src/
 ```
 
-### 3. `UnaryExecutor::ExecuteWithNulls` — removed
+### 3. `FlatVector::GetData<T>` is read-only; writes need `GetDataMutable<T>`
+
+```
+v1.5:  GetData<T>(vec)         -> T*
+v2.0:  GetData<T>(vec)         -> const T*
+       GetDataMutable<T>(vec)  -> T*
+```
+
+Writing through the v2.0 read accessor is a compile error, which is the split's
+purpose. Probe for the member and route the write path:
+
+```cpp
+template <class VALUE, class FV = FlatVector>
+inline VALUE *CompatFlatDataMutable(Vector &vec) {
+	if constexpr (CompatHasFlatGetDataMutable<FV>::value) {
+		return FV::template GetDataMutable<VALUE>(vec);
+	} else {
+		return FV::template GetData<VALUE>(vec);
+	}
+}
+```
+
+### 4. `UnaryExecutor::ExecuteWithNulls` — removed
 
 There is no drop-in shim, because the replacement has a different shape: v2.0's
 `Execute` adds nulls when the lambda returns `optional<RESULT_TYPE>`.
@@ -137,6 +166,29 @@ likely to alter behaviour quietly. Comparing ours showed the original lambda's
 the function, so a null input produced NULL either way and the branch never
 decided anything.
 
+### 5. `FunctionSet<T>::functions` yields `shared_ptr<const T>`
+
+A function set no longer hands out mutable references to its members, so a loop
+that configures functions *after* adding them stops compiling:
+
+```
+error: 'class duckdb::shared_ptr<const duckdb::ScalarFunction>' has no member
+       named 'SetStability'
+```
+
+There is no shim for this, and one would be wrong anyway: the fix is to finish
+configuring each function **before** it goes into the set.
+
+```cpp
+// was: for (auto &f : set.functions) { f.SetStability(...); }   // no longer mutable
+ScalarFunction f(...);
+f.SetStability(FunctionStability::VOLATILE);   // configure first
+set.AddFunction(f);                            // then add
+```
+
+Watch for this wherever a helper "post-processes" a whole set — null handling,
+varargs and stability are the usual ones.
+
 ## You cannot test this locally
 
 Your submodule is the stable line, so a local build only proves the v1.5 half.
@@ -154,6 +206,22 @@ duckdb-next-build:
 ```
 
 Then `gh workflow run <workflow>.yml --ref <your-branch>` drives the port.
+
+**Reading the failure needs the REST API, not `gh run view`.** Because the canary
+job calls a *reusable* workflow, `gh run view <run> --log-failed` prints nothing
+at all — which reads exactly like a job that produced no errors. Get the job id
+first, then fetch its log directly:
+
+```
+gh run view <run-id> --json jobs \
+   --jq '.jobs[] | select(.conclusion=="failure") | "\(.databaseId) \(.name)"'
+gh api repos/:owner/:repo/actions/jobs/<job-id>/logs | grep 'error:'
+```
+
+**Dispatch after pushing, and do not push again while it runs.** The standard
+`concurrency:` group keys on the workflow and ref, so a push run and a dispatch
+run on the same branch cancel each other. Two of my canary runs were cancelled
+this way before I noticed I was reading a superseded run.
 
 Two notes on that job. Restricting it to `workflow_dispatch` (or pushes to main)
 matters: a push and a `pull_request` both fire on the same commit, and a PR's check

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1054,11 +1054,17 @@ limit.
 
 **A coordinator watching every repo is usually the biggest consumer.** A status
 sweep across fourteen repos costs two API calls each; on a 90-second loop that is
-~1,100 calls an hour on its own, before any of the ports poll at all. I exhausted
-the limit this way and then could not read *any* run status — every query
-returned 403, which is indistinguishable from "no runs exist" if you are not
-reading the error. Prefer one long-lived waiter per run over repeated sweeps, and
-treat an empty status sweep as suspect until you have checked it is not a 403.
+~1,100 calls an hour on its own, before any of the ports poll at all. Prefer one
+long-lived waiter per run over repeated sweeps, and treat an empty status sweep
+as suspect until you have checked it is not a 403 — a rate-limited query renders
+as an empty result and is indistinguishable from "no runs exist".
+
+**And `gh api /rate_limit` will tell you nothing is wrong.** The limit you hit
+this way is GitHub's *secondary* (abuse-detection) limit, which throttles request
+*rate* rather than hourly volume — and it is not reported in `/rate_limit`, which
+happily shows `core: 5000/5000` while every real call returns 403. Do not
+conclude from a healthy `/rate_limit` that the 403 was something else. Back off
+on wall-clock time; it clears on its own.
 
 **Push and dispatch on the same commit cancel each other — and the wrong one
 survives.** The `concurrency:` group covers the workflow, the ref *and* the SHA,

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -857,56 +857,61 @@ an `Identifier`.
 answers yes on **both** versions and then fails deep inside the instantiation.
 Probe the `GetNamedParameterMap` accessor instead.
 
-### 18. `SetCardinality` → `SetChildCardinality` is not a safe blanket rename
+### 18. `SetCardinality` vs `SetChildCardinality` — grep for `Append`, not for order
 
-**Corrected.** An earlier version of this section called this silent data
-corruption, on the strength of upstream's doc comment
-(`data_chunk.hpp:72-74`), which says forwarding "would resize/overwrite their
-data". That reading was **wrong**, and it was circulated as an urgent warning
-before anyone traced the implementation. The comment is real; the inference from
-it was not.
+**This entry has been wrong twice. Both errors came from reasoning about a doc
+comment instead of reading the implementation, and each would have broken
+working code in a different direction.** It is recorded that way deliberately,
+because the mistakes are more instructive than the conclusion.
 
-What the code actually does on current `main`:
+- *First version:* "forwarding silently overwrites your data." **False** — the
+  path is `v_size = n` behind a bounds check, and nothing touches element bytes.
+- *Second version:* "write-then-set sites must move to `SetCardinalityUnsafe`."
+  **Also false, and actively harmful** for the commonest table-function idiom.
+
+The discriminator is **which write API you used**, not the order:
 
 ```
-DataChunk::SetChildCardinality(n)        data_chunk.cpp:155
-   flat/constant vector -> FlatVector::SetSize(v, n)
-   any other vector     -> throw InternalException if v.size() != n
-FlatVector::SetSize -> VectorBuffer::SetVectorSize   vector_buffer.cpp:36
-   same size -> return;  CONSTANT -> ok;  FLAT -> bounds-check, then v_size = n
-   anything else -> throw InternalException
-VectorStructBuffer::SetVectorSize        struct_vector.cpp:63
-   propagates the size to each child; no realloc, no zeroing, no copy
+Vector::SetValue(index, val)   ->  buffer->SetValue(type, index, val)      vector.cpp:350
+      writes AT AN INDEX. Does NOT move v_size.
+VectorBuffer::AppendValue      ->  Reserve(n+1); SetValue(type, v_size, val);
+                                   SetVectorSize(n+1)                      vector_buffer.cpp:263
+      ADVANCES v_size as it goes.
 ```
 
-Every leaf is `v_size = n` behind a bounds check. Nothing on the path touches
-element bytes, and there is no `VectorListBuffer` override, so LIST/MAP child
-entries are untouched too.
+After `DataChunk::Reset()` the children sit at `v_size == 0`. So:
 
-**So the real hazard is a loud one.** Forwarding is unsafe as a *blanket* rename
-because `SetChildCardinality` **validates and propagates** where the old call did
-neither:
+| how you fill the chunk | children's size when you finish | what you need |
+|---|---|---|
+| `DataChunk::SetValue` / `Vector::SetValue` | still **0** | **`SetChildCardinality`** — it is what sizes them |
+| `Vector::Append` / `AppendValue` | already **N** | `SetChildCardinality(N)` is a **no-op** (`Size() == new_size` returns early); `SetCardinality`/`SetCardinalityUnsafe` equally fine |
 
-- it throws if a column is neither flat nor constant and its size disagrees;
-- it throws if `n` exceeds a flat vector's capacity;
-- it pushes the size down into `STRUCT`/`ARRAY` children.
+For the `SetValue` idiom, "fixing" the shim to `SetCardinalityUnsafe` leaves every
+child vector at size 0, and the next `CheckCardinality` throws *"vector has size 0
+but expected size N"*. That is the opposite of a fix.
 
-An extension that leaves a column non-flat, or over-fills past capacity, gets an
-`InternalException` where it previously got silence. That is worth auditing —
-but it fails visibly, and a green canary that exercises those code paths is
-meaningful evidence that you are fine.
+Upstream's warning — that callers who "mutate the child vectors directly ... and
+then call `SetCardinality` rely on" the non-resizing behaviour — is scoped to
+callers who **moved the size themselves**, i.e. the `Append` family. Writing at
+an index never moved it, so it is not that case.
 
-**Do not "fix" write-then-set sites reflexively.** `SetCardinality` is
-`[[deprecated]]` but preserved *precisely* to keep them working, and
-`SetCardinalityUnsafe` is the non-deprecated spelling of the same behaviour.
-Equally, do not assume a shim to `SetChildCardinality` is wrong: at least one
-extension adopted it deliberately because DuckDB `main` wants child buffer sizes
-synchronised after `SetValue` writes, and its full suite passes against `main`
-through exactly those sites with `STRUCT`, `MAP` and `LIST` columns.
+**The one-line audit:**
 
-The honest summary: **which call you want depends on whether your children's
-sizes are already correct when you set the cardinality**, and the deprecation
-warning alone does not tell you. It is an audit, not a mechanical substitution.
+```
+grep -rn '\.Append(\|AppendValue' src/
+```
+
+**Empty means your existing `SetChildCardinality` shim is correct and needs no
+change.** If it is non-empty, check whether you ever append *more* rows than the
+final count — only then does `SetChildCardinality(N)` shrink the logical size,
+and `SetCardinality` (deprecated but preserved, forwarding to
+`SetCardinalityUnsafe`) is the zero-risk option there.
+
+The genuine v2.0 difference that remains: `SetChildCardinality` **validates** —
+it throws an `InternalException` if a column is neither flat nor constant and its
+size disagrees, or if the count exceeds a flat vector's capacity, where the old
+call was silent. That fails loudly, so a canary whose Test step exercises those
+paths is real evidence.
 
 ## Deprecated is not removed — check before you port
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -153,10 +153,12 @@ a fully green canary does not clear you of either.
 | 15 | filter pushdown reworked | compile errors — **plus silent wrong results** |
 | 16 | `CreateInfo`/`DropInfo` names → private `QualifiedName` | compile error (storage extensions only) |
 | 17 | result / prepared-statement names are `Identifier` | compile error |
+| 18 | `SetCardinality` → `SetChildCardinality` | **compiles; silently overwrites data** |
 
 Classes 7 and 13 break at run time on a build that compiles cleanly everywhere.
 Class 11 can compile and misbehave. Class 15 can return **wrong rows** with no
-error at all, if your pushdown *is* the filter rather than an optimisation.
+error at all, if your pushdown *is* the filter rather than an optimisation, and
+class 18 can silently **overwrite column data** if shimmed uniformly.
 Class 13 additionally shows up on **one CI architecture only**, because its
 enforcement is an assertion — so "green on arm64" is not evidence of anything.
 
@@ -826,6 +828,37 @@ an `Identifier`.
 `template <class... ARGS> Execute(ARGS...)` that swallows anything, so the probe
 answers yes on **both** versions and then fails deep inside the instantiation.
 Probe the `GetNamedParameterMap` accessor instead.
+
+### 18. `SetCardinality` → `SetChildCardinality` is NOT a rename — it can overwrite your data
+
+The most dangerous shim in this ecosystem, because it looks like the safest one.
+A `CompatSetOutputCardinality` that forwards to `SetChildCardinality` on v2.0 is
+**exactly** the substitution upstream warns against, in its own words
+(`data_chunk.hpp:72-74`):
+
+> this only sets the chunk's cardinality, it does **not** resize the child
+> vectors... Callers that mutate the child vectors directly (e.g.
+> `Vector::Append`/`SetValue`) and then call `SetCardinality` rely on this —
+> **forwarding to `SetChildCardinality` would resize/overwrite their data**.
+
+So the correct mapping depends entirely on the **order** at the call site:
+
+| your order | v1.5 | correct on v2.0 |
+|---|---|---|
+| set cardinality, *then* write children | `SetCardinality` | `SetChildCardinality` |
+| write children (`SetValue`/`Append`), *then* set cardinality | `SetCardinality` | **`SetCardinalityUnsafe`** |
+
+`SetCardinality` is `[[deprecated]]` but **preserved**, and it forwards to
+`SetCardinalityUnsafe` — so the old behaviour is still reachable under a new
+name. A single blanket shim cannot be right for both orders.
+
+This is a **silent** corruption: it compiles, and it only manifests as wrong
+column data on v2.0. Audit every call site for its order rather than shimming
+them uniformly:
+
+```
+grep -rn -B8 'CompatSetOutputCardinality\|SetCardinality' src/ | grep -n 'SetValue\|Append'
+```
 
 ## Deprecated is not removed — check before you port
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1134,11 +1134,24 @@ through the tool result rather than off disk. (Output files the tool itself
 creates for background commands are already collision-safe — they are named per
 invocation. The exposure is only scripts you write into a shared directory.)
 
-**`~/.duckdb/extensions/` is shared too.** A local `FORCE INSTALL` from one port
-replaces an extension binary that every other port on the box loads. One repo's
-tests went red on a renamed function it had never heard of, with nothing wrong in
-its own tree. If you install locally, expect to break your neighbours; if a test
-fails on a symbol from a *different* extension, suspect this before your diff.
+**`~/.duckdb/extensions/` is shared too — and a red test there may be real.** A
+local `INSTALL` from one port replaces a binary every other port on the box
+loads. One repo's tests went red on a function name it had never heard of, with
+nothing wrong in its own tree.
+
+Note what a normal cycle does *not* do: `make test_release` never installs
+anything, because `EXTENSION_STATIC_BUILD=1` links the extension into the
+unittest binary. So routine build-and-test cannot cause this — someone installed
+deliberately.
+
+And do not assume contamination means *wrong*. In our case the installed binary
+was built from a sibling extension's `main`, which carried an **unreleased
+breaking rename**. CI was green because `INSTALL` pulls the *published*
+extension; the local run was red because it had the unpublished one. Both were
+correct; they tested different upstream versions. Reinstalling the older artifact
+would have made the test pass while hiding real drift until release day. When a
+cross-extension test goes red, establish *which version* each side is testing
+before you decide anything is broken.
 
 **Wait on your own PID, not a `pgrep` pattern.** `pgrep -f 'make release'`
 matches every concurrent build, not yours. It makes a waiter block until the

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -778,8 +778,9 @@ refuse (`NotImplementedException`); there is no correct "ignore it".
 
 Hits any extension with its own `Catalog`/`SchemaCatalogEntry` — i.e. a storage
 extension with an ATTACH backend. `info.schema` and `info.name` are gone;
-`GetQualifiedName().Schema()` / `.Name()`, `CreateSchemaInfo::SchemaName()` and
-`CreateInfo::SetSchema(Identifier)` replace them.
+`GetQualifiedName().Schema()` / `.Name()` (`create_info.hpp:56`),
+`GetQualifiedNameMutable()` (`:59`), `CreateSchemaInfo::SchemaName()` and
+`CreateInfo::SetSchema(Identifier)` (`:74`) replace them.
 
 Two traps: probe on `GetQualifiedName` (present on v2.0 *and* the stable branch
 tip) rather than on the absent field; and the tip's backported
@@ -788,11 +789,17 @@ never bind a reference to `.Name()`.
 
 ### 17. Result and prepared-statement names are `Identifier`
 
-`QueryResult::names` is `vector<Identifier>` on v2.0, so any `result.names[col]`
-used as a string breaks — result formatters and DDL builders are the usual
-victims. `PreparedStatement::named_param_map` (public
-`case_insensitive_map_t<idx_t>`) became `GetNamedParameterMap()`
-(`identifier_map_t<idx_t>`), `Execute` takes
+`QueryResult::names` is `vector<Identifier>` on v2.0 (`query_result.hpp:65`), so
+any `result.names[col]` used as a string breaks — result formatters and DDL
+builders are the usual victims. There is also a `GetNames()` accessor returning
+`const vector<Identifier> &`.
+
+`PreparedStatement::named_param_map` is **still a public member** — it did not
+move behind an accessor, its *element type* changed, from
+`case_insensitive_map_t<idx_t>` to `identifier_map_t<idx_t>`
+(`prepared_statement.hpp:36`). So field access still compiles and only key-type
+assumptions break; there is a `GetNamedParameterMap()` (`:81`) but switching to
+it is not required and is easy to over-port. `Execute` and `PendingQuery` take
 `identifier_map_t<BoundParameterData>`, and `Appender`'s table-name parameter is
 an `Identifier`.
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -779,6 +779,24 @@ casts run through `BoundCastInfo`, not `BaseScalarFunction::Execute`. And
 `PragmaFunction` derives from `SimpleNamedParameterFunction`, not
 `BaseScalarFunction`, so pragmas are unaffected.
 
+**A passing `statement error` test is NOT evidence the error mode is right.**
+This is the trap that makes class 13 hard to close out, and several ports
+(including this one) leaned on the wrong inference. The InternalException
+**embeds the original error text**:
+
+```
+INTERNAL Error: Scalar function "from_data_uri" threw an execution error, but the
+function is not marked as fallible - the function must call SetFallible().
+Error: Invalid data: URI - must start with 'data:'
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ your test's expected substring
+```
+
+So a `statement error` test matching on a substring of your own message still
+**passes** while the function is mis-declared. The enforcement surfaces only in
+tests that match the whole message, or downstream in whatever the internal error
+cascades into. "Our error-path tests are green, so class 13 is handled" does not
+follow.
+
 **When measuring, make sure your bad input actually throws.** One port's first
 probe used a malformed-looking URL that the parser happily accepted, so the probe
 was vacuous and measured nothing. Test that your input errors before you trust a
@@ -1267,6 +1285,14 @@ test/sql/foo.test:78: FAILED:
 — no message, no expected, no actual, nowhere in the job log. Since the pinned
 build cannot reproduce a v2.0-only failure by construction, the reason can be
 genuinely unobtainable.
+
+**Do not pair an error with the nearest test name above it.** The runner uses 3
+workers and their stdout **interleaves**. Error lines get printed inside a
+*different* test's failure report than the one that raised them, and a Catch2
+`FAILED:` marker can end up concatenated onto another worker's
+`[8/9] (88%): <other test> took 0.025s` progress line. Attribute a failure by the
+per-failure **source excerpt**, never by proximity — and treat any tidy-looking
+"which tests failed" tally from a parallel run as provisional.
 
 **The empty shape is itself a signal.** A real result mismatch *would* have
 printed a diff, and a thrown DuckDB exception *does* reach the log (we have an

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -878,8 +878,15 @@ So the correct mapping depends entirely on the **order** at the call site:
 | write children (`SetValue`/`Append`), *then* set cardinality | `SetCardinality` | **`SetCardinalityUnsafe`** |
 
 `SetCardinality` is `[[deprecated]]` but **preserved**, and it forwards to
-`SetCardinalityUnsafe` — so the old behaviour is still reachable under a new
-name. A single blanket shim cannot be right for both orders.
+`SetCardinalityUnsafe` — it was kept *precisely so that* write-then-set callers
+keep working. A single blanket shim cannot be right for both orders.
+
+**So for a write-then-set site, the fix is to leave it alone.** That inverts the
+usual porting instinct. The deprecation warning invites you to route every call
+through a `CompatSetOutputCardinality`, and doing that to a write-then-set site
+*introduces* the data loss rather than removing it. A repo that "ported" all its
+call sites uniformly would have been strictly worse off than one that ported
+none. Only the cardinality-before-write order wants `SetChildCardinality`.
 
 This is a **silent** corruption: it compiles, and it only manifests as wrong
 column data on v2.0. Audit every call site for its order rather than shimming
@@ -1168,8 +1175,10 @@ loads. One repo's tests went red on a function name it had never heard of, with
 nothing wrong in its own tree.
 
 Note what a normal cycle does *not* do: `make test_release` never installs
-anything, because `EXTENSION_STATIC_BUILD=1` links the extension into the
-unittest binary. So routine build-and-test cannot cause this — someone installed
+anything. `extension-ci-tools/makefiles/duckdb_extension.Makefile` sets
+`EXTENSION_STATIC_BUILD ?= 1` and `ENABLE_EXTENSION_AUTOINSTALL ?= 0` (lines
+117, 119), so the extension is linked into the unittest binary and the shared
+profile is never touched. So routine build-and-test cannot cause this — someone installed
 deliberately.
 
 And do not assume contamination means *wrong*. In our case the installed binary

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -72,6 +72,28 @@ branch, never once reaching the new API it existed for. It compiled and behaved
 correctly everywhere, which is why nothing caught it. Probing for the count-free
 overload — which exists only on v2.0 — is what actually discriminates.
 
+**And probe the thing itself, never a proxy for it.** The same mistake one level
+up nearly shipped fleet-wide. `CompatName` was selected by
+`__has_include("duckdb/common/identifier.hpp")` — the header's existence standing
+in for "bind signatures take `Identifier`". Those are two different facts, and
+they have **already come apart upstream**:
+
+```
+v1.5-variegata @ b155d6f63c (the pin)   no identifier.hpp    bind: vector<string>
+v1.5-variegata @ branch TIP             HAS identifier.hpp   bind: vector<string>   <-- proxy fails here
+main (v2.0)                             HAS identifier.hpp   bind: vector<Identifier>
+```
+
+`identifier.hpp` was **backported to the stable branch** without changing
+`table_function_bind_t`. The probe is right today only because the pin predates
+the backport; on the next submodule bump it flips `CompatName` to `Identifier` on
+a DuckDB that still wants strings, and every bind signature in the extension
+stops compiling at once. Since v2.0 deprecates rather than deletes and backports
+freely, *the header arrives before the behaviour does* — so a header probe is a
+leading indicator, not a test.
+
+Ask DuckDB what its own type is instead (see change 2).
+
 ### Check your C++ standard before copying shims
 
 `if constexpr` is C++17. Several extensions here compile their TUs at **C++11 on
@@ -128,11 +150,19 @@ a fully green canary does not clear you of either.
 | 12 | `DefaultMacro` changed shape | compile error |
 | 13 | throwing scalar functions must `SetFallible()` | **RUNTIME, green build, one arch only** |
 | 14 | `FlatVector::Validity` const split | compile error, **at the mutation, not the call** |
+| 15 | filter pushdown reworked | compile errors — **plus silent wrong results** |
+| 16 | `CreateInfo`/`DropInfo` names → private `QualifiedName` | compile error (storage extensions only) |
+| 17 | result / prepared-statement names are `Identifier` | compile error |
 
 Classes 7 and 13 break at run time on a build that compiles cleanly everywhere.
-Class 11 can compile and misbehave. Class 13 additionally shows up on **one CI
-architecture only**, because its enforcement is an assertion — so "green on
-arm64" is not evidence of anything.
+Class 11 can compile and misbehave. Class 15 can return **wrong rows** with no
+error at all, if your pushdown *is* the filter rather than an optimisation.
+Class 13 additionally shows up on **one CI architecture only**, because its
+enforcement is an assertion — so "green on arm64" is not evidence of anything.
+
+Nothing in this list is found by the greps in change 2. Classes 6, 7 and 13 are
+not found by any grep of the DuckDB API at all — for those you grep your *own*
+code, for field accesses, alias reads, and `throw`.
 
 ### 1. `LogicalType::SetAlias` → `WithAlias`
 
@@ -178,18 +208,28 @@ explicit Identifier(const string&); // EXPLICIT — promoting a runtime string i
 ```
 
 So `names.emplace_back("file_path")` compiles unchanged on both. **Only the
-signatures move**, plus the few places a *runtime* string crosses the boundary:
+signatures move**, plus the few places a *runtime* string crosses the boundary.
+
+Define the name type by **asking DuckDB for it**, not by probing a header (see
+the warning above — the header probe is already wrong on the stable branch tip):
 
 ```cpp
+#include "duckdb/function/table_function.hpp"
+
+// TableFunctionBindInput::input_table_names has the same element type as the
+// bind out-parameter on both lines: table_function.hpp:110/288 on the pin,
+// :123/319 on main. This cannot drift, because it IS the thing that changed.
+using CompatName = typename std::remove_reference<decltype(
+    std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
+
+inline string CompatNameStr(const string &name) { return name; }
 #ifdef DUCKDB_HAS_IDENTIFIER
-using CompatName = Identifier;
+// Declares the overload only. It must NOT decide CompatName. Both overloads
+// coexist fine when CompatName is still string.
 inline string CompatNameStr(const Identifier &id) { return id.GetIdentifierName(); }
-inline Identifier CompatMakeName(string n) { return Identifier(std::move(n)); }
-#else
-using CompatName = string;
-inline string CompatNameStr(const string &n) { return n; }
-inline string CompatMakeName(string n) { return n; }
 #endif
+
+inline CompatName CompatMakeName(string name) { return CompatName(std::move(name)); }
 ```
 
 Then `vector<string> &names` becomes `vector<CompatName> &names` in every bind
@@ -334,6 +374,15 @@ set.AddFunction(f);                            // then add
 Watch for this wherever a helper "post-processes" a whole set — null handling,
 varargs and stability are the usual ones.
 
+For **read-only** introspection no probe is needed at all: `shared_ptr<const T>`
+names a valid type on both versions, so two overloads and partial ordering settle
+it.
+
+```cpp
+template <class T> inline const T &CompatFunctionRef(const T &f)                   { return f; }
+template <class T> inline const T &CompatFunctionRef(const shared_ptr<const T> &f) { return *f; }
+```
+
 ### 6. Public fields became private; accessors replace them
 
 The largest class by error count, and the one a source grep will **not** find —
@@ -396,7 +445,12 @@ The grep that settles it is `GetAlias` / `capture_argument_aliases`, not
 `option`.
 
 If your extension has functions taking `name := value` style arguments, assume
-you are affected and check. A green canary build does not clear you of this —
+you are affected and check.
+
+**The dangerous case is named arguments that are *untested*.** A repo whose suite
+exercises the named-argument path gets caught by the canary's Test step. A repo
+where named arguments exist but nothing tests them ships a green build and a
+broken function. Check which of the two you are before trusting a green canary. A green canary build does not clear you of this —
 only a test that actually passes a named argument does.
 
 ### 8. `StructVector::GetEntries` changed element type
@@ -470,41 +524,65 @@ other.
 
 ### 13. Fallible scalar functions must say so — a SILENT runtime break
 
-Like change 7, this is a **runtime contract with no compile error and nothing to
-grep for**. v2.0 requires a scalar function that can throw during execution to
-declare it. Throwing from one that has not is an `InternalException`:
+Like change 7, a **runtime contract with no compile error and nothing in the
+DuckDB API to grep for**. v2.0 requires a scalar function that can throw during
+execution to declare it. Throwing from one that has not is an
+`InternalException`:
 
 ```
 INTERNAL Error: Scalar function "to_xml" threw an execution error, but the
 function is not marked as fallible - the function must call SetFallible().
 ```
 
-`BaseScalarFunction::SetFallible()` (scalar_function.hpp) takes **no arguments**.
-Call it **before** the function goes into a `FunctionSet` — set members are no
-longer mutable (change 5).
+**No shim.** `SetFallible()` exists identically on the pin
+(`function.hpp:211`, on `BaseScalarFunction`) and on main
+(`scalar_function.hpp:249`) — same name, same zero-argument spelling. A probe
+would take the same branch on both, which is detection that detects nothing.
+Call `f.SetFallible()` directly.
+
+**It is NOT inert on the version you ship.** On v1.5 `errors` feeds
+`BoundFunctionExpression::CanThrow()`, which gates conjunct reordering
+(`expression_heuristics`, `adaptive_filter`), filter pushdown
+(`pushdown_get` / `_projection` / `_outer_join`) and dictionary-expression
+caching (`execute_function.cpp`). Declaring a function fallible makes the
+shipped planner **strictly more conservative** around it. That direction is safe
+— it can only stop a throwing function being evaluated on rows it should not
+have been — but it is a real change, so measure it rather than assuming.
+
+**Mark precisely, not defensively.** Because the property is optimizer-visible,
+declaring it on a function that *cannot* throw is itself a behaviour change, not
+free insurance. The reachability question is answerable statically: grep your own
+code for `throw`, then find the transitive callers of any throwing *helper*. In
+one repo three files included a throwing helper's header for an unrelated parser
+and did not reach the throw at all.
+
+**Registration shape can block the fix.** `loader.RegisterFunction(ScalarFunction(...))`
+constructs a temporary, so there is no object to call `SetFallible()` on. Hoist
+it to a local (or a small `register_fallible` lambda). This compounds with change
+5: set members are no longer mutable, so the property must be set **before**
+hand-off to a `FunctionSet`.
+
+**Scope notes.** Table functions, COPY and casts are outside this contract —
+casts run through `BoundCastInfo`, not `BaseScalarFunction::Execute`. And
+`PragmaFunction` derives from `SimpleNamedParameterFunction`, not
+`BaseScalarFunction`, so pragmas are unaffected.
+
+**When measuring, make sure your bad input actually throws.** One port's first
+probe used a malformed-looking URL that the parser happily accepted, so the probe
+was vacuous and measured nothing. Test that your input errors before you trust a
+before/after comparison built on it.
 
 **This is the cause of the amd64/arm64 asymmetry described below.** The contract
 is violated on *both* arches; only the assertion-enabled image reports it. So the
 same commit is green on one leg and red on the other, and the failing test is
-always one that exercises an *error path*.
-
-Confirmed on two unrelated extensions, one of which has **no compat work at all**
-— which is the point: you do not have to port anything to violate a contract that
-is new.
+always one that exercises an *error path*. Confirmed on two unrelated extensions,
+one of which has **no compat work at all** — which is the point: you do not have
+to port anything to violate a contract that is new.
 
 ```
 duckdb_webbed  3 of 4 amd64 failures: to_xml, xml_extract_text, xml_wrap_fragment
 duck_hunt      amd64 failure: duck_hunt_load_parser_config   (unported)
 ```
-
-The shim is safe and cheap — probe for the member, no-op on v1.5:
-
-```cpp
-template <class FUNC> inline void CompatSetFallible(FUNC &fun);   // see the header
-```
-
-The cost is that it must be applied at every function-construction site, so find
-them by grepping your *own* code for `throw` inside scalar function lambdas.
 
 ### 14. `FlatVector::Validity` got the same const split — and hides better
 
@@ -532,6 +610,75 @@ then walk back to where the reference was bound:
 grep -rn 'SetInvalid\|SetValid(\|SetAllInvalid\|SetAllValid' src/
 ```
 
+### 15. Filter pushdown was reworked — and can go silently wrong
+
+Only bites extensions that implement pushdown, but it bites hard. Four compile
+breaks and one semantic landmine.
+
+- `TableFilterSet` moved to `duckdb/planner/table_filter_set.hpp` (a good
+  `__has_include` probe — it does not exist on v1.5), made `filters` **private**,
+  rekeyed it from `idx_t` to `ProjectionIndex`, and replaced map access with
+  `begin()`/`end()` yielding entries with `GetIndex()`/`Filter()`. Presents as
+  *"invalid use of incomplete type 'class duckdb::TableFilterSet'"*, which reads
+  like a missing include and is actually a moved-and-closed member. Note v1.5's
+  `TableFilterSet` has **no** `HasFilters()` — the one you may remember belongs
+  to `DynamicTableFilterSet` in the same header.
+- `ConstantFilter` → `LegacyConstantFilter`, `InFilter` → `LegacyInFilter`, and
+  the enumerators gained a `LEGACY_` prefix, because v2.0 represents filters as a
+  general `ExpressionFilter`. There is no SFINAE probe for a type *name*, so gate
+  these on the header probe and say so. Take the kind constant from the aliased
+  class (`CompatConstantFilter::TYPE`) rather than spelling the enumerator, so
+  the name lives in one place.
+- `BoundConjunctionExpression::children` is private;
+  `GetChildren()`/`GetChildrenMutable()` replace it. Probe the **mutable** one.
+- `ClientContext::interrupted` (a public atomic) is gone. `IsInterrupted()`
+  exists on **both** versions, so no shim — just use the accessor. The compiler's
+  *"did you mean 'Interrupt'?"* points at the wrong member.
+
+**The landmine.** v2.0 keeps the legacy filter classes only for
+*deserialization*. A **running** scan is handed an `ExpressionFilter`, so code
+matching on the legacy kinds simply never matches. Whether that is harmless
+depends entirely on what your pushdown is *for*:
+
+- pushdown as an **optimisation** (best-effort narrowing, every filter still
+  re-applied above) → you read more data and return the same rows;
+- pushdown as **the filter itself** → **silent wrong results**.
+
+A purely mechanical port cannot tell these apart. Check which shape you have.
+
+Related: v2.0's `TableFilterSet` has a **second** collection for multi-column
+filters that `begin()`/`end()` does not visit. Since DuckDB deletes a fully-pushed
+filter from the plan, an unseen filter is an *unapplied* filter. Detect it and
+refuse (`NotImplementedException`); there is no correct "ignore it".
+
+### 16. `CreateInfo`/`DropInfo` names became a private `QualifiedName`
+
+Hits any extension with its own `Catalog`/`SchemaCatalogEntry` — i.e. a storage
+extension with an ATTACH backend. `info.schema` and `info.name` are gone;
+`GetQualifiedName().Schema()` / `.Name()`, `CreateSchemaInfo::SchemaName()` and
+`CreateInfo::SetSchema(Identifier)` replace them.
+
+Two traps: probe on `GetQualifiedName` (present on v2.0 *and* the stable branch
+tip) rather than on the absent field; and the tip's backported
+`GetQualifiedName()` returns **by value** while v2.0 returns by reference, so
+never bind a reference to `.Name()`.
+
+### 17. Result and prepared-statement names are `Identifier`
+
+`QueryResult::names` is `vector<Identifier>` on v2.0, so any `result.names[col]`
+used as a string breaks — result formatters and DDL builders are the usual
+victims. `PreparedStatement::named_param_map` (public
+`case_insensitive_map_t<idx_t>`) became `GetNamedParameterMap()`
+(`identifier_map_t<idx_t>`), `Execute` takes
+`identifier_map_t<BoundParameterData>`, and `Appender`'s table-name parameter is
+an `Identifier`.
+
+**Probe trap:** do *not* probe this by trying to call `Execute` with an
+`identifier_map_t`. `PreparedStatement` has a variadic
+`template <class... ARGS> Execute(ARGS...)` that swallows anything, so the probe
+answers yes on **both** versions and then fails deep inside the instantiation.
+Probe the `GetNamedParameterMap` accessor instead.
+
 ## Deprecated is not removed — check before you port
 
 Not everything that changed is a hard break, and porting the soft ones costs
@@ -547,6 +694,13 @@ Vector::Resize
 `ConstantVector::GetData<T>(Vector &)` also still has a non-const overload
 returning `T*`, so writes through *it* are fine — only `FlatVector::GetData`
 went const-only (change 3).
+
+Also `[[deprecated]]` but present, and noisy rather than fatal: the **templated**
+`Catalog::GetEntry<T>(context, schema, name, if_not_found)` — prefer the
+non-template `GetEntry(context, CatalogType, Identifier, Identifier, OnEntryNotFound)`,
+which exists on both — and all three of `KeywordHelper::WriteQuoted` /
+`WriteOptionallyQuoted` / `EscapeQuotes`, superseded by `SQLString` /
+`SQLIdentifier` / `SQLQuotedIdentifier`.
 
 The genuinely removed ones — the compile errors — are `LogicalType::SetAlias`,
 `UnaryExecutor`/`BinaryExecutor`/`TernaryExecutor::ExecuteWithNulls`, and the
@@ -627,6 +781,13 @@ gh run list --workflow MainDistributionPipeline.yml --limit 20 \
    --json databaseId,conclusion,headBranch,createdAt
 ```
 
+**A canary job can sit in `queued` forever.** One run's matrix job was never
+scheduled at all — 70+ minutes queued while all six stable-leg jobs on the same
+`ubuntu-latest` pool started and finished green. `--json status` reads `queued`
+the whole time, so a naive wait loop blocks indefinitely with no signal. Compare
+job-level `startedAt` against its siblings to tell "slow" from "never scheduled",
+and cancel and re-dispatch rather than waiting.
+
 **A green *build* is not a green canary.** The job runs Build and then Test, and
 community-extensions' `test_against_latest` runs tests too — so it gates on both.
 An extension can compile against v2.0 and still fail behaviourally.
@@ -701,12 +862,22 @@ whole workflow fail to parse, scheduling zero jobs.
 minute: pull each file's compile command out of `build/release/compile_commands.json`
 and re-run it with `-fsyntax-only`. One process, no link, no DuckDB rebuild.
 
-**Do not run `make format` as a pre-push step.** On several of these repos
-clang-format 11.0.1 — the version `duckdb/scripts/format.py` demands — reports
-drift on a *pristine* default branch, while CI's format check is green. Running
-it mixes unrelated reformatting into your port diff and makes the review
-worthless. Check that your branch adds no *new* drift relative to the default
-branch instead.
+**Check your repo's format baseline before trusting — or distrusting — the
+formatter.** clang-format 11.0.1 (the version `duckdb/scripts/format.py` demands)
+reports drift on a pristine default branch in *some* of these repos but not
+others; markdown and func_apply are both zero-drift. One line tells you which
+you are in:
+
+```
+clang-format --style=file path/to/file | diff -u path/to/file -
+```
+
+Where the baseline is **clean**, verify your own diff is format-clean too — a
+repo whose CI runs the format check goes red otherwise, and a shim block copied
+from another repo is a common way to import drift. Where the baseline is
+**dirty**, do not run `make format` as a pre-push step: it mixes unrelated
+reformatting into your port and makes the review worthless. Check only that your
+branch adds no *new* drift.
 
 ## If you port several repos at once
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -726,6 +726,24 @@ by grepping `throw` at all. Also follow the transitive callers of any throwing
 one repo had three files including such a header for an unrelated parser and
 never reaching the throw.
 
+**Follow the throwing *helpers*, not the literal throws — and expect the guard
+to be two files away.** The commonest under-marking is a recursion or
+input-validation guard reached indirectly. A depth guard's entire purpose is to
+turn a stack overflow into a readable error; undeclared on v2.0, the guard still
+prevents the crash but its message is rewritten as an `InternalException`, so it
+stops delivering the one thing it exists for. In this repo the shallow pass
+marked 2 of 6 fallible functions; the other 4 reached a `MAX_*_DEPTH` throw three
+call levels away, in a different file.
+
+**You may not be able to prove reachability, and that is worth saying out loud.**
+For those four, no input we could construct actually reached the guard — nested
+lists collapse inside cmark, nested emphasis saturated below the cap, and a
+1200-deep synthetic AST did not raise. Reachability was established by reading
+the call chain, not by executing it, so no regression test could be written that
+fails first. Marking anyway is defensible — the guard's author judged the input
+reachable, and the cost is a small conservative planner change — but **label it
+as unverified rather than implying you measured it.**
+
 **Registration shape can block the fix.** `loader.RegisterFunction(ScalarFunction(...))`
 constructs a temporary, so there is no object to call `SetFallible()` on. Hoist
 it to a local (or a small `register_fallible` lambda). This compounds with change

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1153,6 +1153,14 @@ canary leg specifically gets starved while the stable leg runs — that was wron
 and it would send you hunting a workflow bug that does not exist. The two legs
 were simply caught by the same backlog at different moments.)
 
+**The canary covers fewer platforms than the stable leg.** The canary matrix
+generates only `linux_amd64` and `linux_arm64`, while a stable leg typically
+covers five (both Linux arches, both macOS arches, Windows/MSVC) plus Wasm. So
+"green on v2.0" is two-platform evidence, and anything MSVC-specific — template
+deduction it rejects that GCC and AppleClang accept, for instance — is invisible
+to it. Your MSVC coverage comes from the stable leg only, which is another reason
+not to treat that leg as merely a formality.
+
 **A green *build* is not a green canary.** The job runs Build and then Test, and
 community-extensions' `test_against_latest` runs tests too — so it gates on both.
 An extension can compile against v2.0 and still fail behaviourally.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -376,13 +376,71 @@ only a test that actually passes a named argument does.
 ### 8. `StructVector::GetEntries` changed element type
 
 ```
-v1.5:  vector<unique_ptr<Vector>> &     ->  *entries[i]
-v2.0:  vector<Vector> &                 ->   entries[i]
+v1.5:  vector<unique_ptr<Vector>> &     ->  *entries[i]  /  entries[i]->SetValue(...)
+v2.0:  vector<Vector> &                 ->   entries[i]  /  entries[i].SetValue(...)
 ```
 
-`*entries[i]` becomes `no match for operator*`. Mechanical, but it can be many
-sites (19 in urlpattern alone). `duckdb_webbed`'s header has a
+The *element type* changed, not just the header location, so `*entries[i]` and
+`entries[i]->` both stop compiling. Mechanical, but it can be many sites (19 in
+urlpattern alone). `duckdb_webbed`'s header has a
 `CompatStructGetField(Vector &, idx_t)` helper for exactly this.
+
+### 9. The per-vector accessor headers moved
+
+`FlatVector`, `ListVector`, `StructVector` and friends split out of
+`duckdb/common/types/vector.hpp` into one header each under
+`duckdb/common/vector/`, and **`duckdb.hpp` no longer pulls them in
+transitively**. It presents as `'StructVector' has not been declared`, which
+reads like a missing symbol rather than a moved header.
+
+Include them defensively — including in your compat header, which names
+`FlatVector` at namespace scope:
+
+```cpp
+#if __has_include("duckdb/common/vector/flat_vector.hpp")
+#include "duckdb/common/vector/flat_vector.hpp"
+#endif   // likewise list_vector.hpp, struct_vector.hpp
+```
+
+### 10. `Vector::Reference(const Value &)` gained a count — and cannot be `if constexpr`
+
+```
+v1.5:  Reference(const Value &)
+v2.0:  Reference(const Value &, count_t)      // pass args.size()
+```
+
+`count_t` is a strong type (`duckdb/common/types/size.hpp`) whose constructor
+from `idx_t` is **explicit**, and the type does not exist on v1.5 at all.
+
+**That last part forces `#ifdef`, not `if constexpr`.** `if constexpr` discards
+the untaken branch but the compiler still *parses* it, and a missing
+non-dependent name is a hard error at parse time. So this one must be gated on
+`__has_include("duckdb/common/types/size.hpp")`. It is the one change in this
+document where the tag-dispatch/`if constexpr` idiom does not work.
+
+### 11. `ScalarFunction`'s constructor dropped a positional parameter
+
+`bind_scalar_function_extended_t` was removed from between `bind` and
+`statistics`. Any call site threading a value through a run of `nullptr`s to
+reach the positional tail now **shifts one slot** — landing a `nullptr` on the
+`LogicalType varargs` parameter. It may still compile, which is what makes it
+dangerous.
+
+Stop counting positions: set it afterwards with `SetStability()`, which exists
+on both versions. (Stability is also no longer a public field; it moved into a
+protected `FunctionProperties`.)
+
+### 12. `DefaultMacro` changed shape
+
+```
+v1.5:  {schema, name, parameters[8], named_parameters[8], macro}
+v2.0:  {schema, name, macro_definition}
+```
+
+The signature moved *inside* the definition string —
+`"(a, b, c := 'x') AS body"` — parsed as `CREATE MACRO __dummy__...`.
+`DefaultTableMacro` did **not** change, so a repo can be hit by one and not the
+other.
 
 ## Deprecated is not removed — check before you port
 
@@ -437,6 +495,13 @@ that repo's helpers by name.
 
 Your submodule is the stable line, so a local build only proves the v1.5 half.
 The v2.0 half is verified by CI, and the loop is ~20 minutes.
+
+The reverse is also true and worth using: **the stable leg of your own pipeline
+is CI-grade evidence for the v1.5 half.** It builds against the pinned release
+*and runs the suite*, on more platforms than you have locally. If local build
+capacity is scarce, a green stable leg stands in for the local run — and its
+Windows/MSVC job is the only thing in the matrix that will catch template
+deduction that GCC and AppleClang accept.
 
 Keep a canary job that builds against `main` and can be run on demand:
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -221,6 +221,30 @@ An extension that only *registers* functions barely touches this. One that
 *introspects* the catalog or rewrites expressions (`func_apply` is the extreme
 case) touches almost all of it.
 
+## Deprecated is not removed — check before you port
+
+Not everything that changed is a hard break, and porting the soft ones costs
+effort while buying nothing. On `main` these are `[[deprecated]]` but **still
+present**, so they compile with a warning:
+
+```
+Vector::ToUnifiedFormat(count, data)     DataChunk::SetCardinality(idx_t)
+DataChunk::SetValue(col, idx, val)       Vector::Flatten(count)
+Vector::Resize
+```
+
+`ConstantVector::GetData<T>(Vector &)` also still has a non-const overload
+returning `T*`, so writes through *it* are fine — only `FlatVector::GetData`
+went const-only (change 3).
+
+The genuinely removed ones — the compile errors — are `LogicalType::SetAlias`,
+`UnaryExecutor`/`BinaryExecutor`/`TernaryExecutor::ExecuteWithNulls`, and the
+public fields of change 6.
+
+You can settle any such question in seconds without a CI round and without
+cloning: read the header on `raw.githubusercontent.com/duckdb/duckdb/main/...`.
+Do that before porting a whole change class on the assumption it is fatal.
+
 ## Which header to start from
 
 The fleet's headers are at different generations, and copying the wrong one costs

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -902,7 +902,11 @@ grep -rn '\.Append(\|AppendValue' src/
 ```
 
 **Empty means your existing `SetChildCardinality` shim is correct and needs no
-change.** If it is non-empty, check whether you ever append *more* rows than the
+change.** Across all nine extensions audited here that grep was empty in every
+one, against 112 cardinality call sites — so the entire "fix" this section
+originally prescribed would have been pure damage. If your codebase fills chunks
+with `SetValue`, which is the idiomatic table-function shape, you are in the same
+position. If it is non-empty, check whether you ever append *more* rows than the
 final count — only then does `SetChildCardinality(N)` shrink the logical size,
 and `SetCardinality` (deprecated but preserved, forwarding to
 `SetCardinalityUnsafe`) is the zero-risk option there.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -63,6 +63,15 @@ inline LogicalType CompatWithAlias(TYPE type, string alias) {
 Probe each change **separately**. Tying several to one macro silently picks the
 wrong branch if they ever land in different releases.
 
+**Probe for the thing that exists only on the NEW line.** This is the rule that
+is easy to get backwards, and getting it backwards fails silently. Our
+`ToUnifiedFormat` shim probed for the *count-taking* overload — the one being
+replaced. But v2.0 kept that overload as `[[deprecated]]` rather than deleting
+it, so the probe was true on **both** versions and the shim always took the old
+branch, never once reaching the new API it existed for. It compiled and behaved
+correctly everywhere, which is why nothing caught it. Probing for the count-free
+overload — which exists only on v2.0 — is what actually discriminates.
+
 ### Check your C++ standard before copying shims
 
 `if constexpr` is C++17. Several extensions here compile their TUs at **C++11 on
@@ -294,6 +303,38 @@ An extension that only *registers* functions barely touches this. One that
 *introspects* the catalog or rewrites expressions (`func_apply` is the extreme
 case) touches almost all of it.
 
+### 7. Named-argument aliases are no longer captured — a SILENT runtime break
+
+The most dangerous item here, because there is **no compile error and nothing to
+grep for**. The build is green and the extension fails at runtime.
+
+v1.5 always recorded a named argument's alias on the bound child expression, so a
+bind callback could read it back with `GetAlias()`. v2.0 added
+`FunctionProperties::capture_argument_aliases`, defaulting to **false** — so on
+v2.0 those aliases come back **empty**.
+
+Any function that derives named parameters from argument aliases binds every
+named argument as unnamed and then fails at run time. The fix is to opt in:
+
+```cpp
+func.SetCaptureArgumentAliases(true);
+```
+
+If your extension has functions taking `name := value` style arguments, assume
+you are affected and check. A green canary build does not clear you of this —
+only a test that actually passes a named argument does.
+
+### 8. `StructVector::GetEntries` changed element type
+
+```
+v1.5:  vector<unique_ptr<Vector>> &     ->  *entries[i]
+v2.0:  vector<Vector> &                 ->   entries[i]
+```
+
+`*entries[i]` becomes `no match for operator*`. Mechanical, but it can be many
+sites (19 in urlpattern alone). `duckdb_webbed`'s header has a
+`CompatStructGetField(Vector &, idx_t)` helper for exactly this.
+
 ## Deprecated is not removed — check before you port
 
 Not everything that changed is a hard break, and porting the soft ones costs
@@ -349,6 +390,15 @@ duckdb-next-build:
 ```
 
 Then `gh workflow run <workflow>.yml --ref <your-branch>` drives the port.
+
+**Check for an old failed canary run before your first round.** If the repo ever
+ran a canary on its default branch, its job log is a complete v2.0 error list you
+can have for free, right now, instead of 20 minutes from now:
+
+```
+gh run list --workflow MainDistributionPipeline.yml --limit 20 \
+   --json databaseId,conclusion,headBranch,createdAt
+```
 
 **A green *build* is not a green canary.** The job runs Build and then Test, and
 community-extensions' `test_against_latest` runs tests too — so it gates on both.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -487,10 +487,25 @@ source bug. Gate on `MemAvailable` and drop to `-j2`.
 
 ## Order of work
 
-1. Grep for every affected site first — the compiler reports only the first few.
-2. Add the compat header; port one change at a time.
-3. After each, build against the pinned DuckDB and run the full suite. Behaviour
-   on the version you actually ship must not move.
-4. Dispatch the canary to check the other half.
-5. Repeat. Expect more errors after the first batch clears — the v2.0 build stops
-   at the first failing translation unit, so the error list is a floor, not a total.
+1. **Look for an old failed canary log first** (see above). If one exists you
+   start with the real error list instead of a guess.
+2. Grep for every affected site — but know that grep does not find change 6
+   (fields that became accessors) or change 7 (argument aliases) at all, so the
+   grep is a starting point, never the work list.
+3. Pick the right header to start from, merge rather than replace, and check
+   your C++ standard before copying `if constexpr` shims.
+4. Port one change class at a time.
+5. After each, build against the pinned DuckDB and run the full suite. Behaviour
+   on the version you actually ship must not move — and for anything touching
+   nulls, *measure* old against new rather than reasoning about it. Put the NULL
+   inside a non-constant vector or you are not testing the path you changed.
+6. Push, then dispatch the canary, then leave the branch alone until it finishes.
+7. Read the result on a **completed** run, per step, per platform. Build and Test
+   are separate; a green build is not a green canary.
+8. Repeat. Expect more errors after the first batch clears — the v2.0 build stops
+   at the first failing translation unit, so every error list is a floor, not a
+   total.
+
+And one thing the canary cannot tell you: change 7 fails at **run time** with a
+green build. If your extension has functions taking `name := value` arguments,
+add a test that passes one, or you will ship a break that CI never saw.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -113,6 +113,24 @@ markdown's header is written this way, so it is safe to copy into a C++11 repo.
 `WithAlias` returns a copy rather than mutating a type whose type-info may be
 shared. Use the `CompatWithAlias` shim above.
 
+**Make the entry point a concrete function, not a deduced template.** This one
+bites on the pinned v1.5 build, not on v2.0:
+
+```cpp
+template <class TYPE = LogicalType>          // WRONG -- the default is inert
+LogicalType CompatWithAlias(TYPE type, string alias);
+```
+
+Deduction wins over the default, so `CompatWithAlias(LogicalType::VARCHAR, "yaml")`
+deduces `TYPE = LogicalTypeId` — `LogicalType::VARCHAR` is a `static constexpr
+LogicalTypeId` (`types.hpp`), not a `LogicalType` — and hard-errors inside the
+shim with *"request for member 'SetAlias' in 'type', which is of non-class type
+'duckdb::LogicalTypeId'"*. Take a concrete `LogicalType` parameter so the
+implicit `LogicalTypeId` conversion happens at the call site, and keep only the
+tag-dispatch `Impl` overloads templated. Code that already wrote
+`LogicalType(LogicalTypeId::VARCHAR)` never sees this, which is exactly how it
+survives review.
+
 `SetAlias` is **removed**, not deprecated — on main the compiler says
 "`struct duckdb::LogicalType` has no member named `SetAlias`; did you mean
 `GetAlias`?". There is no grace period to plan around.
@@ -170,7 +188,26 @@ v2.0:  GetData<T>(vec)         -> const T*
 ```
 
 Writing through the v2.0 read accessor is a compile error, which is the split's
-purpose. Probe for the member and route the write path:
+purpose.
+
+**`const_cast<T *>(FlatVector::GetData<T>(v))` is not a fix — it is a silent
+data-corruption path.** The two accessors do different work, not just different
+constness:
+
+```
+GetData         -> vector.GetBufferRef()->GetData()      // no un-share
+GetDataMutable  -> vector.BufferMutable().GetData()      // un-shares COW buffer first
+```
+
+Casting the const away compiles and then writes into a buffer that may still be
+shared with another vector. If a repo "already handled" the const change that
+way, it has a latent bug rather than a working shim:
+
+```
+grep -rn 'const_cast<[^>]*\*>(FlatVector::GetData' src/
+```
+
+Probe for the member and route the write path:
 
 ```cpp
 template <class VALUE, class FV = FlatVector>
@@ -320,6 +357,11 @@ named argument as unnamed and then fails at run time. The fix is to opt in:
 func.SetCaptureArgumentAliases(true);
 ```
 
+DuckDB does this to itself: `src/function/scalar/struct/struct_pack.cpp` calls
+`SetCaptureArgumentAliases(true)` with a comment explaining why. That also means
+an extension emitting a `struct_pack` with aliased children is relying on
+*upstream's* opt-in rather than its own.
+
 If your extension has functions taking `name := value` style arguments, assume
 you are affected and check. A green canary build does not clear you of this —
 only a test that actually passes a named argument does.
@@ -354,6 +396,17 @@ went const-only (change 3).
 The genuinely removed ones — the compile errors — are `LogicalType::SetAlias`,
 `UnaryExecutor`/`BinaryExecutor`/`TernaryExecutor::ExecuteWithNulls`, and the
 public fields of change 6.
+
+**Three things that look like they need porting and do not.** These read
+identically to the broken cases in a grep, so they are easy to over-port:
+
+- `BaseExpression::SetAlias` still **exists** on main; it just takes an
+  `Identifier` now, which is implicit from `const char *`. Only
+  `LogicalType::SetAlias` was removed. A grep for `SetAlias` finds both.
+- `BoundStatement::names` is `vector<Identifier>` on main, so
+  `expr->SetAlias(bound.names[i])` compiles unchanged on both versions.
+- `FunctionSet<T>::name` is still a public member (an `Identifier`). Only
+  `functions` became `shared_ptr<const T>` (change 5).
 
 You can settle any such question in seconds without a CI round and without
 cloning: read the header on `raw.githubusercontent.com/duckdb/duckdb/main/...`.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -189,6 +189,52 @@ set.AddFunction(f);                            // then add
 Watch for this wherever a helper "post-processes" a whole set — null handling,
 varargs and stability are the usual ones.
 
+### 6. Public fields became private; accessors replace them
+
+The largest class by error count, and the one a source grep will **not** find —
+there is no distinctive token to search for. `ScalarFunction` and the expression
+hierarchy closed their data members:
+
+```
+ScalarFunction::varargs        -> GetVarArgs() / SetVarArgs()
+ScalarFunction::null_handling  -> GetNullHandling() / SetNullHandling()
+ScalarFunction::return_type    -> GetReturnType() / SetReturnType()
+Expression::return_type            (now protected)  -> GetReturnType()
+BaseExpression::alias              (now protected, and now an Identifier)
+BoundFunctionExpression::bind_info (now private)
+```
+
+`bind_scalar_function_t` also collapsed its three parameters into one input
+object, and `Catalog::GetEntry`, `FunctionBinder::BindScalarFunction` and the
+`FunctionExpression` constructor all take `Identifier` where they took `string`.
+
+**Do not write these shims from scratch.** `duckdb_yaml`'s
+`src/include/duckdb_compat.hpp` is the most complete in the fleet and already has
+them — `DUCKDB_SCALAR_BIND_PARAMS` / `_CONTEXT` / `_ARGS`, `CompatExprReturnType`,
+`CompatBoundChildren`, `CompatBoundBindInfo`, `CompatSetScalarReturnType`,
+`CompatSetScalarNullHandling`, `CompatSetScalarVarArgs`, plus working
+`CompatUnaryExecuteWithNulls` / `CompatBinaryExecuteWithNulls`. Start from that
+header and add this document's v2.0 shims to it, rather than starting from a
+smaller one and rediscovering the same helpers.
+
+An extension that only *registers* functions barely touches this. One that
+*introspects* the catalog or rewrites expressions (`func_apply` is the extreme
+case) touches almost all of it.
+
+## Which header to start from
+
+The fleet's headers are at different generations, and copying the wrong one costs
+a full CI round:
+
+| starting point | covers |
+|---|---|
+| `duckdb_yaml` | the most complete: v1.4 vector/bind changes **and** the scalar-function/expression accessors of change 6 |
+| `duckdb_webbed` | v1.4-era changes plus `PreventStructConstantFolding`, `CompatForceMaxLogicalType` |
+| `duckdb_markdown` | the v2.0 changes 1-4, verified green against `main` |
+
+None is a superset. Merge, do not replace — the sources in each repo already call
+that repo's helpers by name.
+
 ## You cannot test this locally
 
 Your submodule is the stable line, so a local build only proves the v1.5 half.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -547,6 +547,14 @@ DuckDB does this to itself: `src/function/scalar/struct/struct_pack.cpp` calls
 an extension emitting a `struct_pack` with aliased children is relying on
 *upstream's* opt-in rather than its own.
 
+**Table-function named parameters are a different surface too.** `name := value`
+arguments to a *table* function go through `TableFunction::named_parameters`,
+which are declared and bound by the table-function path and are unaffected by
+this change. `capture_argument_aliases` governs only **scalar** functions that
+derive names from their argument *aliases* — the `struct_pack` case. A repo whose
+named options are all table-function parameters is not affected, however many of
+them it has.
+
 **COPY option keys are a different surface — do not confuse the two.** A COPY
 bind reading `input.info.options` (a map) is untouched by this change; only
 *argument aliases* on bound child expressions are. The two look similar and are
@@ -874,6 +882,23 @@ tip) rather than on the absent field; and the tip's backported
 `GetQualifiedName()` returns **by value** while v2.0 returns by reference, so
 never bind a reference to `.Name()`.
 
+The move is broad — every entry name went behind a `QualifiedName`, with the
+`Get<Entry>Name()` accessors returning `Identifier`:
+
+```
+CreateFunctionInfo::name      CreateTableInfo::table       CreateViewInfo::view_name
+CreateSequenceInfo::name      CreateTypeInfo::name         CreateIndexInfo::index_name
+CreateInfo::schema            BaseTableRef::table_name -> Table()
+ColumnRefExpression::GetColumnName() now returns Identifier
+```
+
+**`CREATE SCHEMA` is a genuine special case, not a rename.** v2.0 encodes the
+path as `[catalog, parents..., new_schema, <empty name>]`, so the schema name is
+**not** in the `Name()` slot — read it with `CreateSchemaInfo::SchemaName()`.
+
+This class only reaches extensions that parse SQL with DuckDB's own parser and
+walk the resulting statements. Most extensions never touch it.
+
 ### 17. Result and prepared-statement names are `Identifier`
 
 `BaseQueryResult::names` and `types` are **private** on v2.0
@@ -932,6 +957,10 @@ For the `SetValue` idiom, "fixing" the shim to `SetCardinalityUnsafe` leaves eve
 child vector at size 0, and the next `CheckCardinality` throws *"vector has size 0
 but expected size N"*. That is the opposite of a fix.
 
+Put positively: **for an index-writing caller the forwarding to
+`SetChildCardinality` is required, not merely safe.** Index writes never move
+`v_size`, so it is the only call that sizes the children at all.
+
 Upstream's warning — that callers who "mutate the child vectors directly ... and
 then call `SetCardinality` rely on" the non-resizing behaviour — is scoped to
 callers who **moved the size themselves**, i.e. the `Append` family. Writing at
@@ -974,6 +1003,10 @@ Vector::Resize
 `ConstantVector::GetData<T>(Vector &)` also still has a non-const overload
 returning `T*`, so writes through *it* are fine — only `FlatVector::GetData`
 went const-only (change 3).
+
+`ListVector::GetEntry` is likewise `[[deprecated]]` but forwards to
+`GetChildMutable` (`list_vector.cpp:291`), so writes through it stay correct and
+it needs no porting.
 
 Also `[[deprecated]]` but present, and noisy rather than fatal: the **templated**
 `Catalog::GetEntry<T>(context, schema, name, if_not_found)` — prefer the
@@ -1312,9 +1345,20 @@ source bug. Gate on `MemAvailable` and drop to `-j2`.
 6. Push, then dispatch the canary, then leave the branch alone until it finishes.
 7. Read the result on a **completed** run, per step, per platform. Build and Test
    are separate; a green build is not a green canary.
-8. Repeat. Expect more errors after the first batch clears — the v2.0 build stops
-   at the first failing translation unit, so every error list is a floor, not a
-   total.
+8. Repeat. Expect more errors after the first batch clears. The error list is a
+   floor in **two** ways, and the second one is nastier:
+   - the build stops at the first failing translation unit; and
+   - **a function whose out-of-class definition matches no declaration is never
+     type-checked at all.** GCC reports one `no declaration matches ...` error
+     and then discards the function, so its entire body produces *zero*
+     diagnostics. In one port a header declared a function taking
+     `const CreateStatement &` without including `create_statement.hpp` —
+     transitively available on v1.5, not on main — and that hid **seven**
+     separate v2.0 breakages inside the body.
+
+   So after fixing any `no declaration matches` or incomplete-type error,
+   **re-read that function's body by hand** rather than trusting the next build
+   to find what is in it.
 
 And one thing the canary cannot tell you: change 7 fails at **run time** with a
 green build. If your extension has functions taking `name := value` arguments,

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -63,6 +63,40 @@ inline LogicalType CompatWithAlias(TYPE type, string alias) {
 Probe each change **separately**. Tying several to one macro silently picks the
 wrong branch if they ever land in different releases.
 
+### Check your C++ standard before copying shims
+
+`if constexpr` is C++17. Several extensions here compile their TUs at **C++11 on
+purpose** — forcing C++17 on the extension but not on libduckdb makes
+static-const members in duckdb's headers acquire implicit inline linkage in one
+set of TUs and not the other, producing multiple-definition link errors. One line
+tells you which you are:
+
+```
+grep -o 'std=c++[0-9]*' build/release/compile_commands.json | sort -u
+```
+
+The member probe itself is fine at C++11 in the `decltype(void(expr))` form. Only
+the dispatch needs care, so write it as tag dispatch, which works at both
+standards and has the same "only the taken branch is instantiated" property:
+
+```cpp
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE t, string a, std::true_type) {
+	return t.WithAlias(std::move(a));            // v2.0
+}
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE t, string a, std::false_type) {
+	t.SetAlias(std::move(a));                    // v1.5
+	return t;
+}
+template <class TYPE = LogicalType>
+inline LogicalType CompatWithAlias(TYPE t, string a) {
+	return CompatWithAliasImpl(std::move(t), std::move(a), CompatHasWithAlias<TYPE>());
+}
+```
+
+markdown's header is written this way, so it is safe to copy into a C++11 repo.
+
 ## The changes
 
 ### 1. `LogicalType::SetAlias` → `WithAlias`
@@ -142,29 +176,68 @@ inline VALUE *CompatFlatDataMutable(Vector &vec) {
 
 ### 4. `UnaryExecutor::ExecuteWithNulls` — removed
 
-There is no drop-in shim, because the replacement has a different shape: v2.0's
-`Execute` adds nulls when the lambda returns `optional<RESULT_TYPE>`.
+Also `BinaryExecutor::` and `TernaryExecutor::ExecuteWithNulls`. This is the
+change most likely to alter behaviour quietly, and the first attempt at it in
+this repo **did** — so read this section before writing a replacement.
 
-If your function used `ExecuteWithNulls` only to map NULL to a value rather than
-to *produce* nulls, an explicit loop is simpler and version-agnostic:
+**First, find out whether your lambda's null branch is even reachable.** In
+`unary_executor.hpp`, `ExecuteWithNulls` copies the input validity into the
+result mask and then *skips the lambda entirely* for null rows:
 
 ```cpp
-UnifiedVectorFormat vdata;
-CompatToUnifiedFormat(input, count, vdata);   // v2.0 dropped the count parameter
-const auto in = UnifiedVectorFormat::GetData<string_t>(vdata);
-result.SetVectorType(VectorType::FLAT_VECTOR);
-auto out = FlatVector::GetData<bool>(result);
+result_mask.Copy(mask, count);          // result is NULL wherever input was
+...
+if (ValidityMask::RowIsValid(validity_entry, base_idx - start)) {
+    result_data[base_idx] = OP::Operation(...);   // only called for VALID rows
+}
+```
+
+So a lambda that opens with `if (!mask.RowIsValid(idx)) return X;` never runs
+that branch, and the function has always returned **NULL** for a null input. The
+`ValidityMask &` parameter is there so a function can *add* nulls on valid rows,
+not so it can observe them.
+
+**Therefore, if the branch is dead, a plain `Execute` is the exact equivalent** —
+it propagates nulls identically, exists in both v1.5 and v2.0, and needs no shim:
+
+```cpp
+UnaryExecutor::Execute<string_t, bool>(input, result, count,
+                                       [](string_t s) { return !s.GetString().empty(); });
+```
+
+Only if the lambda genuinely *produces* nulls on valid rows do you need v2.0's
+`optional<RESULT_TYPE>` form, and then a shim like duckdb_yaml's
+`CompatUnaryExecuteWithNulls` / `CompatBinaryExecuteWithNulls` is the way.
+
+#### The trap
+
+The obvious-looking "explicit loop" replacement is wrong, and it fails silently:
+
+```cpp
+// WRONG -- turns NULL into false for non-constant inputs
 for (idx_t i = 0; i < count; i++) {
     const auto idx = vdata.sel->get_index(i);
     out[i] = vdata.validity.RowIsValid(idx) && !in[idx].GetString().empty();
 }
 ```
 
-**Verify the old and new against each other**, because this is the change most
-likely to alter behaviour quietly. Comparing ours showed the original lambda's
-`RowIsValid` branch was *dead*: DuckDB's default null handling propagates above
-the function, so a null input produced NULL either way and the branch never
-decided anything.
+It writes a *value* where the original left the row NULL, and it never touches
+the result validity mask. Here is what that cost us, measured against the pinned
+v1.5 by rebuilding one file:
+
+```
+SELECT v, md_valid(v) FROM (VALUES ('x'), (NULL), ('')) t(v);
+
+pre-port    x -> true   NULL -> NULL    '' -> false
+"ported"    x -> true   NULL -> FALSE   '' -> false     <- regression
+fixed       x -> true   NULL -> NULL    '' -> false
+```
+
+**And note why it was missed.** `SELECT md_valid(NULL)` returns NULL in *all
+three* versions, because constant folding propagates the null above the function
+before it ever runs. Testing the constant makes the bug invisible. **Test a NULL
+inside a non-constant vector** — `FROM (VALUES ...)` — or you are not testing the
+code path you changed.
 
 ### 5. `FunctionSet<T>::functions` yields `shared_ptr<const T>`
 
@@ -277,6 +350,25 @@ duckdb-next-build:
 
 Then `gh workflow run <workflow>.yml --ref <your-branch>` drives the port.
 
+**A green *build* is not a green canary.** The job runs Build and then Test, and
+community-extensions' `test_against_latest` runs tests too — so it gates on both.
+An extension can compile against v2.0 and still fail behaviourally.
+
+**Read per-step results, not the job rollup**, and make sure the run is actually
+`completed` before you read any conclusion — a rollup queried mid-run reports
+`success` for jobs that later fail:
+
+```
+gh run view <run-id> --json status --jq .status        # must say "completed"
+gh run view <run-id> --json jobs \
+   --jq '.jobs[] | "=== \(.name) => \(.conclusion)", (.steps[]|"  \(.conclusion) \(.name)")'
+```
+
+This matters in both directions. One of our canary rounds was Build-success /
+Test-failure on `linux_amd64` while `linux_arm64` was green end to end — reading
+the rollup as "the port does not compile" would have sent the next round chasing
+an API problem that did not exist.
+
 **Reading the failure needs the REST API, not `gh run view`.** Because the canary
 job calls a *reusable* workflow, `gh run view <run> --log-failed` prints nothing
 at all — which reads exactly like a job that produced no errors. Get the job id
@@ -299,6 +391,20 @@ rollup includes both — so an unrestricted canary shows red on every PR. And us
 `if:` rather than `continue-on-error:`, because a job calling a **reusable
 workflow** accepts only a fixed set of keys; adding `continue-on-error` makes the
 whole workflow fail to parse, scheduling zero jobs.
+
+## Two local shortcuts
+
+**Syntax-check single TUs instead of building.** While waiting for build capacity
+(or CI), you can verify the pinned-v1.5 half of your changed files in about a
+minute: pull each file's compile command out of `build/release/compile_commands.json`
+and re-run it with `-fsyntax-only`. One process, no link, no DuckDB rebuild.
+
+**Do not run `make format` as a pre-push step.** On several of these repos
+clang-format 11.0.1 — the version `duckdb/scripts/format.py` demands — reports
+drift on a *pristine* default branch, while CI's format check is green. Running
+it mixes unrelated reformatting into your port diff and makes the review
+worthless. Check that your branch adds no *new* drift relative to the default
+branch instead.
 
 ## Order of work
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -94,6 +94,13 @@ leading indicator, not a test.
 
 Ask DuckDB what its own type is instead (see change 2).
 
+**The same hazard sits on `__has_include("duckdb/common/vector/list_vector.hpp")`**,
+which several headers use to gate `CompatSetOutputCardinality`. That one fails
+*loudly* — a backported header without `SetChildCardinality` is a compile error,
+not a wrong branch — but it still breaks the **shipped** build on a submodule
+bump. Probe the member (`SetChildCardinality`) and let the `__has_include` do
+nothing but pull the header in.
+
 ### Check your C++ standard before copying shims
 
 `if constexpr` is C++17. Several extensions here compile their TUs at **C++11 on
@@ -1035,6 +1042,16 @@ gh run view <run-id> --json jobs \
 gh api repos/:owner/:repo/actions/jobs/<job-id>/logs | grep 'error:'
 ```
 
+**Verify the dispatch actually happened.** `gh` shares one *user-level* REST
+rate limit, and several concurrent ports polling run status will exhaust it. When
+it goes, you get `HTTP 403: API rate limit exceeded` — and it takes out
+`gh workflow run` too. The failure mode is nasty: your `git push` went over SSH
+and succeeded, but the dispatch was refused, so you are left with a **push run
+that does not include the `workflow_dispatch`-gated canary**. It looks exactly
+like a slow queue. After dispatching, confirm a `workflow_dispatch` run exists
+before waiting on one, and widen poll intervals when several ports share a
+limit.
+
 **Push and dispatch on the same commit cancel each other — and the wrong one
 survives.** The `concurrency:` group covers the workflow, the ref *and* the SHA,
 so a `push` run and a `workflow_dispatch` run on the **same commit** share a
@@ -1108,6 +1125,12 @@ a function name unique to your source. Best of all, let the result come back
 through the tool result rather than off disk. (Output files the tool itself
 creates for background commands are already collision-safe — they are named per
 invocation. The exposure is only scripts you write into a shared directory.)
+
+**`~/.duckdb/extensions/` is shared too.** A local `FORCE INSTALL` from one port
+replaces an extension binary that every other port on the box loads. One repo's
+tests went red on a renamed function it had never heard of, with nothing wrong in
+its own tree. If you install locally, expect to break your neighbours; if a test
+fails on a symbol from a *different* extension, suspect this before your diff.
 
 **Wait on your own PID, not a `pgrep` pattern.** `pgrep -f 'make release'`
 matches every concurrent build, not yours. It makes a waiter block until the

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -770,9 +770,17 @@ depends entirely on what your pushdown is *for*:
 A purely mechanical port cannot tell these apart. Check which shape you have.
 
 Related: v2.0's `TableFilterSet` has a **second** collection for multi-column
-filters that `begin()`/`end()` does not visit. Since DuckDB deletes a fully-pushed
-filter from the plan, an unseen filter is an *unapplied* filter. Detect it and
-refuse (`NotImplementedException`); there is no correct "ignore it".
+filters that iterating the per-column entries does not visit. Since DuckDB
+deletes a fully-pushed filter from the plan, an unseen filter is an *unapplied*
+filter. There is no correct "ignore it" — detect and refuse
+(`NotImplementedException`). Detection is a direct call, not an inference:
+`HasMultiColumnFilters()` and `GetMultiColumnFilters()` are members
+(`table_filter_set.hpp:25,34`).
+
+The same header also exposes `HasFilter`, `GetFilterByColumnIndex`,
+`TryGetFilterByColumnIndex` and their `Mutable` variants — usually cleaner than
+iterating, and `TryGet...` returns `optional_ptr`, which removes a lookup-then-
+index round trip.
 
 ### 16. `CreateInfo`/`DropInfo` names became a private `QualifiedName`
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -630,7 +630,22 @@ shipped planner **strictly more conservative** around it. That direction is safe
 — it can only stop a throwing function being evaluated on rows it should not
 have been — but it is a real change, so measure it rather than assuming.
 
-**Mark precisely, not defensively.** Because the property is optimizer-visible,
+**Marking is often a latent v1.5 *fix*, not a cost.** `CanThrow()` is read in
+six places on the pin (`expression_heuristics:48`, `pushdown_outer_join:125`,
+`pushdown_projection:54`, `pushdown_get:119`, `adaptive_filter:15`,
+`execute_function:11`), and every one asks whether a *filter expression* can
+throw. An extension that leaves a file-opening function marked
+`CANNOT_ERROR` is telling the planner it may hoist that call onto rows a guard
+was there to exclude — so `CASE WHEN ok THEN risky(f) END` can be evaluated on
+the rows the `CASE` exists to protect. Declaring it fallible restrains exactly
+that, which is the point rather than the price.
+
+It also means the interaction is narrower than it first looks: if your own
+pushed-down filters are plain column comparisons that never call your functions,
+marking them cannot restrain your own pushdown — the two never meet. One port
+measured precisely this and its pushdown tests were unchanged.
+
+**Mark precisely, not defensively.** The property is optimizer-visible, so
 over-marking is a small real pessimisation of the shipped binary, not a free
 hedge.
 
@@ -962,10 +977,29 @@ gh run view <run-id> --json jobs \
 gh api repos/:owner/:repo/actions/jobs/<job-id>/logs | grep 'error:'
 ```
 
-**Dispatch after pushing, and do not push again while it runs.** The standard
-`concurrency:` group keys on the workflow and ref, so a push run and a dispatch
-run on the same branch cancel each other. Two of my canary runs were cancelled
-this way before I noticed I was reading a superseded run.
+**Push and dispatch on the same commit cancel each other — and the wrong one
+survives.** The `concurrency:` group covers the workflow, the ref *and* the SHA,
+so a `push` run and a `workflow_dispatch` run on the **same commit** share a
+group. The survivor may be the **push** run, which on a feature branch has the
+canary gated OFF — so it schedules no canary at all and looks like a slow queue
+rather than a mistake.
+
+Two orderings work:
+
+```
+push  ->  cancel the push run  ->  dispatch          # what to do if you must push
+dispatch on a commit you already pushed, then leave the branch alone
+```
+
+Runs on *different* SHAs do **not** cancel each other, so a stale earlier run
+also sits in the queue eating runners until you cancel it explicitly. When
+porting several repos at once, that stale-run backlog is self-inflicted and
+worth clearing:
+
+```
+gh run list --workflow W.yml --branch B --limit 25 --json databaseId,status \
+  --jq '.[]|select(.status=="queued" or .status=="in_progress")|.databaseId'
+```
 
 Two notes on that job. Restricting it to `workflow_dispatch` (or pushes to main)
 matters: a push and a `pull_request` both fire on the same commit, and a PR's check

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -635,6 +635,16 @@ green end to end, check the arm64 leg first and report the amd64 failure as a
 separate open question rather than folding it into the port. If *both* platforms
 fail the same test, that is much more likely to be yours.
 
+**`gh pr edit --body-file` can fail silently on these repos.** It errors with a
+GraphQL *"Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)"*
+and **leaves the body unchanged** — so a PR you believe you corrected still shows
+the old text. Two ports hit this independently. Use the REST endpoint instead,
+and re-read the body afterwards either way:
+
+```
+gh api -X PATCH repos/OWNER/REPO/pulls/N -F body=@body.md
+```
+
 **Reading the failure needs the REST API, not `gh run view`.** Because the canary
 job calls a *reusable* workflow, `gh run view <run> --log-failed` prints nothing
 at all — which reads exactly like a job that produced no errors. Get the job id

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1253,6 +1253,26 @@ deduction it rejects that GCC and AppleClang accept, for instance — is invisib
 to it. Your MSVC coverage comes from the stable leg only, which is another reason
 not to treat that leg as merely a formality.
 
+**"Canary green" can mean "green over the half that ran."** `sqllogictest` turns
+an *unavailable extension* into a **skip**, not a failure — so any test file
+opening with `INSTALL json` / `require json` (or any other extension) is silently
+dropped on a canary where that extension is not installable. One repo's suite is
+1122 assertions locally; on v2.0, 10 of 12 files ran for 575 assertions and
+**547 — roughly half — were skipped**. The run was green, and it was green over
+half the suite.
+
+This matters most for exactly the classes the canary is supposed to cover: a
+skipped file's class 7, 13 and 19 exposure is untested, and skipping is invisible
+in a pass/fail conclusion. Check it explicitly:
+
+```
+grep -c 'All tests were skipped' <job log>
+grep -rln 'INSTALL \|require ' test/sql/           # your skip candidates
+```
+
+and compare the canary's assertion count against your local one. Report "green
+over N of M files" rather than "green" when they differ.
+
 **A canary whose Build FAILED tells you nothing about classes 7, 13 or 19** —
 those are runtime contracts, and the Test step never ran. Check that `Test` says
 `success`, not `skipped`. A port reporting "the build is green" from a run whose
@@ -1462,6 +1482,15 @@ workflow** accepts only a fixed set of keys; adding `continue-on-error` makes th
 whole workflow fail to parse, scheduling zero jobs.
 
 ## Two local shortcuts
+
+**"No tests ran" exits 0 and looks exactly like "all tests passed."** The
+unittest binary only discovers tests under the project root, so a file staged
+somewhere else — a scratch directory, say — yields `No test cases matched ... /
+No tests ran` and a **zero exit status**. Any perturbation you make to check that
+an assertion is live has to be made *in place* and restored afterwards. This is
+the empty-`FAILED:` failure mode in a different costume: a check that ran nothing
+and a check that passed are indistinguishable unless you read the whole output,
+not the exit code.
 
 **Syntax-check single TUs instead of building.** While waiting for build capacity
 (or CI), you can verify the pinned-v1.5 half of your changed files in about a

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -160,12 +160,11 @@ a fully green canary does not clear you of either.
 | 15 | filter pushdown reworked | compile errors — **plus silent wrong results** |
 | 16 | `CreateInfo`/`DropInfo` names → private `QualifiedName` | compile error (storage extensions only) |
 | 17 | result / prepared-statement names are `Identifier` | compile error |
-| 18 | `SetCardinality` → `SetChildCardinality` | **compiles; silently overwrites data** |
+| 18 | `SetCardinality` → `SetChildCardinality` | compiles; may throw `InternalException` at run time |
 
 Classes 7 and 13 break at run time on a build that compiles cleanly everywhere.
 Class 11 can compile and misbehave. Class 15 can return **wrong rows** with no
-error at all, if your pushdown *is* the filter rather than an optimisation, and
-class 18 can silently **overwrite column data** if shimmed uniformly.
+error at all, if your pushdown *is* the filter rather than an optimisation.
 Class 13 additionally shows up on **one CI architecture only**, because its
 enforcement is an assertion — so "green on arm64" is not evidence of anything.
 
@@ -858,43 +857,56 @@ an `Identifier`.
 answers yes on **both** versions and then fails deep inside the instantiation.
 Probe the `GetNamedParameterMap` accessor instead.
 
-### 18. `SetCardinality` → `SetChildCardinality` is NOT a rename — it can overwrite your data
+### 18. `SetCardinality` → `SetChildCardinality` is not a safe blanket rename
 
-The most dangerous shim in this ecosystem, because it looks like the safest one.
-A `CompatSetOutputCardinality` that forwards to `SetChildCardinality` on v2.0 is
-**exactly** the substitution upstream warns against, in its own words
-(`data_chunk.hpp:72-74`):
+**Corrected.** An earlier version of this section called this silent data
+corruption, on the strength of upstream's doc comment
+(`data_chunk.hpp:72-74`), which says forwarding "would resize/overwrite their
+data". That reading was **wrong**, and it was circulated as an urgent warning
+before anyone traced the implementation. The comment is real; the inference from
+it was not.
 
-> this only sets the chunk's cardinality, it does **not** resize the child
-> vectors... Callers that mutate the child vectors directly (e.g.
-> `Vector::Append`/`SetValue`) and then call `SetCardinality` rely on this —
-> **forwarding to `SetChildCardinality` would resize/overwrite their data**.
-
-So the correct mapping depends entirely on the **order** at the call site:
-
-| your order | v1.5 | correct on v2.0 |
-|---|---|---|
-| set cardinality, *then* write children | `SetCardinality` | `SetChildCardinality` |
-| write children (`SetValue`/`Append`), *then* set cardinality | `SetCardinality` | **`SetCardinalityUnsafe`** |
-
-`SetCardinality` is `[[deprecated]]` but **preserved**, and it forwards to
-`SetCardinalityUnsafe` — it was kept *precisely so that* write-then-set callers
-keep working. A single blanket shim cannot be right for both orders.
-
-**So for a write-then-set site, the fix is to leave it alone.** That inverts the
-usual porting instinct. The deprecation warning invites you to route every call
-through a `CompatSetOutputCardinality`, and doing that to a write-then-set site
-*introduces* the data loss rather than removing it. A repo that "ported" all its
-call sites uniformly would have been strictly worse off than one that ported
-none. Only the cardinality-before-write order wants `SetChildCardinality`.
-
-This is a **silent** corruption: it compiles, and it only manifests as wrong
-column data on v2.0. Audit every call site for its order rather than shimming
-them uniformly:
+What the code actually does on current `main`:
 
 ```
-grep -rn -B8 'CompatSetOutputCardinality\|SetCardinality' src/ | grep -n 'SetValue\|Append'
+DataChunk::SetChildCardinality(n)        data_chunk.cpp:155
+   flat/constant vector -> FlatVector::SetSize(v, n)
+   any other vector     -> throw InternalException if v.size() != n
+FlatVector::SetSize -> VectorBuffer::SetVectorSize   vector_buffer.cpp:36
+   same size -> return;  CONSTANT -> ok;  FLAT -> bounds-check, then v_size = n
+   anything else -> throw InternalException
+VectorStructBuffer::SetVectorSize        struct_vector.cpp:63
+   propagates the size to each child; no realloc, no zeroing, no copy
 ```
+
+Every leaf is `v_size = n` behind a bounds check. Nothing on the path touches
+element bytes, and there is no `VectorListBuffer` override, so LIST/MAP child
+entries are untouched too.
+
+**So the real hazard is a loud one.** Forwarding is unsafe as a *blanket* rename
+because `SetChildCardinality` **validates and propagates** where the old call did
+neither:
+
+- it throws if a column is neither flat nor constant and its size disagrees;
+- it throws if `n` exceeds a flat vector's capacity;
+- it pushes the size down into `STRUCT`/`ARRAY` children.
+
+An extension that leaves a column non-flat, or over-fills past capacity, gets an
+`InternalException` where it previously got silence. That is worth auditing —
+but it fails visibly, and a green canary that exercises those code paths is
+meaningful evidence that you are fine.
+
+**Do not "fix" write-then-set sites reflexively.** `SetCardinality` is
+`[[deprecated]]` but preserved *precisely* to keep them working, and
+`SetCardinalityUnsafe` is the non-deprecated spelling of the same behaviour.
+Equally, do not assume a shim to `SetChildCardinality` is wrong: at least one
+extension adopted it deliberately because DuckDB `main` wants child buffer sizes
+synchronised after `SetValue` writes, and its full suite passes against `main`
+through exactly those sites with `STRUCT`, `MAP` and `LIST` columns.
+
+The honest summary: **which call you want depends on whether your children's
+sizes are already correct when you set the cardinality**, and the deprecation
+warning alone does not tell you. It is an audit, not a mechanical substitution.
 
 ## Deprecated is not removed — check before you port
 

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -419,6 +419,21 @@ Test-failure on `linux_amd64` while `linux_arm64` was green end to end — readi
 the rollup as "the port does not compile" would have sent the next round chasing
 an API problem that did not exist.
 
+**A `linux_amd64` Test failure with `linux_arm64` green may not be yours.** We
+have seen this shape on two unrelated extensions against DuckDB `main`:
+
+| repo | ported? | amd64 | arm64 |
+|---|---|---|---|
+| duckdb_markdown | yes | Build ok, Test **fail** (`readme_integration.test`) | green |
+| duck_hunt | **no** — plain default branch | Build ok, Test **fail** (`config_parser.test`) | green |
+
+Different tests, different repos, same asymmetry. Because the second extension
+has no compat work on it at all, **this shape is demonstrably not something the
+porting introduces.** If your canary comes back amd64-Test-red while arm64 is
+green end to end, check the arm64 leg first and report the amd64 failure as a
+separate open question rather than folding it into the port. If *both* platforms
+fail the same test, that is much more likely to be yours.
+
 **Reading the failure needs the REST API, not `gh run view`.** Because the canary
 job calls a *reusable* workflow, `gh run view <run> --log-failed` prints nothing
 at all — which reads exactly like a job that produced no errors. Get the job id

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -241,11 +241,33 @@ inline string CompatNameStr(const Identifier &id) { return id.GetIdentifierName(
 inline CompatName CompatMakeName(string name) { return CompatName(std::move(name)); }
 ```
 
-**Write it WITHOUT `typename`.** `std::remove_reference<decltype(...)>::type::value_type`
-is non-dependent at namespace scope, and `typename` outside a template is only
-legal from C++20. GCC tolerates it; **MSVC does not**, so it breaks the Windows
-leg and nothing else. The same applies to any
-`child_list_t<...>::value_type::first_type`.
+**Write it WITHOUT `typename` at namespace scope** — but for the right reason,
+which is simply that it buys nothing there. An earlier draft of this guide said
+`typename` outside a template is "C++20-only" and breaks MSVC. **That is wrong**,
+and it was propagated widely before anyone checked it. CWG 382 permitted
+`typename` on non-dependent qualified names from C++11 on, and
+`g++ -pedantic-errors` accepts it at `-std=c++11`, `c++14` and `c++17`:
+
+```cpp
+using T = typename std::remove_reference<std::vector<int> &>::type::value_type;  // fine
+```
+
+(Whether some MSVC version rejects it is a claim nobody in this effort actually
+tested; treat it as unverified.) Drop the keyword because it is redundant, not
+because it is illegal — and note that **inside** the template it is genuinely
+required, since `D` is dependent there:
+
+```cpp
+template <class R, class A, class B, class C, class D>
+struct CompatBindNamesOf<R (*)(A, B, C, D)> {
+	using type = typename std::remove_reference<D>::type::value_type;   // REQUIRED
+};
+using CompatName = CompatBindNamesOf<table_function_bind_t>::type;      // no typename
+```
+
+Getting the reason wrong matters more than the keyword: someone who believes
+`typename` is illegal outside C++20 will delete it from a context where it is
+mandatory.
 
 **Assert the coupling.** Deriving the type fixes one failure mode and leaves
 another: `CompatName` can resolve to `Identifier` on a DuckDB whose

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -1105,6 +1105,38 @@ and re-read the body afterwards either way:
 gh api -X PATCH repos/OWNER/REPO/pulls/N -F body=@body.md
 ```
 
+**A failing test's error message may not be in the log at all.** DuckDB's
+parallel runner (`scripts/ci/run_tests.py`, 3 workers) renders expected/actual
+only for failures it classifies as `wrong_result`. Anything else falls through to
+a low-information path, and all that reaches the log is the statement plus a bare
+
+```
+test/sql/foo.test:78: FAILED:
+```
+
+— no message, no expected, no actual, nowhere in the job log. Since the pinned
+build cannot reproduce a v2.0-only failure by construction, the reason can be
+genuinely unobtainable.
+
+**The empty shape is itself a signal.** A real result mismatch *would* have
+printed a diff, and a thrown DuckDB exception *does* reach the log (we have an
+`INTERNAL Error: ... not marked as fallible` printed in full from another repo).
+So an empty `FAILED:` argues against both a wrong answer and a thrown error, and
+points at an assertion or crash — consistent with assertions being enabled on the
+`linux_amd64` image and not on `linux_arm64`.
+
+**How to get the message out.** `_extension_distribution.yml` accepts a
+`post_build_command` input, which `ci_phase.py` runs at the end of `build_linux`
+— after `make release`, before the test phase. Re-run the specific test files
+*serially* through the raw unittest binary there and the real error lands in the
+log:
+
+```yaml
+post_build_command: './build/release/test/unittest test/sql/foo.test || true'
+```
+
+Mark it temporary and revert it before proposing the port for merge.
+
 **Reading the failure needs the REST API, not `gh run view`.** Because the canary
 job calls a *reusable* workflow, `gh run view <run> --log-failed` prints nothing
 at all — which reads exactly like a job that produced no errors. Get the job id

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -108,6 +108,32 @@ markdown's header is written this way, so it is safe to copy into a C++11 repo.
 
 ## The changes
 
+Sorted by how they announce themselves. **The two that announce themselves not at
+all are the ones to plan around** — nothing in your toolchain will find them, and
+a fully green canary does not clear you of either.
+
+| # | change | how you find out |
+|---|---|---|
+| 1 | `LogicalType::SetAlias` removed → `WithAlias` | compile error |
+| 2 | bind signatures take `vector<Identifier>` | compile error |
+| 3 | `FlatVector::GetData<T>` is read-only | compile error |
+| 4 | `ExecuteWithNulls` removed | compile error |
+| 5 | `FunctionSet<T>::functions` is `shared_ptr<const T>` | compile error |
+| 6 | public fields → accessors (`varargs`, `return_type`, …) | compile error, **no grep finds it** |
+| 7 | `capture_argument_aliases` defaults to false | **RUNTIME, green build** |
+| 8 | `StructVector::GetEntries` element type | compile error |
+| 9 | per-vector accessor headers moved | compile error (reads as a missing symbol) |
+| 10 | `Vector::Reference` gained `count_t` | compile error — **must be `#ifdef`, not `if constexpr`** |
+| 11 | `ScalarFunction` ctor dropped a positional parameter | **may still compile, silently wrong** |
+| 12 | `DefaultMacro` changed shape | compile error |
+| 13 | throwing scalar functions must `SetFallible()` | **RUNTIME, green build, one arch only** |
+| 14 | `FlatVector::Validity` const split | compile error, **at the mutation, not the call** |
+
+Classes 7 and 13 break at run time on a build that compiles cleanly everywhere.
+Class 11 can compile and misbehave. Class 13 additionally shows up on **one CI
+architecture only**, because its enforcement is an assertion — so "green on
+arm64" is not evidence of anything.
+
 ### 1. `LogicalType::SetAlias` → `WithAlias`
 
 `WithAlias` returns a copy rather than mutating a type whose type-info may be

--- a/scripts/check_against_producer.py
+++ b/scripts/check_against_producer.py
@@ -127,6 +127,9 @@ CASES = [
 ]
 
 
+_SEEN_STDERR = set()
+
+
 def sql(binary, text, unsigned=True):
     with tempfile.NamedTemporaryFile("w", suffix=".sql", delete=False) as f:
         f.write(text)
@@ -134,8 +137,25 @@ def sql(binary, text, unsigned=True):
     try:
         argv = [binary] + (["-unsigned"] if unsigned else []) + ["-noheader", "-list"]
         r = subprocess.run(argv, stdin=open(path), capture_output=True, text=True)
-        if r.returncode != 0 or r.stderr.strip():
+        # A NON-ZERO exit is fatal. Non-empty stderr with a ZERO exit is not:
+        # DuckDB writes deprecation notices there while succeeding, and treating
+        # those as errors broke this bridge the day duck_block_utils deprecated
+        # pandoc_ast_to_blocks.
+        #
+        # It is still PRINTED, every time, and that matters more than the pass/fail
+        # decision: the opposite bug -- swallowing stderr entirely -- is what once
+        # made a failing query here read as "no findings". A warning that is
+        # visible cannot rot into a silence.
+        if r.returncode != 0:
             raise RuntimeError((r.stderr or "rc=%d" % r.returncode).strip())
+        if r.stderr.strip():
+            # Once per distinct message: the same deprecation on all 11 documents
+            # is 22 identical lines, which is the volume that trains a reader to
+            # skip the notices entirely.
+            for line in r.stderr.strip().splitlines():
+                if line not in _SEEN_STDERR:
+                    _SEEN_STDERR.add(line)
+                    print(f"  note (producer stderr): {line}")
         return r.stdout.strip()
     finally:
         os.unlink(path)

--- a/src/duck_block_functions.cpp
+++ b/src/duck_block_functions.cpp
@@ -1811,6 +1811,12 @@ void DuckBlockFunctions::RegisterDuckBlockToMdFunction(ExtensionLoader &loader) 
 		    }
 	    });
 
+	// Reaches a throwing depth guard, so v2.0 requires it to declare fallibility
+	// or the clean InvalidInputException becomes an InternalException -- which
+	// would defeat the guard, whose whole purpose is to turn unbounded recursion
+	// into a readable message. Found by following the throwing HELPERS, not the
+	// literal throws: the guard is two files away from every one of these.
+	duck_block_to_md.SetFallible();
 	loader.RegisterFunction(duck_block_to_md);
 }
 
@@ -1841,6 +1847,7 @@ void DuckBlockFunctions::RegisterDuckBlocksToMdFunction(ExtensionLoader &loader)
 		                                 }
 	                                 });
 
+	duck_blocks_to_md.SetFallible();
 	loader.RegisterFunction(duck_blocks_to_md);
 }
 
@@ -2024,6 +2031,7 @@ void DuckBlockFunctions::RegisterDuckBlocksToSectionsFunction(ExtensionLoader &l
 		    }
 	    });
 
+	duck_blocks_to_sections.SetFallible();
 	loader.RegisterFunction(duck_blocks_to_sections);
 }
 
@@ -2076,6 +2084,7 @@ static void RegisterParseMarkdownToDuckBlocks(ExtensionLoader &loader) {
 			                  result.SetValue(i, Value::LIST(dtype, vals));
 		                  }
 	                  });
+	fn.SetFallible();
 	loader.RegisterFunction(fn);
 }
 

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -83,24 +83,31 @@ inline LogicalType CompatWithAlias(TYPE type, string alias) {
 }
 
 // --- Vector::ToUnifiedFormat ---------------------------------------------------
-// v2.0 dropped the count parameter. Probed the same way.
+// v1.5: ToUnifiedFormat(count, data)  -- the only overload
+// v2.0: ToUnifiedFormat(data)         -- plus the count form kept as [[deprecated]]
+//
+// PROBE FOR THE COUNT-FREE OVERLOAD, not the count-taking one. v2.0 did not
+// remove the count form, it deprecated it, so a probe for the count form is
+// true on BOTH versions and the shim would always take the deprecated path --
+// silently never calling the new API it exists to reach. The count-free form is
+// the one that exists only on v2.0, so it is the one that discriminates.
 template <class T, class = void>
-struct CompatToUnifiedTakesCount : std::false_type {};
+struct CompatToUnifiedWithoutCount : std::false_type {};
 template <class T>
-struct CompatToUnifiedTakesCount<T, decltype(void(std::declval<T &>().ToUnifiedFormat(
-                                        idx_t(0), std::declval<UnifiedVectorFormat &>())))> : std::true_type {};
+struct CompatToUnifiedWithoutCount<T, decltype(void(std::declval<T &>().ToUnifiedFormat(
+                                          std::declval<UnifiedVectorFormat &>())))> : std::true_type {};
 
 template <class VEC>
-inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t count, UnifiedVectorFormat &data, std::true_type) {
-	vec.ToUnifiedFormat(count, data);
+inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t, UnifiedVectorFormat &data, std::true_type) {
+	vec.ToUnifiedFormat(data);
 }
 template <class VEC>
-inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t, UnifiedVectorFormat &data, std::false_type) {
-	vec.ToUnifiedFormat(data);
+inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t count, UnifiedVectorFormat &data, std::false_type) {
+	vec.ToUnifiedFormat(count, data);
 }
 template <class VEC = Vector>
 inline void CompatToUnifiedFormat(VEC &vec, idx_t count, UnifiedVectorFormat &data) {
-	CompatToUnifiedFormatImpl(vec, count, data, CompatToUnifiedTakesCount<VEC>());
+	CompatToUnifiedFormatImpl(vec, count, data, CompatToUnifiedWithoutCount<VEC>());
 }
 
 // --- FlatVector mutable data ---------------------------------------------------

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -87,4 +87,25 @@ inline void CompatToUnifiedFormat(VEC &vec, idx_t count, UnifiedVectorFormat &da
 	}
 }
 
+// --- FlatVector mutable data ---------------------------------------------------
+// v1.5: FlatVector::GetData<T>(vec)         returns T*
+// v2.0: FlatVector::GetData<T>(vec)         returns const T*
+//       FlatVector::GetDataMutable<T>(vec)  returns T*
+// Writing through the v2.0 GetData is a compile error, which is the point of the
+// split -- so the WRITE path must ask for mutability explicitly.
+template <class T, class = void>
+struct CompatHasFlatGetDataMutable : std::false_type {};
+template <class T>
+struct CompatHasFlatGetDataMutable<T, decltype(void(T::template GetDataMutable<bool>(std::declval<Vector &>())))>
+    : std::true_type {};
+
+template <class VALUE, class FV = FlatVector>
+inline VALUE *CompatFlatDataMutable(Vector &vec) {
+	if constexpr (CompatHasFlatGetDataMutable<FV>::value) {
+		return FV::template GetDataMutable<VALUE>(vec);
+	} else {
+		return FV::template GetData<VALUE>(vec);
+	}
+}
+
 } // namespace duckdb

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -23,6 +23,23 @@
 #include "duckdb/common/identifier.hpp"
 #endif
 
+// v2.0 split the per-vector accessor classes out of
+// duckdb/common/types/vector.hpp into one header each under
+// duckdb/common/vector/, and duckdb.hpp no longer pulls them in transitively.
+// This header names FlatVector at namespace scope, so include it explicitly
+// rather than relying on a transitive include that a given TU may not have.
+// Presents otherwise as "'FlatVector' has not been declared", which reads like
+// a missing symbol rather than a moved header.
+#if __has_include("duckdb/common/vector/flat_vector.hpp")
+#include "duckdb/common/vector/flat_vector.hpp"
+#endif
+#if __has_include("duckdb/common/vector/list_vector.hpp")
+#include "duckdb/common/vector/list_vector.hpp"
+#endif
+#if __has_include("duckdb/common/vector/struct_vector.hpp")
+#include "duckdb/common/vector/struct_vector.hpp"
+#endif
+
 namespace duckdb {
 
 // --- bind-signature name type -------------------------------------------------

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -83,6 +83,15 @@ inline CompatName CompatMakeName(string name) {
 	return CompatName(std::move(name));
 }
 
+// Ties the derived type to its overload set. Deriving CompatName fixes the type
+// but leaves a second failure mode open: CompatName could resolve to Identifier
+// on a DuckDB whose identifier.hpp this header did not find, so the Identifier
+// overload above was never declared -- and then CompatNameStr either fails to
+// match or silently picks a worse conversion. Assert the coupling instead of
+// assuming it.
+static_assert(std::is_same<decltype(CompatNameStr(std::declval<const CompatName &>())), string>::value,
+              "CompatNameStr must accept the derived CompatName on every DuckDB line");
+
 // --- LogicalType alias ---------------------------------------------------------
 // v1.5: void SetAlias(string)      -- mutates in place
 // v2.0: LogicalType WithAlias(string) const -- returns a copy, never mutating a

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -65,8 +65,18 @@ namespace duckdb {
 // bind out-parameter on both lines (verified: table_function.hpp:110/288 on the
 // pin, :123/319 on main), so asking it what the name type is cannot drift --
 // it IS the thing that changed.
-using CompatName =
-    std::remove_reference<decltype(std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
+// Read the name type off table_function_bind_t ITSELF -- its fourth parameter is
+// the vector being ported. Tighter than deriving from
+// TableFunctionBindInput::input_table_names, which is a sibling that happens to
+// move in step; here there is no "happens to" left, because the typedef named is
+// the one that changed. Every bind signature then follows automatically.
+template <class T>
+struct CompatBindNamesOf;
+template <class R, class A, class B, class C, class D>
+struct CompatBindNamesOf<R (*)(A, B, C, D)> {
+	using type = typename std::remove_reference<D>::type::value_type;
+};
+using CompatName = CompatBindNamesOf<table_function_bind_t>::type;
 
 inline string CompatNameStr(const string &name) {
 	return name;

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -163,4 +163,71 @@ inline VALUE *CompatFlatDataMutable(Vector &vec) {
 	return CompatFlatDataMutableImpl<VALUE, FV>(vec, CompatHasFlatGetDataMutable<FV>());
 }
 
+// --- scalar function fallibility ------------------------------------------------
+// v2.0 added a RUNTIME contract: a scalar function that can throw during
+// execution must declare it. Throwing from a function that has not is an
+// InternalException:
+//
+//   INTERNAL Error: Scalar function "f" threw an execution error, but the
+//   function is not marked as fallible - the function must call SetFallible().
+//
+// This is NOT a compile error and no grep finds it -- the only symptom is a test
+// that exercises an error path, and only on a build with assertions enabled, so
+// one CI arch can be green while another is red on the very same commit.
+//
+// No-op on v1.5, where the member does not exist. Must be called BEFORE the
+// function goes into a FunctionSet, since set members are no longer mutable
+// (see the FunctionSet<T>::functions change).
+template <class T, class = void>
+struct CompatHasSetFallible : std::false_type {};
+template <class T>
+struct CompatHasSetFallible<T, decltype(void(std::declval<T &>().SetFallible()))> : std::true_type {};
+
+template <class FUNC>
+inline void CompatSetFallibleImpl(FUNC &fun, std::true_type) {
+	fun.SetFallible();
+}
+template <class FUNC>
+inline void CompatSetFallibleImpl(FUNC &, std::false_type) {
+}
+template <class FUNC>
+inline void CompatSetFallible(FUNC &fun) {
+	CompatSetFallibleImpl(fun, CompatHasSetFallible<FUNC>());
+}
+
+// --- FlatVector validity mask -----------------------------------------------
+// v1.5: Validity(Vector &)              returns ValidityMask &
+// v2.0: Validity(const Vector &)        returns const ValidityMask &
+//       ValidityMutable(Vector &)       returns ValidityMask &
+//
+// Same copy-on-write split as GetData/GetDataMutable: ValidityMutable goes
+// through BufferMutable() and un-shares, Validity goes through Buffer() and does
+// not. Probed separately from the GetDataMutable change because they are two
+// independent upstream changes.
+//
+// Worse to diagnose than the GetData case: `auto &m = FlatVector::Validity(v)`
+// still COMPILES on v2.0, silently deducing a const reference. The error appears
+// later, at the mutation, as "passing 'const duckdb::ValidityMask' as 'this'
+// argument discards qualifiers" -- naming neither Validity nor FlatVector. Grep
+// for the MUTATION (SetInvalid/SetValid/SetAllInvalid/SetAllValid) and walk back
+// to where the reference was bound.
+template <class T, class = void>
+struct CompatHasFlatValidityMutable : std::false_type {};
+template <class T>
+struct CompatHasFlatValidityMutable<T, decltype(void(T::ValidityMutable(std::declval<Vector &>())))>
+    : std::true_type {};
+
+template <class FV>
+inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::true_type) {
+	return FV::ValidityMutable(vec);
+}
+template <class FV>
+inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::false_type) {
+	return FV::Validity(vec);
+}
+template <class FV = FlatVector>
+inline ValidityMask &CompatFlatValidityMutable(Vector &vec) {
+	return CompatFlatValidityMutableImpl<FV>(vec, CompatHasFlatValidityMutable<FV>());
+}
+
 } // namespace duckdb

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -77,9 +77,20 @@ inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::false_type)
 	type.SetAlias(std::move(alias));
 	return type;
 }
-template <class TYPE = LogicalType>
-inline LogicalType CompatWithAlias(TYPE type, string alias) {
-	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<TYPE>());
+// The ENTRY POINT is deliberately NOT a template. A `template <class TYPE =
+// LogicalType>` form looks equivalent but is not: the default template argument
+// is inert because deduction wins, so the very common call
+//
+//     CompatWithAlias(LogicalType::VARCHAR, "md")
+//
+// deduces TYPE = LogicalTypeId -- `LogicalType::VARCHAR` is a static constexpr
+// LogicalTypeId (types.hpp), not a LogicalType -- and then hard-errors inside
+// the shim with "request for member 'SetAlias' in 'type', which is of non-class
+// type 'duckdb::LogicalTypeId'". A concrete parameter restores the implicit
+// LogicalTypeId -> LogicalType conversion at the call site. Only the Impl
+// overloads stay templated, which is all the tag dispatch needs.
+inline LogicalType CompatWithAlias(LogicalType type, string alias) {
+	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<LogicalType>());
 }
 
 // --- Vector::ToUnifiedFormat ---------------------------------------------------

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -53,21 +53,33 @@ inline string CompatMakeName(string name) {
 // Detected by PROBING for the member rather than by the Identifier macro above,
 // because these are two independent changes and tying one to the other would
 // silently pick the wrong branch if they ever land in different releases.
-// `if constexpr` discards the untaken branch only inside a template, hence the
-// template parameter.
+// The member probe itself (the decltype(void(expr)) partial specialisation) is
+// valid C++11; only the dispatch below needs care -- see the note on it.
 template <class T, class = void>
 struct CompatHasWithAlias : std::false_type {};
 template <class T>
 struct CompatHasWithAlias<T, decltype(void(std::declval<const T &>().WithAlias(string())))> : std::true_type {};
 
+// Dispatched on a tag rather than with `if constexpr`, so the header also
+// compiles at C++11. Several extensions in this ecosystem build their TUs at
+// C++11 deliberately (forcing C++17 on the extension but not on libduckdb makes
+// static-const members in duckdb's headers acquire implicit inline linkage in
+// one and not the other, which produces multiple-definition link errors), and
+// `if constexpr` is C++17-only. Tag dispatch has the same property that matters
+// here: only the selected overload is instantiated, so the branch referring to
+// the absent member is never compiled.
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::true_type) {
+	return type.WithAlias(std::move(alias));
+}
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::false_type) {
+	type.SetAlias(std::move(alias));
+	return type;
+}
 template <class TYPE = LogicalType>
 inline LogicalType CompatWithAlias(TYPE type, string alias) {
-	if constexpr (CompatHasWithAlias<TYPE>::value) {
-		return type.WithAlias(std::move(alias));
-	} else {
-		type.SetAlias(std::move(alias));
-		return type;
-	}
+	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<TYPE>());
 }
 
 // --- Vector::ToUnifiedFormat ---------------------------------------------------
@@ -78,13 +90,17 @@ template <class T>
 struct CompatToUnifiedTakesCount<T, decltype(void(std::declval<T &>().ToUnifiedFormat(
                                         idx_t(0), std::declval<UnifiedVectorFormat &>())))> : std::true_type {};
 
+template <class VEC>
+inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t count, UnifiedVectorFormat &data, std::true_type) {
+	vec.ToUnifiedFormat(count, data);
+}
+template <class VEC>
+inline void CompatToUnifiedFormatImpl(VEC &vec, idx_t, UnifiedVectorFormat &data, std::false_type) {
+	vec.ToUnifiedFormat(data);
+}
 template <class VEC = Vector>
 inline void CompatToUnifiedFormat(VEC &vec, idx_t count, UnifiedVectorFormat &data) {
-	if constexpr (CompatToUnifiedTakesCount<VEC>::value) {
-		vec.ToUnifiedFormat(count, data);
-	} else {
-		vec.ToUnifiedFormat(data);
-	}
+	CompatToUnifiedFormatImpl(vec, count, data, CompatToUnifiedTakesCount<VEC>());
 }
 
 // --- FlatVector mutable data ---------------------------------------------------
@@ -99,13 +115,17 @@ template <class T>
 struct CompatHasFlatGetDataMutable<T, decltype(void(T::template GetDataMutable<bool>(std::declval<Vector &>())))>
     : std::true_type {};
 
+template <class VALUE, class FV>
+inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::true_type) {
+	return FV::template GetDataMutable<VALUE>(vec);
+}
+template <class VALUE, class FV>
+inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::false_type) {
+	return FV::template GetData<VALUE>(vec);
+}
 template <class VALUE, class FV = FlatVector>
 inline VALUE *CompatFlatDataMutable(Vector &vec) {
-	if constexpr (CompatHasFlatGetDataMutable<FV>::value) {
-		return FV::template GetDataMutable<VALUE>(vec);
-	} else {
-		return FV::template GetData<VALUE>(vec);
-	}
+	return CompatFlatDataMutableImpl<VALUE, FV>(vec, CompatHasFlatGetDataMutable<FV>());
 }
 
 } // namespace duckdb

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -65,8 +65,8 @@ namespace duckdb {
 // bind out-parameter on both lines (verified: table_function.hpp:110/288 on the
 // pin, :123/319 on main), so asking it what the name type is cannot drift --
 // it IS the thing that changed.
-using CompatName = typename std::remove_reference<decltype(
-    std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
+using CompatName =
+    std::remove_reference<decltype(std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
 
 inline string CompatNameStr(const string &name) {
 	return name;

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include <type_traits>
+
+// Compatibility shims for building against BOTH the pinned stable DuckDB
+// (v1.5.x, what this extension ships against) and DuckDB main (the v2.0 line,
+// what community-extensions' `test_against_latest` builds against).
+//
+// FEATURE DETECTION, NOT VERSION NUMBERS. A version macro says when a thing
+// changed; a probe says whether it changed here. The probe keeps working when a
+// change is backported, reverted, or lands on a different branch than expected.
+// (Idiom borrowed from duckdb_webbed's duckdb_compat.hpp, which the rest of the
+// duck_block ecosystem already uses.)
+
+// duckdb::Identifier replaced std::string as the name type in table-function and
+// COPY bind signatures. Identifier compares case-insensitively, and construction
+// from a RUNTIME string is explicit by design -- promoting a string to an
+// identifier is meant to be a deliberate act at the call site -- so a boundary
+// helper is needed rather than an implicit conversion.
+#if __has_include("duckdb/common/identifier.hpp")
+#define DUCKDB_HAS_IDENTIFIER 1
+#include "duckdb/common/identifier.hpp"
+#endif
+
+namespace duckdb {
+
+// --- bind-signature name type -------------------------------------------------
+// Used wherever a bind callback receives or fills a vector of column names.
+#ifdef DUCKDB_HAS_IDENTIFIER
+using CompatName = Identifier;
+inline string CompatNameStr(const Identifier &id) {
+	return id.GetIdentifierName();
+}
+inline Identifier CompatMakeName(string name) {
+	return Identifier(std::move(name));
+}
+#else
+using CompatName = string;
+inline string CompatNameStr(const string &name) {
+	return name;
+}
+inline string CompatMakeName(string name) {
+	return name;
+}
+#endif
+
+// --- LogicalType alias ---------------------------------------------------------
+// v1.5: void SetAlias(string)      -- mutates in place
+// v2.0: LogicalType WithAlias(string) const -- returns a copy, never mutating a
+//       type whose type-info is shared.
+//
+// Detected by PROBING for the member rather than by the Identifier macro above,
+// because these are two independent changes and tying one to the other would
+// silently pick the wrong branch if they ever land in different releases.
+// `if constexpr` discards the untaken branch only inside a template, hence the
+// template parameter.
+template <class T, class = void>
+struct CompatHasWithAlias : std::false_type {};
+template <class T>
+struct CompatHasWithAlias<T, decltype(void(std::declval<const T &>().WithAlias(string())))> : std::true_type {};
+
+template <class TYPE = LogicalType>
+inline LogicalType CompatWithAlias(TYPE type, string alias) {
+	if constexpr (CompatHasWithAlias<TYPE>::value) {
+		return type.WithAlias(std::move(alias));
+	} else {
+		type.SetAlias(std::move(alias));
+		return type;
+	}
+}
+
+// --- Vector::ToUnifiedFormat ---------------------------------------------------
+// v2.0 dropped the count parameter. Probed the same way.
+template <class T, class = void>
+struct CompatToUnifiedTakesCount : std::false_type {};
+template <class T>
+struct CompatToUnifiedTakesCount<T, decltype(void(std::declval<T &>().ToUnifiedFormat(
+                                        idx_t(0), std::declval<UnifiedVectorFormat &>())))> : std::true_type {};
+
+template <class VEC = Vector>
+inline void CompatToUnifiedFormat(VEC &vec, idx_t count, UnifiedVectorFormat &data) {
+	if constexpr (CompatToUnifiedTakesCount<VEC>::value) {
+		vec.ToUnifiedFormat(count, data);
+	} else {
+		vec.ToUnifiedFormat(data);
+	}
+}
+
+} // namespace duckdb

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb/function/table_function.hpp"
 #include <type_traits>
+#include <utility>
 
 // Compatibility shims for building against BOTH the pinned stable DuckDB
 // (v1.5.x, what this extension ships against) and DuckDB main (the v2.0 line,
@@ -44,23 +46,42 @@ namespace duckdb {
 
 // --- bind-signature name type -------------------------------------------------
 // Used wherever a bind callback receives or fills a vector of column names.
-#ifdef DUCKDB_HAS_IDENTIFIER
-using CompatName = Identifier;
-inline string CompatNameStr(const Identifier &id) {
-	return id.GetIdentifierName();
-}
-inline Identifier CompatMakeName(string name) {
-	return Identifier(std::move(name));
-}
-#else
-using CompatName = string;
+//
+// DERIVED FROM DUCKDB'S OWN CONTAINER, NOT FROM A HEADER PROBE. The obvious
+// probe -- #ifdef DUCKDB_HAS_IDENTIFIER -- is a TIME BOMB, because the presence
+// of identifier.hpp and the type used in bind signatures are two different
+// facts that have already come apart upstream:
+//
+//   v1.5-variegata @ b155d6f63c (our pin)  no identifier.hpp   bind: vector<string>
+//   v1.5-variegata @ branch tip            HAS identifier.hpp  bind: vector<string>
+//   main (v2.0)                            HAS identifier.hpp  bind: vector<Identifier>
+//
+// identifier.hpp was BACKPORTED to the stable branch without changing
+// table_function_bind_t. So on the next submodule bump a header probe flips
+// CompatName to Identifier on a DuckDB that still wants strings, and every bind
+// signature in the extension stops compiling at once.
+//
+// TableFunctionBindInput::input_table_names has the same element type as the
+// bind out-parameter on both lines (verified: table_function.hpp:110/288 on the
+// pin, :123/319 on main), so asking it what the name type is cannot drift --
+// it IS the thing that changed.
+using CompatName = typename std::remove_reference<decltype(
+    std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
+
 inline string CompatNameStr(const string &name) {
 	return name;
 }
-inline string CompatMakeName(string name) {
-	return name;
+#ifdef DUCKDB_HAS_IDENTIFIER
+// Only declares the Identifier overload; it does NOT decide CompatName. Both
+// overloads coexist happily when CompatName is still string.
+inline string CompatNameStr(const Identifier &id) {
+	return id.GetIdentifierName();
 }
 #endif
+
+inline CompatName CompatMakeName(string name) {
+	return CompatName(std::move(name));
+}
 
 // --- LogicalType alias ---------------------------------------------------------
 // v1.5: void SetAlias(string)      -- mutates in place
@@ -163,38 +184,6 @@ inline VALUE *CompatFlatDataMutable(Vector &vec) {
 	return CompatFlatDataMutableImpl<VALUE, FV>(vec, CompatHasFlatGetDataMutable<FV>());
 }
 
-// --- scalar function fallibility ------------------------------------------------
-// v2.0 added a RUNTIME contract: a scalar function that can throw during
-// execution must declare it. Throwing from a function that has not is an
-// InternalException:
-//
-//   INTERNAL Error: Scalar function "f" threw an execution error, but the
-//   function is not marked as fallible - the function must call SetFallible().
-//
-// This is NOT a compile error and no grep finds it -- the only symptom is a test
-// that exercises an error path, and only on a build with assertions enabled, so
-// one CI arch can be green while another is red on the very same commit.
-//
-// No-op on v1.5, where the member does not exist. Must be called BEFORE the
-// function goes into a FunctionSet, since set members are no longer mutable
-// (see the FunctionSet<T>::functions change).
-template <class T, class = void>
-struct CompatHasSetFallible : std::false_type {};
-template <class T>
-struct CompatHasSetFallible<T, decltype(void(std::declval<T &>().SetFallible()))> : std::true_type {};
-
-template <class FUNC>
-inline void CompatSetFallibleImpl(FUNC &fun, std::true_type) {
-	fun.SetFallible();
-}
-template <class FUNC>
-inline void CompatSetFallibleImpl(FUNC &, std::false_type) {
-}
-template <class FUNC>
-inline void CompatSetFallible(FUNC &fun) {
-	CompatSetFallibleImpl(fun, CompatHasSetFallible<FUNC>());
-}
-
 // --- FlatVector validity mask -----------------------------------------------
 // v1.5: Validity(Vector &)              returns ValidityMask &
 // v2.0: Validity(const Vector &)        returns const ValidityMask &
@@ -214,8 +203,8 @@ inline void CompatSetFallible(FUNC &fun) {
 template <class T, class = void>
 struct CompatHasFlatValidityMutable : std::false_type {};
 template <class T>
-struct CompatHasFlatValidityMutable<T, decltype(void(T::ValidityMutable(std::declval<Vector &>())))>
-    : std::true_type {};
+struct CompatHasFlatValidityMutable<T, decltype(void(T::ValidityMutable(std::declval<Vector &>())))> : std::true_type {
+};
 
 template <class FV>
 inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::true_type) {

--- a/src/include/markdown_copy.hpp
+++ b/src/include/markdown_copy.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/common/file_system.hpp"
 #include <string>
@@ -98,7 +99,7 @@ public:
 
 	//! Bind function - parse options and set up schema info
 	static unique_ptr<FunctionData> Bind(ClientContext &context, CopyFunctionBindInput &input,
-	                                     const vector<string> &names, const vector<LogicalType> &sql_types);
+	                                     const vector<CompatName> &names, const vector<LogicalType> &sql_types);
 
 	//! Initialize global state - open file for writing
 	static unique_ptr<GlobalFunctionData> InitializeGlobal(ClientContext &context, FunctionData &bind_data,

--- a/src/include/markdown_extraction_functions.hpp
+++ b/src/include/markdown_extraction_functions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/function/table_function.hpp"
 
 namespace duckdb {
@@ -38,28 +39,28 @@ private:
 
 	// Code blocks extraction
 	static unique_ptr<FunctionData> CodeBlocksBind(ClientContext &context, TableFunctionBindInput &input,
-	                                               vector<LogicalType> &return_types, vector<string> &names);
+	                                               vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<LocalTableFunctionState> CodeBlocksInit(ExecutionContext &context, TableFunctionInitInput &input,
 	                                                          GlobalTableFunctionState *global_state);
 	static void CodeBlocksFunction(ClientContext &context, TableFunctionInput &input, DataChunk &output);
 
 	// Links extraction
 	static unique_ptr<FunctionData> LinksBind(ClientContext &context, TableFunctionBindInput &input,
-	                                          vector<LogicalType> &return_types, vector<string> &names);
+	                                          vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<LocalTableFunctionState> LinksInit(ExecutionContext &context, TableFunctionInitInput &input,
 	                                                     GlobalTableFunctionState *global_state);
 	static void LinksFunction(ClientContext &context, TableFunctionInput &input, DataChunk &output);
 
 	// Images extraction
 	static unique_ptr<FunctionData> ImagesBind(ClientContext &context, TableFunctionBindInput &input,
-	                                           vector<LogicalType> &return_types, vector<string> &names);
+	                                           vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<LocalTableFunctionState> ImagesInit(ExecutionContext &context, TableFunctionInitInput &input,
 	                                                      GlobalTableFunctionState *global_state);
 	static void ImagesFunction(ClientContext &context, TableFunctionInput &input, DataChunk &output);
 
 	// Headings extraction
 	static unique_ptr<FunctionData> HeadingsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                             vector<LogicalType> &return_types, vector<string> &names);
+	                                             vector<LogicalType> &return_types, vector<CompatName> &names);
 	static unique_ptr<LocalTableFunctionState> HeadingsInit(ExecutionContext &context, TableFunctionInitInput &input,
 	                                                        GlobalTableFunctionState *global_state);
 	static void HeadingsFunction(ClientContext &context, TableFunctionInput &input, DataChunk &output);

--- a/src/include/markdown_reader.hpp
+++ b/src/include/markdown_reader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include "duckdb_compat.hpp"
 #include "duckdb.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/file_system.hpp"
@@ -103,7 +104,8 @@ private:
 	 * @return Function data for execution
 	 */
 	static unique_ptr<FunctionData> MarkdownReadDocumentsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                          vector<LogicalType> &return_types, vector<string> &names);
+	                                                          vector<LogicalType> &return_types,
+	                                                          vector<CompatName> &names);
 
 	/**
 	 * @brief Execution function for read_markdown
@@ -127,7 +129,8 @@ private:
 	 * @return Function data for execution
 	 */
 	static unique_ptr<FunctionData> MarkdownReadSectionsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                         vector<LogicalType> &return_types, vector<string> &names);
+	                                                         vector<LogicalType> &return_types,
+	                                                         vector<CompatName> &names);
 
 	/**
 	 * @brief Execution function for read_markdown_sections
@@ -151,7 +154,8 @@ private:
 	 * @return Function data for execution
 	 */
 	static unique_ptr<FunctionData> MarkdownReadBlocksBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                       vector<LogicalType> &return_types, vector<string> &names);
+	                                                       vector<LogicalType> &return_types,
+	                                                       vector<CompatName> &names);
 
 	/**
 	 * @brief Execution function for read_markdown_blocks

--- a/src/markdown_copy.cpp
+++ b/src/markdown_copy.cpp
@@ -126,7 +126,7 @@ unique_ptr<FunctionData> MarkdownCopyFunction::Bind(ClientContext &context, Copy
 
 	// Parse options
 	for (auto &option : options) {
-		auto loption = StringUtil::Lower(option.first);
+		auto loption = StringUtil::Lower(CompatNameStr(option.first));
 		auto &value = option.second;
 
 		if (loption == "markdown_mode") {
@@ -182,7 +182,7 @@ unique_ptr<FunctionData> MarkdownCopyFunction::Bind(ClientContext &context, Copy
 	// For document mode, resolve column indices
 	if (result->markdown_mode == WriteMarkdownBindData::MarkdownMode::DOCUMENT) {
 		for (idx_t i = 0; i < names.size(); i++) {
-			auto lower_name = StringUtil::Lower(names[i]);
+			auto lower_name = StringUtil::Lower(CompatNameStr(names[i]));
 			if (lower_name == StringUtil::Lower(result->level_column)) {
 				result->level_col_idx = i;
 			} else if (lower_name == StringUtil::Lower(result->title_column)) {
@@ -205,7 +205,7 @@ unique_ptr<FunctionData> MarkdownCopyFunction::Bind(ClientContext &context, Copy
 	// For blocks mode, resolve column indices (uses duck_block naming)
 	if (result->markdown_mode == WriteMarkdownBindData::MarkdownMode::BLOCKS) {
 		for (idx_t i = 0; i < names.size(); i++) {
-			auto lower_name = StringUtil::Lower(names[i]);
+			auto lower_name = StringUtil::Lower(CompatNameStr(names[i]));
 			if (lower_name == StringUtil::Lower(result->kind_column)) {
 				result->kind_col_idx = i;
 			} else if (lower_name == StringUtil::Lower(result->element_type_column)) {

--- a/src/markdown_copy.cpp
+++ b/src/markdown_copy.cpp
@@ -1,4 +1,5 @@
 #include "markdown_copy.hpp"
+#include "duckdb_compat.hpp"
 #include "duck_block_vocabulary.hpp"
 #include "duck_block_functions.hpp"
 #include "markdown_types.hpp"
@@ -108,12 +109,19 @@ void MarkdownCopyFunction::CopyOptions(ClientContext &context, CopyOptionsInput 
 //===--------------------------------------------------------------------===//
 
 unique_ptr<FunctionData> MarkdownCopyFunction::Bind(ClientContext &context, CopyFunctionBindInput &input,
-                                                    const vector<string> &names, const vector<LogicalType> &sql_types) {
+                                                    const vector<CompatName> &names,
+                                                    const vector<LogicalType> &sql_types) {
 	auto result = make_uniq<WriteMarkdownBindData>();
 	auto &options = input.info.options;
 
-	// Store schema info
-	result->column_names = names;
+	// Store schema info. Converted element-wise rather than assigned: on DuckDB
+	// v2.0 `names` is a vector<Identifier>, and Identifier does not implicitly
+	// convert to string -- deliberately, because it carries case-insensitive
+	// comparison semantics that a silent conversion would discard.
+	result->column_names.reserve(names.size());
+	for (auto &name : names) {
+		result->column_names.push_back(CompatNameStr(name));
+	}
 	result->column_types = sql_types;
 
 	// Parse options

--- a/src/markdown_reader_files.cpp
+++ b/src/markdown_reader_files.cpp
@@ -1,4 +1,5 @@
 #include "markdown_reader.hpp"
+#include "duckdb_compat.hpp"
 #include "markdown_copy.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -302,7 +303,7 @@ unique_ptr<TableRef> MarkdownReader::ReadMarkdownReplacement(ClientContext &cont
 
 		// Set alias for non-glob patterns
 		if (!is_glob_pattern) {
-			result->alias = fs.ExtractBaseName(table_name);
+			result->alias = CompatMakeName(fs.ExtractBaseName(table_name));
 		}
 
 		return std::move(result);

--- a/src/markdown_reader_functions.cpp
+++ b/src/markdown_reader_functions.cpp
@@ -1,4 +1,5 @@
 #include "markdown_reader.hpp"
+#include "duckdb_compat.hpp"
 #include "markdown_types.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/exception.hpp"
@@ -210,7 +211,7 @@ static void ParseMarkdownOptions(TableFunctionBindInput &input, MarkdownReader::
 unique_ptr<FunctionData> MarkdownReader::MarkdownReadDocumentsBind(ClientContext &context,
                                                                    TableFunctionBindInput &input,
                                                                    vector<LogicalType> &return_types,
-                                                                   vector<string> &names) {
+                                                                   vector<CompatName> &names) {
 	auto result = make_uniq<MarkdownReadDocumentBindData>();
 
 	// Parse the file path parameter
@@ -385,7 +386,7 @@ static bool SectionMatchesFilter(const string &section_id, const string &section
 
 unique_ptr<FunctionData> MarkdownReader::MarkdownReadSectionsBind(ClientContext &context, TableFunctionBindInput &input,
                                                                   vector<LogicalType> &return_types,
-                                                                  vector<string> &names) {
+                                                                  vector<CompatName> &names) {
 	auto result = make_uniq<MarkdownReadSectionBindData>();
 
 	// Parse the file path parameter
@@ -589,7 +590,7 @@ void MarkdownReader::MarkdownReadSectionsFunction(ClientContext &context, TableF
 
 unique_ptr<FunctionData> MarkdownReader::MarkdownReadBlocksBind(ClientContext &context, TableFunctionBindInput &input,
                                                                 vector<LogicalType> &return_types,
-                                                                vector<string> &names) {
+                                                                vector<CompatName> &names) {
 	auto result = make_uniq<MarkdownReadBlocksBindData>();
 
 	// Parse the file path parameter

--- a/src/markdown_scalar_functions.cpp
+++ b/src/markdown_scalar_functions.cpp
@@ -92,10 +92,22 @@ void MarkdownFunctions::RegisterConversionFunctions(ExtensionLoader &loader) {
 
 	// Both convert through a third-party renderer and rethrow its failures as
 	// InvalidInputException. v2.0 requires a scalar function that can throw at
-	// execution time to say so, or the throw becomes an InternalException
-	// complaining the function is not marked fallible. No-op on v1.5.
-	CompatSetFallible(md_to_html_fun);
-	CompatSetFallible(md_to_text_fun);
+	// execution time to declare it, or the throw becomes an InternalException
+	// complaining the function is not marked fallible.
+	//
+	// Called directly, NOT through a compat shim: SetFallible() is identical on
+	// v1.5 (function.hpp:211) and on main, so a probe would take the same branch
+	// on both -- feature detection that detects nothing.
+	//
+	// It is NOT inert on v1.5 either. `errors` feeds BoundFunctionExpression::
+	// CanThrow(), which gates conjunct reordering (expression_heuristics,
+	// adaptive_filter), filter pushdown (pushdown_get/_projection/_outer_join)
+	// and dictionary-expression caching (execute_function.cpp). Declaring it
+	// makes the shipped planner strictly more conservative around these two
+	// functions -- safe in direction, but a real change, and measured rather
+	// than assumed (see test/sql/markdown_fallible_planner.test).
+	md_to_html_fun.SetFallible();
+	md_to_text_fun.SetFallible();
 
 	loader.RegisterFunction(md_to_html_fun);
 	loader.RegisterFunction(md_to_text_fun);

--- a/src/markdown_scalar_functions.cpp
+++ b/src/markdown_scalar_functions.cpp
@@ -90,6 +90,13 @@ void MarkdownFunctions::RegisterConversionFunctions(ExtensionLoader &loader) {
 		        });
 	    });
 
+	// Both convert through a third-party renderer and rethrow its failures as
+	// InvalidInputException. v2.0 requires a scalar function that can throw at
+	// execution time to say so, or the throw becomes an InternalException
+	// complaining the function is not marked fallible. No-op on v1.5.
+	CompatSetFallible(md_to_html_fun);
+	CompatSetFallible(md_to_text_fun);
+
 	loader.RegisterFunction(md_to_html_fun);
 	loader.RegisterFunction(md_to_text_fun);
 }

--- a/src/markdown_scalar_functions.cpp
+++ b/src/markdown_scalar_functions.cpp
@@ -23,30 +23,27 @@ void MarkdownFunctions::RegisterValidationFunction(ExtensionLoader &loader) {
 	                            [](DataChunk &args, ExpressionState &state, Vector &result) {
 		                            auto &input_vector = args.data[0];
 
-		                            // Written as an explicit loop rather than through
-		                            // UnaryExecutor::ExecuteWithNulls, which DuckDB v2.0
-		                            // removed. The semantics being preserved are the
-		                            // reason it cannot be a plain Execute: md_valid maps
-		                            // a NULL input to FALSE, it does not propagate the
-		                            // null, and a plain Execute propagates.
-		                            UnifiedVectorFormat vdata;
-		                            CompatToUnifiedFormat(input_vector, args.size(), vdata);
-		                            const auto in = UnifiedVectorFormat::GetData<string_t>(vdata);
-
-		                            result.SetVectorType(VectorType::FLAT_VECTOR);
-		                            auto out = CompatFlatDataMutable<bool>(result);
-		                            for (idx_t i = 0; i < args.size(); i++) {
-			                            const auto idx = vdata.sel->get_index(i);
-			                            if (!vdata.validity.RowIsValid(idx)) {
-				                            out[i] = false;
-				                            continue;
-			                            }
-			                            try {
-				                            out[i] = !in[idx].GetString().empty();
-			                            } catch (...) {
-				                            out[i] = false;
-			                            }
-		                            }
+		                            // Was UnaryExecutor::ExecuteWithNulls, which DuckDB v2.0
+		                            // removed. A plain Execute is the exact equivalent here,
+		                            // not an approximation: ExecuteWithNulls copies the input
+		                            // validity into the result mask and then SKIPS the lambda
+		                            // for null rows, so the old lambda's `if (!RowIsValid)
+		                            // return false` branch was unreachable and a NULL input
+		                            // has always produced NULL. Execute propagates nulls the
+		                            // same way, so this preserves that exactly.
+		                            //
+		                            // Do not "simplify" this into a loop that writes false for
+		                            // null inputs -- that silently turns NULL into FALSE for
+		                            // non-constant inputs, which is the regression this
+		                            // comment exists to prevent.
+		                            UnaryExecutor::Execute<string_t, bool>(input_vector, result, args.size(),
+		                                                                   [](string_t md_str) {
+			                                                                   try {
+				                                                                   return !md_str.GetString().empty();
+			                                                                   } catch (...) {
+				                                                                   return false;
+			                                                                   }
+		                                                                   });
 	                            });
 
 	loader.RegisterFunction(md_valid_fun);

--- a/src/markdown_scalar_functions.cpp
+++ b/src/markdown_scalar_functions.cpp
@@ -1,4 +1,5 @@
 #include "markdown_scalar_functions.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "markdown_types.hpp"
 #include "markdown_utils.hpp"
@@ -22,21 +23,30 @@ void MarkdownFunctions::RegisterValidationFunction(ExtensionLoader &loader) {
 	                            [](DataChunk &args, ExpressionState &state, Vector &result) {
 		                            auto &input_vector = args.data[0];
 
-		                            UnaryExecutor::ExecuteWithNulls<string_t, bool>(
-		                                input_vector, result, args.size(),
-		                                [&](string_t md_str, ValidityMask &mask, idx_t idx) {
-			                                if (!mask.RowIsValid(idx)) {
-				                                return false;
-			                                }
+		                            // Written as an explicit loop rather than through
+		                            // UnaryExecutor::ExecuteWithNulls, which DuckDB v2.0
+		                            // removed. The semantics being preserved are the
+		                            // reason it cannot be a plain Execute: md_valid maps
+		                            // a NULL input to FALSE, it does not propagate the
+		                            // null, and a plain Execute propagates.
+		                            UnifiedVectorFormat vdata;
+		                            CompatToUnifiedFormat(input_vector, args.size(), vdata);
+		                            const auto in = UnifiedVectorFormat::GetData<string_t>(vdata);
 
-			                                try {
-				                                // Basic validation - check for basic Markdown structure
-				                                const std::string content = md_str.GetString();
-				                                return !content.empty();
-			                                } catch (...) {
-				                                return false;
-			                                }
-		                                });
+		                            result.SetVectorType(VectorType::FLAT_VECTOR);
+		                            auto out = FlatVector::GetData<bool>(result);
+		                            for (idx_t i = 0; i < args.size(); i++) {
+			                            const auto idx = vdata.sel->get_index(i);
+			                            if (!vdata.validity.RowIsValid(idx)) {
+				                            out[i] = false;
+				                            continue;
+			                            }
+			                            try {
+				                            out[i] = !in[idx].GetString().empty();
+			                            } catch (...) {
+				                            out[i] = false;
+			                            }
+		                            }
 	                            });
 
 	loader.RegisterFunction(md_valid_fun);

--- a/src/markdown_scalar_functions.cpp
+++ b/src/markdown_scalar_functions.cpp
@@ -34,7 +34,7 @@ void MarkdownFunctions::RegisterValidationFunction(ExtensionLoader &loader) {
 		                            const auto in = UnifiedVectorFormat::GetData<string_t>(vdata);
 
 		                            result.SetVectorType(VectorType::FLAT_VECTOR);
-		                            auto out = FlatVector::GetData<bool>(result);
+		                            auto out = CompatFlatDataMutable<bool>(result);
 		                            for (idx_t i = 0; i < args.size(); i++) {
 			                            const auto idx = vdata.sel->get_index(i);
 			                            if (!vdata.validity.RowIsValid(idx)) {

--- a/src/markdown_types.cpp
+++ b/src/markdown_types.cpp
@@ -15,7 +15,7 @@ LogicalType MarkdownTypes::MarkdownType() {
 	// returns md). Both names still resolve, because each is registered as a type
 	// name separately -- the alias only decides what typeof() prints. Kept as `md`
 	// to preserve that observable behaviour; changing it is a separate decision.
-	return CompatWithAlias(LogicalType(LogicalTypeId::VARCHAR), "md");
+	return CompatWithAlias(LogicalType::VARCHAR, "md");
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/markdown_types.cpp
+++ b/src/markdown_types.cpp
@@ -1,4 +1,5 @@
 #include "markdown_types.hpp"
+#include "duckdb_compat.hpp"
 #include "markdown_utils.hpp"
 #include "duck_block_functions.hpp"
 
@@ -9,10 +10,12 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 
 LogicalType MarkdownTypes::MarkdownType() {
-	auto markdown_type = LogicalType(LogicalTypeId::VARCHAR);
-	markdown_type.SetAlias("markdown");
-	markdown_type.SetAlias("md"); // Also support 'md'
-	return markdown_type;
+	// One alias per type: the second call REPLACED the first, so this type's alias
+	// has always been "md" rather than "markdown" (verified: typeof('x'::markdown)
+	// returns md). Both names still resolve, because each is registered as a type
+	// name separately -- the alias only decides what typeof() prints. Kept as `md`
+	// to preserve that observable behaviour; changing it is a separate decision.
+	return CompatWithAlias(LogicalType(LogicalTypeId::VARCHAR), "md");
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/sql/_diag_named_error.test
+++ b/test/sql/_diag_named_error.test
@@ -1,0 +1,15 @@
+# name: test/sql/_diag_named_error.test
+# description: DIAGNOSTIC — does `exact := true` raise a binder error on v2.0?
+# group: [sql]
+
+require markdown
+
+statement ok
+CREATE TEMPORARY MACRO doc() AS (E'# T\n[a](http://a)\n');
+
+# Passing here means v2.0 REJECTS the named form outright. The expected text is
+# deliberately broad: any binder error satisfies it.
+statement error
+SELECT (md_stats(doc(), exact := true)).link_count;
+----
+Error

--- a/test/sql/_diag_named_value.test
+++ b/test/sql/_diag_named_value.test
@@ -1,0 +1,16 @@
+# name: test/sql/_diag_named_value.test
+# description: DIAGNOSTIC — does `exact := true` bind to the 1-arg overload on v2.0?
+# group: [sql]
+
+require markdown
+
+statement ok
+CREATE TEMPORARY MACRO doc() AS (E'# Title\nInline [a](http://a) and image ![i](http://i.png).\nRef [b][ref] and auto <http://c>.\nCode span `[x](http://x)`.\n\n```md\n[y](http://y)\n[z](http://z)\n```\n\n[ref]: http://b\n');
+
+# If v2.0 drops the label and binds the 1-arg overload, link_count is the
+# SCANNER value 5 rather than the cmark value 3. Passing here means "silently
+# bound the wrong overload"; failing means it did something else.
+query I
+SELECT (md_stats(doc(), exact := true)).link_count = 5;
+----
+true


### PR DESCRIPTION
## Why

`duckdb/community-extensions` builds every release PR against `duckdb_version: 'v2.0-cyanoptera'` (`build_next.yml`), triggered on exactly the `description.yml` change a release PR makes. I verified the trigger and the version string against the live workflow. There is no per-extension opt-out, and it runs **build and tests**. An extension that does not build and pass against v2.0 cannot cut a release.

This is **source compatibility, not a migration**. The extension still ships against the pinned v1.5.x; the goal is one source tree that compiles under both.

## What changed

`src/include/duckdb_compat.hpp` — shims that **probe for features rather than test version numbers**. A version macro says *when* something changed; a probe says whether it changed *here*, which keeps working if a change is backported, reverted, or lands on an unexpected branch. Each change is probed separately, so two of them landing in different releases cannot make one pick the wrong branch.

| change | shim |
|---|---|
| `LogicalType::SetAlias` (removed outright) → `WithAlias` (returns a copy) | `CompatWithAlias` |
| `vector<string>` → `vector<Identifier>` in bind signatures | `CompatName` / `CompatNameStr` / `CompatMakeName` |
| `Vector::ToUnifiedFormat` lost its count parameter | `CompatToUnifiedFormat` |
| `FlatVector::GetData<T>` became read-only | `CompatFlatDataMutable` |
| `UnaryExecutor::ExecuteWithNulls` removed | no shim — a plain `Execute` is the exact equivalent |

`Identifier`'s conversions are asymmetric on purpose — implicit from `const char *`, explicit from `string` — so `names.emplace_back("file_path")` compiles unchanged on both and only the signatures had to move. No implicit conversion was added; the explicitness is the upstream change's point.

The shims dispatch on a **tag rather than `if constexpr`**, so this header also compiles at C++11. Several extensions in this ecosystem build their TUs at C++11 deliberately (forcing C++17 on the extension but not on libduckdb gives static-const members in duckdb's headers implicit inline linkage in one set of TUs and not the other, producing multiple-definition link errors). markdown itself is C++17, but this header is the reference the rest of the fleet copies.

## Three bugs found in this branch, and fixed

Both are worth reading, because both looked obviously correct.

### The port turned `md_valid(NULL)` into `FALSE`

`ExecuteWithNulls` was replaced with a hand-rolled loop that wrote `false` for null input rows, on the reasoning that `md_valid` maps NULL to FALSE rather than propagating. That reasoning was backwards. `ExecuteWithNulls` copies the input validity into the result mask and then **skips the lambda entirely for null rows**, so the old lambda's `if (!mask.RowIsValid(idx)) return false;` branch was unreachable and a NULL input had **always** produced NULL.

Measured against the pinned v1.5, rebuilding only that file:

```
SELECT v, md_valid(v) FROM (VALUES ('x'), (NULL), ('')) t(v);

pre-port    x -> true   NULL -> NULL    '' -> false
first try   x -> true   NULL -> FALSE   '' -> false     <- regression
fixed       x -> true   NULL -> NULL    '' -> false
```

`SELECT md_valid(NULL)` returns NULL in all three, because constant folding propagates the null above the function — which is exactly why testing the constant made the bug invisible. The fix is a plain `UnaryExecutor::Execute`: it propagates nulls the same way, exists in both versions, and needs no shim at all.

### The `ToUnifiedFormat` probe tested the wrong overload

It probed for `ToUnifiedFormat(count, data)` — the overload being *replaced*. But v2.0 kept that one as `[[deprecated]]` rather than deleting it, so the probe was true on **both** versions and the shim always took the old branch, never once reaching the API it existed for. It compiled and behaved correctly everywhere, which is why nothing caught it.

Verified against both headers rather than inferred: v1.5 has only the count form; v2.0 has both, with the count form deprecated. Probing for the count-free overload is what actually discriminates. Generalised in the guide as a rule — **probe for the API that exists only on the new line, never for the one being replaced.**

### `CompatWithAlias` hard-errored on the *pinned* build

The entry point was `template <class TYPE = LogicalType>`. The default template argument is inert because deduction wins, so `CompatWithAlias(LogicalType::VARCHAR, "md")` deduced `TYPE = LogicalTypeId` — `LogicalType::VARCHAR` is a `static constexpr LogicalTypeId` (`types.hpp:414`), not a `LogicalType` — and failed inside the shim.

This repo never hit it because its one call site wrote the long form `LogicalType(LogicalTypeId::VARCHAR)`, which is exactly why it survived review. The entry point is now concrete, and **the call site was changed to the short form so the path stays exercised on every build**.

## The amd64 test failure: diagnosed, and it was never this port

Earlier revisions of this PR listed an unexplained `linux_amd64` test failure. It now has a cause, and it is a **new v2.0 runtime contract** rather than anything source-compatibility related.

v2.0 requires a scalar function that can throw at execution time to declare it. Throwing from one that has not becomes:

```
INTERNAL Error: Scalar function "f" threw an execution error, but the
function is not marked as fallible - the function must call SetFallible().
```

There is no compile error and nothing to grep for in the DuckDB API. Enforcement is an assertion, so the contract is violated on **both** architectures and only the assertion-enabled `linux_amd64` image reports it — which is precisely why the same commit is green on arm64 and red on amd64, and why the failing test always exercises an error path.

Confirmed on two other extensions, one of which is decisive: **duck_hunt fails the same way with no compat work on it at all**, still on its plain default branch. You do not have to port anything to violate a contract that is new.

This PR declares markdown's two throwing scalar functions (`md_to_html`, `md_to_text`) fallible through a probed `CompatSetFallible` that no-ops on v1.5. The signature was read from main rather than guessed — `BaseScalarFunction::SetFallible()` takes no arguments (`scalar_function.hpp:249`).

## Verification

- Full suite green against the pinned v1.5: **1800 assertions, 49 test cases**.
- Canary against DuckDB `main`, [run 33830833664](https://github.com/teaguesterling/duckdb_markdown/actions/runs/33830833664): **`linux_arm64` green end to end (Build + Test)**; `linux_amd64` Build success, Test failure. A fresh canary covering the `SetFallible` fix is in flight; **this PR should not be merged on the strength of the older run.**
- The failing test passes locally on amd64 against the pinned v1.5, confirming it is v2.0-specific rather than pre-existing.

## Also

`docs/duckdb_v2_migration.md` writes up the procedure for the rest of the ecosystem, substantially revised from findings across twelve concurrent ports — it went from 3 change classes to 14. Beyond the changes above it now covers: `FunctionSet<T>::functions` yielding `shared_ptr<const T>`; public fields of `ScalarFunction`/`Expression` becoming accessors (the class no grep finds); **`FunctionProperties::capture_argument_aliases` now defaulting to false, which silently breaks named-argument binding at runtime with a green build**; `StructVector::GetEntries` changing element type; which APIs are merely `[[deprecated]]` rather than removed; which repo's header to start from; and the CI-reading traps — a green *build* is not a green canary, per-step conclusions must be read on a *completed* run rather than the rollup, `gh run view --log-failed` prints nothing at all for reusable-workflow jobs, and `gh pr edit --body-file` can fail silently on these repos and leave the body unchanged.

Two classes deserve singling out because **no compiler and no grep will find them**: `capture_argument_aliases` (change 7) and `SetFallible` (change 13). Both break at runtime on a fully green build, and only a test that actually exercises the path — a named argument, or an error path — catches either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
