### PR TITLE
duck_block 6.4: emit and accept a trailing filename field

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,21 +107,21 @@ Reads Markdown files and returns one row per file.
 
 **Parameters:**
 - `files` (required) - File path, glob pattern, directory, or list of mixed patterns
-- `include_filepath := false` - Include file_path column in output (alias: `filename`)
+- `filename := false` - Append a trailing `filename` column naming the source file (deprecated alias: `include_filepath`). Boolean only: the string form that renames the column is deliberately not accepted, because a renamed column produces a struct no duck_block consumer accepts.
 - `content_as_varchar := false` - Return content as VARCHAR instead of MARKDOWN type
 - `maximum_file_size := 16777216` - Maximum file size in bytes (16MB default)
 - `extract_metadata := true` - Extract frontmatter into the `metadata` column. This uses the same **line-split key/value** reader as [`md_extract_metadata`](#content-extraction-functions) — each line split on the first `:` (or the first `=` inside a `+++` TOML block), typed as `MAP(VARCHAR, VARCHAR)` — **not** a full YAML parser (nested maps, lists, and multiline `|`/`>` scalars are not interpreted). For real YAML, use the `yaml` extension's `read_yaml_frontmatter` — see [Frontmatter Handling](#frontmatter-handling).
 - `normalize_content := true` - Normalize Markdown content
 - `extract_extensions := NULL` - Opt-in add-on extractors (comma-separated VARCHAR; see [Optional Add-On Extractors](#optional-add-on-extractors-extract_extensions)). When set, adds `wikilinks` and/or `tags` `LIST<STRUCT>` columns to the output
 
-**Returns:** `(content MARKDOWN, metadata MAP(VARCHAR, VARCHAR))` or `(file_path VARCHAR, content MARKDOWN, metadata MAP(VARCHAR, VARCHAR))` with `include_filepath := true`. With `extract_extensions`, the requested add-on columns are appended.
+**Returns:** `(content MARKDOWN, metadata MAP(VARCHAR, VARCHAR))` or `(content MARKDOWN, metadata MAP(VARCHAR, VARCHAR), filename VARCHAR)` with `filename := true` -- provenance is appended, never prepended. With `extract_extensions`, the requested add-on columns are appended.
 
 #### `read_markdown_blocks(files, [parameters...])`
 Reads Markdown files and parses them into block-level elements (headings, paragraphs, code blocks, lists, tables, etc.).
 
 **Parameters:**
 - `files` (required) - File path, glob pattern, or list of patterns
-- `include_filepath := false` - Include file_path column in output (alias: `filename`)
+- `filename := false` - Append a trailing `filename` column naming the source file (deprecated alias: `include_filepath`). Boolean only: the string form that renames the column is deliberately not accepted, because a renamed column produces a struct no duck_block consumer accepts.
 - `extract_extensions := NULL` - Opt-in add-on extractors (see [Optional Add-On Extractors](#optional-add-on-extractors-extract_extensions)). When set, adds per-block `wikilinks` and/or `tags` columns extracted from each block's content.
 
 **Returns:** `(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER, encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER)`. `level` is structural **depth**, minimum 1 — a heading's rank is `attributes['heading_level']`, not `level`. A heading carries both a flattened plain-text title in `content` (what `section_id` and the sections API read) and its formatted text as inline children, so `# **Bold** t` keeps its emphasis instead of collapsing to `# Bold t`. (`read_markdown_sections` has a `level` column too, but that one is heading rank, 0-6.) With `extract_extensions`, the requested add-on columns are appended.
@@ -166,7 +166,7 @@ Reads Markdown files and parses them into hierarchical sections.
 - `max_depth := 6` - Maximum depth relative to min_level (e.g., `max_depth := 2` with `min_level := 1` includes h1 and h2 only)
 - `max_content_length := 0` - Maximum content length for 'smart' mode (0 = auto, uses 2000 chars)
 - `include_empty_sections := false` - Include sections without content
-- `include_filepath := false` - Include file_path column in output (alias: `filename`)
+- `filename := false` - Append a trailing `filename` column naming the source file (deprecated alias: `include_filepath`). Boolean only: the string form that renames the column is deliberately not accepted, because a renamed column produces a struct no duck_block consumer accepts.
 - `extract_metadata := true` - Include frontmatter as a special section (level=0)
 - `extract_extensions := NULL` - Opt-in add-on extractors (see [Optional Add-On Extractors](#optional-add-on-extractors-extract_extensions)). When set, adds per-section `wikilinks` and/or `tags` columns extracted from each section's content.
 - Plus all `read_markdown` parameters
@@ -176,7 +176,7 @@ Reads Markdown files and parses them into hierarchical sections.
 - `'full'` - Content includes all subsections until next same-or-higher level heading. Use this for complete section extraction.
 - `'smart'` - Adaptive mode: includes small subsections fully, truncates large ones with references like `"... (see #subsection-id)"`.
 
-**Returns:** `(section_id VARCHAR, section_path VARCHAR, level INTEGER, title VARCHAR, content MARKDOWN, parent_id VARCHAR, start_line BIGINT, end_line BIGINT)` or with `include_filepath := true` adds `file_path VARCHAR` column.
+**Returns:** `(section_id VARCHAR, section_path VARCHAR, level INTEGER, title VARCHAR, content MARKDOWN, parent_id VARCHAR, start_line BIGINT, end_line BIGINT)` or with `filename := true` appends a trailing `filename VARCHAR` column.
 
 **Notes:**
 - When `extract_metadata := true`, the frontmatter block is included as a special section with `level=0`, `section_id='frontmatter'`, and the **raw, unparsed** text between the `---` (or `+++`) delimiters as the content. This `level` is heading **rank** (0 for frontmatter, 1-6 for headings) and is a different measurement from `read_markdown_blocks`' `level`, which is structural **depth** and is 1 for every top-level element including frontmatter. Nothing in this extension interprets that text as YAML — see [Frontmatter Handling](#frontmatter-handling).
@@ -326,7 +326,7 @@ The two extensions compose in both directions:
 -- markdown extension finds the documents and the body; yaml extension types the frontmatter
 SELECT y.title, y.tags, md_stats(m.content).word_count
 FROM read_yaml_frontmatter('posts/*.md', filename := true) y
-JOIN read_markdown('posts/*.md', include_filepath := true) m ON m.file_path = y.filename;
+JOIN read_markdown('posts/*.md', filename := true) m ON m.filename = y.filename;
 
 -- or hand a single raw block to the YAML parser yourself
 SELECT yaml(md_extract_frontmatter(content)) FROM read_markdown('posts/*.md');
@@ -696,7 +696,7 @@ A vault is just a folder of `.md` files. With `extract_extensions := 'obsidian'`
 ```sql
 -- Backlink edges across a vault: (source_file, target_note)
 WITH wl AS (
-  SELECT file_path AS source, unnest(wikilinks) AS w
+  SELECT filename AS source, unnest(wikilinks) AS w
   FROM read_markdown('vault/**/*.md', include_filepath := true, extract_extensions := 'wikilinks')
 )
 SELECT source, w.target AS target_note, w.is_embed, w.line_number
@@ -704,7 +704,7 @@ FROM wl;
 
 -- Orphan notes (no incoming wikilinks)
 WITH edges AS (
-  SELECT regexp_extract(file_path, '([^/]+)\.md$', 1) AS note,
+  SELECT regexp_extract(filename, '([^/]+)\.md$', 1) AS note,
          unnest(wikilinks).target AS target
   FROM read_markdown('vault/**/*.md', include_filepath := true, extract_extensions := 'wikilinks')
 )

--- a/docs/doc_block_spec.md
+++ b/docs/doc_block_spec.md
@@ -62,7 +62,7 @@ All compliant extensions MUST produce rows with these columns:
 Optional columns:
 | Column | Type | Description |
 |--------|------|-------------|
-| `file_path` | VARCHAR | Source file path (when reading multiple files) |
+| `filename` | VARCHAR | Source file path (when reading multiple files). Trailing field, after `element_order`. |
 
 ### Column Semantics
 

--- a/docs/doc_block_spec.md
+++ b/docs/doc_block_spec.md
@@ -359,3 +359,20 @@ The DuckDB Markdown extension (`duckdb_markdown`) serves as the reference implem
 - Reader: `read_markdown_blocks()`
 - Writer: `COPY TO ... (FORMAT MARKDOWN, markdown_mode 'blocks')`
 - Converters: `duck_block_to_md()`, `duck_blocks_to_md()`, `duck_blocks_to_sections()`
+
+#### Two things that surprise people writing blocks by hand
+
+**The converters emit trailing newlines.** A paragraph with content `hi` renders as `hi\n\n`, not `hi`. DuckDB's `trim()` strips spaces only, so `trim(duck_block_to_md(...)) = 'hi'` is false; use `rtrim(x, chr(10))`.
+
+**The widened 8-field shape needs its `attributes` child typed.** Acceptance of the optional trailing `filename` is keyed on an exact source type, so an untyped `MAP{}` -- which infers `MAP("NULL", "NULL")` -- is not that type, no registered cast matches, and the call is refused:
+
+```sql
+-- refused: MAP{} is MAP("NULL", "NULL")
+SELECT duck_block_to_md({..., element_order: 0, filename: 'a.md'});
+
+-- binds
+SELECT duck_block_to_md({..., attributes: MAP{}::MAP(VARCHAR, VARCHAR),
+                         element_order: 0, filename: 'a.md'});
+```
+
+The canonical 7-field shape does not go through a registered cast, so DuckDB's ordinary implicit struct cast coerces the MAP child and it binds either way. Blocks that come from a reader are already correctly typed; this only bites hand-written literals.

--- a/docs/duckdb_v2_migration.md
+++ b/docs/duckdb_v2_migration.md
@@ -246,7 +246,7 @@ Identifier(const char *str);       // IMPLICIT — literals are identifiers by i
 explicit Identifier(const string&); // EXPLICIT — promoting a runtime string is deliberate
 ```
 
-So `names.emplace_back("file_path")` compiles unchanged on both. **Only the
+So `names.emplace_back("filename")` compiles unchanged on both. **Only the
 signatures move**, plus the few places a *runtime* string crosses the boundary.
 
 Define the name type by **asking DuckDB for it**, not by probing a header (see

--- a/docs/markdown_doc_block.md
+++ b/docs/markdown_doc_block.md
@@ -85,7 +85,7 @@ STRUCT(
 ```sql
 read_markdown_blocks(
     path VARCHAR,                    -- File path or glob pattern
-    include_filepath := false,       -- Add file_path column (alias: filename)
+    filename := false,               -- Append trailing filename column (deprecated alias: include_filepath)
     include_raw_html := false        -- Include raw HTML blocks
 )
 ```
@@ -103,7 +103,7 @@ Returns rows with duck_block shape:
 | `encoding` | VARCHAR | `text`, `json` (tables), `yaml`/`toml` (frontmatter) |
 | `attributes` | MAP(VARCHAR, VARCHAR) | Block metadata (heading_level, language, id, etc.) |
 | `element_order` | INTEGER | Position in document (1-indexed) |
-| `file_path` | VARCHAR | Source file (when enabled) |
+| `filename` | VARCHAR | Source file (when enabled). Trailing: duck_block spec 6.4 puts it after `element_order`. |
 
 **Note on heading levels:** For headings, the actual H1-H6 level is stored in `attributes['heading_level']`, while `level` indicates document nesting depth (always 1 for top-level blocks). This matches the duck_block_utils convention.
 
@@ -125,9 +125,9 @@ FROM read_markdown_blocks('tutorial.md')
 WHERE element_type = 'code';
 
 -- Multi-file analysis
-SELECT file_path, element_type, count(*) as count
+SELECT filename, element_type, count(*) as count
 FROM read_markdown_blocks('docs/**/*.md', include_filepath := true)
-GROUP BY file_path, element_type;
+GROUP BY filename, element_type;
 ```
 
 ## Writer: COPY TO Blocks

--- a/src/markdown_reader_functions.cpp
+++ b/src/markdown_reader_functions.cpp
@@ -226,11 +226,6 @@ unique_ptr<FunctionData> MarkdownReader::MarkdownReadDocumentsBind(ClientContext
 	ParseMarkdownOptions(input, result->options);
 
 	// Define return columns
-	if (result->options.include_filepath) {
-		names.emplace_back("file_path");
-		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
-	}
-
 	names.emplace_back("content");
 	if (result->options.content_as_varchar) {
 		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
@@ -257,6 +252,17 @@ unique_ptr<FunctionData> MarkdownReader::MarkdownReadDocumentsBind(ClientContext
 		stats_struct.push_back(make_pair("reading_time_minutes", LogicalType(LogicalTypeId::DOUBLE)));
 
 		return_types.emplace_back(LogicalType::STRUCT(stats_struct));
+	}
+
+	// Provenance, trailing. duck_block spec 6.4 puts `filename` after the canonical
+	// fields and consumers accept the exact 8-field struct with it LAST, so a leading
+	// field would put the path at index 0 where index-based consumers expect `kind`.
+	// DuckDB core (read_csv/read_json/read_parquet) also names it `filename` and
+	// appends it. Only the boolean form is accepted: a renamed column produces a
+	// struct no duck_block consumer accepts.
+	if (result->options.include_filepath) {
+		names.emplace_back("filename");
+		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
 	}
 
 	// Optional add-on extractor columns (extract_extensions param)
@@ -292,12 +298,6 @@ void MarkdownReader::MarkdownReadDocumentsFunction(ClientContext &context, Table
 
 			idx_t column_idx = 0;
 
-			// Set file path if requested
-			if (bind_data.options.include_filepath) {
-				output.data[column_idx].SetValue(output_idx, Value(file_path));
-				column_idx++;
-			}
-
 			// Set content
 			output.data[column_idx].SetValue(output_idx, Value(content));
 			column_idx++;
@@ -325,6 +325,12 @@ void MarkdownReader::MarkdownReadDocumentsFunction(ClientContext &context, Table
 				    std::make_pair("reading_time_minutes", Value::DOUBLE(stats.reading_time_minutes)));
 
 				output.data[column_idx].SetValue(output_idx, Value::STRUCT(struct_values));
+				column_idx++;
+			}
+
+			// Provenance, trailing -- see the bind for why.
+			if (bind_data.options.include_filepath) {
+				output.data[column_idx].SetValue(output_idx, Value(file_path));
 				column_idx++;
 			}
 
@@ -477,11 +483,6 @@ unique_ptr<FunctionData> MarkdownReader::MarkdownReadSectionsBind(ClientContext 
 	}
 
 	// Define return columns for sections
-	if (result->options.include_filepath) {
-		names.emplace_back("file_path");
-		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
-	}
-
 	names.emplace_back("section_id");
 	return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
 
@@ -509,6 +510,17 @@ unique_ptr<FunctionData> MarkdownReader::MarkdownReadSectionsBind(ClientContext 
 
 	names.emplace_back("end_line");
 	return_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
+
+	// Provenance, trailing. duck_block spec 6.4 puts `filename` after the canonical
+	// fields and consumers accept the exact 8-field struct with it LAST, so a leading
+	// field would put the path at index 0 where index-based consumers expect `kind`.
+	// DuckDB core (read_csv/read_json/read_parquet) also names it `filename` and
+	// appends it. Only the boolean form is accepted: a renamed column produces a
+	// struct no duck_block consumer accepts.
+	if (result->options.include_filepath) {
+		names.emplace_back("filename");
+		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+	}
 
 	// Optional add-on extractor columns (per-section: extracted from section.content)
 	if (result->options.extract_wikilinks) {
@@ -544,12 +556,6 @@ void MarkdownReader::MarkdownReadSectionsFunction(ClientContext &context, TableF
 
 		idx_t column_idx = 0;
 
-		// Set file path if requested
-		if (bind_data.options.include_filepath) {
-			output.data[column_idx].SetValue(output_idx, Value(file_path));
-			column_idx++;
-		}
-
 		output.data[column_idx].SetValue(output_idx, Value(section.id));
 		column_idx++;
 		output.data[column_idx].SetValue(output_idx, Value(section.section_path));
@@ -566,6 +572,12 @@ void MarkdownReader::MarkdownReadSectionsFunction(ClientContext &context, TableF
 		column_idx++;
 		output.data[column_idx].SetValue(output_idx, Value::BIGINT(static_cast<int64_t>(section.end_line)));
 		column_idx++;
+
+		// Provenance, trailing -- see the bind for why.
+		if (bind_data.options.include_filepath) {
+			output.data[column_idx].SetValue(output_idx, Value(file_path));
+			column_idx++;
+		}
 
 		// Optional add-on extractor columns (extracted from this section's content)
 		if (bind_data.options.extract_wikilinks) {
@@ -622,11 +634,6 @@ unique_ptr<FunctionData> MarkdownReader::MarkdownReadBlocksBind(ClientContext &c
 
 	// Define return columns (flattened - one row per block)
 	// Uses duck_block shape: kind, element_type, content, level, encoding, attributes, element_order
-	if (result->options.include_filepath) {
-		names.emplace_back("file_path");
-		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
-	}
-
 	names.emplace_back("kind");
 	return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
 
@@ -648,6 +655,17 @@ unique_ptr<FunctionData> MarkdownReader::MarkdownReadBlocksBind(ClientContext &c
 
 	names.emplace_back("element_order");
 	return_types.emplace_back(LogicalType(LogicalTypeId::INTEGER));
+
+	// Provenance, trailing. duck_block spec 6.4 puts `filename` after the canonical
+	// fields and consumers accept the exact 8-field struct with it LAST, so a leading
+	// field would put the path at index 0 where index-based consumers expect `kind`.
+	// DuckDB core (read_csv/read_json/read_parquet) also names it `filename` and
+	// appends it. Only the boolean form is accepted: a renamed column produces a
+	// struct no duck_block consumer accepts.
+	if (result->options.include_filepath) {
+		names.emplace_back("filename");
+		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+	}
 
 	// Optional add-on extractor columns (per-block: extracted from block.content)
 	if (result->options.extract_wikilinks) {
@@ -676,12 +694,6 @@ void MarkdownReader::MarkdownReadBlocksFunction(ClientContext &context, TableFun
 		const auto &[file_path, block] = bind_data.all_blocks[bind_data.current_block_index];
 
 		idx_t column_idx = 0;
-
-		// Set file path if requested
-		if (bind_data.options.include_filepath) {
-			output.data[column_idx].SetValue(output_idx, Value(file_path));
-			column_idx++;
-		}
 
 		// kind ('block', or 'inline' for structured rich-text children)
 		output.data[column_idx].SetValue(output_idx, Value(block.kind));
@@ -719,6 +731,12 @@ void MarkdownReader::MarkdownReadBlocksFunction(ClientContext &context, TableFun
 		// element_order (was block_order)
 		output.data[column_idx].SetValue(output_idx, Value::INTEGER(block.block_order));
 		column_idx++;
+
+		// Provenance, trailing -- see the bind for why.
+		if (bind_data.options.include_filepath) {
+			output.data[column_idx].SetValue(output_idx, Value(file_path));
+			column_idx++;
+		}
 
 		// Optional add-on extractor columns (extracted from this block's content)
 		if (bind_data.options.extract_wikilinks) {

--- a/src/markdown_types.cpp
+++ b/src/markdown_types.cpp
@@ -2,6 +2,7 @@
 #include "duckdb_compat.hpp"
 #include "markdown_utils.hpp"
 #include "duck_block_functions.hpp"
+#include "duckdb/function/cast/default_casts.hpp"
 
 namespace duckdb {
 
@@ -118,6 +119,34 @@ static bool DuckBlockListToMarkdownCast(Vector &source, Vector &result, idx_t co
 }
 
 //===--------------------------------------------------------------------===//
+// duck_block 6.4: accepting the widened shape
+//===--------------------------------------------------------------------===//
+
+// The one accepted widened shape: duck_block plus a trailing `filename VARCHAR`,
+// exactly. Registration and shape supplied by duck_block_utils, who own the spec.
+//
+// The literal "filename" becomes Vocab FIELD_FILENAME once 6.4 is vendored here;
+// markdown's drift check still reports upstream 6.3, so the constant does not
+// exist locally yet.
+static LogicalType DuckBlockWithFilenameType() {
+	auto children = StructType::GetChildTypes(MarkdownTypes::DuckBlockType());
+	children.push_back(make_pair("filename", LogicalType::VARCHAR));
+	return LogicalType::STRUCT(std::move(children));
+}
+
+// Hands back DuckDB's own default cast for the pair, so the cast IS the standard
+// name-based struct cast: it matches children by name and skips a source child the
+// target lacks, which drops `filename`. Consumers do not widen to read it.
+//
+// The only thing refusing the implicit path is the child-count rule in
+// cast_rules.cpp, and the binder consults registered casts before that rule --
+// which is why registering it at all is what makes the shape bind.
+static BoundCastInfo BindDefaultDuckBlockCast(BindCastInput &input, const LogicalType &source,
+                                              const LogicalType &target) {
+	return DefaultCasts::GetDefaultCastFunction(input, source, target);
+}
+
+//===--------------------------------------------------------------------===//
 // Registration
 //===--------------------------------------------------------------------===//
 
@@ -142,6 +171,21 @@ void MarkdownTypes::Register(ExtensionLoader &loader) {
 	const auto duck_block_type = DuckBlockType();
 	const auto duck_block_list_type = LogicalType::LIST(duck_block_type);
 	loader.RegisterCastFunction(duck_block_list_type, markdown_type, DuckBlockListToMarkdownCast, 1);
+
+	// Accept the 6.4 widened shape wherever a duck_block is taken. Both registrations
+	// are needed and neither is reached through the other by the implicit-cost rule:
+	// the LIST one covers LIST(duck_block) parameters (duck_blocks_to_md,
+	// duck_blocks_to_sections), the struct one covers functions taking a bare block
+	// (duck_block_to_md).
+	//
+	// Cost 10: positive so it never beats an exact 7-field match, small so it beats
+	// any to-VARCHAR fallback. Checked before adopting it that nothing here is
+	// overloaded on its block argument -- each of the three takes exactly one
+	// signature -- which is the condition that makes a single cost safe.
+	const auto duck_block_with_filename = DuckBlockWithFilenameType();
+	loader.RegisterCastFunction(duck_block_with_filename, duck_block_type, BindDefaultDuckBlockCast, 10);
+	loader.RegisterCastFunction(LogicalType::LIST(duck_block_with_filename), duck_block_list_type,
+	                            BindDefaultDuckBlockCast, 10);
 }
 
 } // namespace duckdb

--- a/test/sql/docs_roundtrip.test
+++ b/test/sql/docs_roundtrip.test
@@ -12,7 +12,7 @@ require markdown
 statement ok
 CREATE TEMPORARY TABLE original_docs AS
 SELECT
-    replace(file_path, '\', '/') as file_path,
+    replace(filename, '\', '/') as filename,
     content as md_content
 FROM read_markdown('docs/*.md', filename := true);
 
@@ -22,11 +22,11 @@ SELECT count(*) >= 1 FROM original_docs;
 ----
 true
 
-# Create blocks from original docs (excluding file_path from block struct)
+# Create blocks from original docs (excluding filename from block struct)
 statement ok
 CREATE TEMPORARY TABLE doc_blocks AS
 SELECT
-    replace(file_path, '\', '/') as file_path,
+    replace(filename, '\', '/') as filename,
     list({
         kind: b.kind,
         element_type: b.element_type,
@@ -37,7 +37,7 @@ SELECT
         element_order: b.element_order
     } ORDER BY b.element_order) as blocks
 FROM read_markdown_blocks('docs/*.md', filename := true) b
-GROUP BY replace(file_path, '\', '/');
+GROUP BY replace(filename, '\', '/');
 
 # Verify blocks were created for all docs (same count as original_docs)
 query I
@@ -58,7 +58,7 @@ true
 statement ok
 CREATE TEMPORARY TABLE regenerated_docs AS
 SELECT
-    file_path,
+    filename,
     duck_blocks_to_md(blocks) as md_content
 FROM doc_blocks;
 
@@ -85,19 +85,19 @@ true
 # =============================================================================
 
 statement ok
-COPY (SELECT md_content::VARCHAR FROM regenerated_docs WHERE file_path = 'docs/doc_block_spec.md')
+COPY (SELECT md_content::VARCHAR FROM regenerated_docs WHERE filename = 'docs/doc_block_spec.md')
 TO '__TEST_DIR__/regen_doc_block_spec.md' (FORMAT CSV, HEADER false, QUOTE '');
 
 statement ok
-COPY (SELECT md_content::VARCHAR FROM regenerated_docs WHERE file_path = 'docs/ecosystem.md')
+COPY (SELECT md_content::VARCHAR FROM regenerated_docs WHERE filename = 'docs/ecosystem.md')
 TO '__TEST_DIR__/regen_ecosystem.md' (FORMAT CSV, HEADER false, QUOTE '');
 
 statement ok
-COPY (SELECT md_content::VARCHAR FROM regenerated_docs WHERE file_path = 'docs/index.md')
+COPY (SELECT md_content::VARCHAR FROM regenerated_docs WHERE filename = 'docs/index.md')
 TO '__TEST_DIR__/regen_index.md' (FORMAT CSV, HEADER false, QUOTE '');
 
 statement ok
-COPY (SELECT md_content::VARCHAR FROM regenerated_docs WHERE file_path = 'docs/markdown_doc_block.md')
+COPY (SELECT md_content::VARCHAR FROM regenerated_docs WHERE filename = 'docs/markdown_doc_block.md')
 TO '__TEST_DIR__/regen_markdown_doc_block.md' (FORMAT CSV, HEADER false, QUOTE '');
 
 # =============================================================================
@@ -107,7 +107,7 @@ TO '__TEST_DIR__/regen_markdown_doc_block.md' (FORMAT CSV, HEADER false, QUOTE '
 # Create section comparison tables
 statement ok
 CREATE TEMPORARY TABLE original_sections AS
-SELECT 'docs/doc_block_spec.md' as file_path, section_id, title, level
+SELECT 'docs/doc_block_spec.md' as filename, section_id, title, level
 FROM read_markdown_sections('docs/doc_block_spec.md')
 UNION ALL
 SELECT 'docs/ecosystem.md', section_id, title, level
@@ -121,7 +121,7 @@ FROM read_markdown_sections('docs/markdown_doc_block.md');
 
 statement ok
 CREATE TEMPORARY TABLE regen_sections AS
-SELECT 'docs/doc_block_spec.md' as file_path, section_id, title, level
+SELECT 'docs/doc_block_spec.md' as filename, section_id, title, level
 FROM read_markdown_sections('__TEST_DIR__/regen_doc_block_spec.md')
 UNION ALL
 SELECT 'docs/ecosystem.md', section_id, title, level
@@ -145,12 +145,12 @@ SELECT count(*) >= 10 FROM original_sections;
 ----
 true
 
-# All sections should match by file_path, section_id, title, and level
+# All sections should match by filename, section_id, title, and level
 query I
 SELECT count(*) = 0
 FROM original_sections o
 FULL OUTER JOIN regen_sections r
-    ON o.file_path = r.file_path
+    ON o.filename = r.filename
     AND o.section_id = r.section_id
 WHERE o.section_id IS NULL OR r.section_id IS NULL;
 ----
@@ -161,7 +161,7 @@ query I
 SELECT count(*) = 0
 FROM original_sections o
 JOIN regen_sections r
-    ON o.file_path = r.file_path
+    ON o.filename = r.filename
     AND o.section_id = r.section_id
 WHERE o.title != r.title;
 ----
@@ -172,7 +172,7 @@ query I
 SELECT count(*) = 0
 FROM original_sections o
 JOIN regen_sections r
-    ON o.file_path = r.file_path
+    ON o.filename = r.filename
     AND o.section_id = r.section_id
 WHERE o.level != r.level;
 ----
@@ -186,12 +186,12 @@ true
 statement ok
 CREATE TEMPORARY TABLE original_headings AS
 SELECT
-    replace(file_path, '\', '/') as file_path,
+    replace(filename, '\', '/') as filename,
     content,
     attributes['heading_level'] as heading_level
 FROM read_markdown_blocks('docs/*.md', filename := true)
 WHERE element_type = 'heading'
-  AND replace(file_path, '\', '/') IN (
+  AND replace(filename, '\', '/') IN (
       'docs/doc_block_spec.md',
       'docs/ecosystem.md',
       'docs/index.md',
@@ -202,7 +202,7 @@ WHERE element_type = 'heading'
 statement ok
 CREATE TEMPORARY TABLE regen_headings AS
 SELECT
-    'docs/doc_block_spec.md' as file_path,
+    'docs/doc_block_spec.md' as filename,
     content,
     attributes['heading_level'] as heading_level
 FROM read_markdown_blocks('__TEST_DIR__/regen_doc_block_spec.md')
@@ -231,7 +231,7 @@ query I
 SELECT count(*) = 0
 FROM original_headings o
 JOIN regen_headings r
-    ON o.file_path = r.file_path
+    ON o.filename = r.filename
     AND o.content = r.content
 WHERE o.heading_level != r.heading_level;
 ----
@@ -244,16 +244,16 @@ true
 statement ok
 CREATE TEMPORARY TABLE original_block_counts AS
 SELECT
-    replace(file_path, '\', '/') as file_path,
+    replace(filename, '\', '/') as filename,
     element_type,
     count(*) as cnt
 FROM read_markdown_blocks('docs/*.md', filename := true)
-GROUP BY replace(file_path, '\', '/'), element_type;
+GROUP BY replace(filename, '\', '/'), element_type;
 
 statement ok
 CREATE TEMPORARY TABLE regen_block_counts AS
 SELECT
-    'docs/doc_block_spec.md' as file_path,
+    'docs/doc_block_spec.md' as filename,
     element_type,
     count(*) as cnt
 FROM read_markdown_blocks('__TEST_DIR__/regen_doc_block_spec.md')
@@ -275,11 +275,11 @@ GROUP BY element_type;
 query I
 SELECT count(*) = 0
 FROM (
-    SELECT file_path, sum(cnt) as cnt FROM original_block_counts WHERE element_type = 'heading' GROUP BY file_path
+    SELECT filename, sum(cnt) as cnt FROM original_block_counts WHERE element_type = 'heading' GROUP BY filename
 ) o
 JOIN (
-    SELECT file_path, sum(cnt) as cnt FROM regen_block_counts WHERE element_type = 'heading' GROUP BY file_path
-) r ON o.file_path = r.file_path
+    SELECT filename, sum(cnt) as cnt FROM regen_block_counts WHERE element_type = 'heading' GROUP BY filename
+) r ON o.filename = r.filename
 WHERE o.cnt != r.cnt;
 ----
 true
@@ -288,11 +288,11 @@ true
 query I
 SELECT count(*) = 0
 FROM (
-    SELECT file_path, sum(cnt) as cnt FROM original_block_counts WHERE element_type = 'code' GROUP BY file_path
+    SELECT filename, sum(cnt) as cnt FROM original_block_counts WHERE element_type = 'code' GROUP BY filename
 ) o
 JOIN (
-    SELECT file_path, sum(cnt) as cnt FROM regen_block_counts WHERE element_type = 'code' GROUP BY file_path
-) r ON o.file_path = r.file_path
+    SELECT filename, sum(cnt) as cnt FROM regen_block_counts WHERE element_type = 'code' GROUP BY filename
+) r ON o.filename = r.filename
 WHERE o.cnt != r.cnt;
 ----
 true

--- a/test/sql/duck_block_filename_field.test
+++ b/test/sql/duck_block_filename_field.test
@@ -1,0 +1,109 @@
+# name: test/sql/duck_block_filename_field.test
+# description: duck_block 6.4 -- accepting the widened shape with a trailing filename
+# group: [sql]
+
+require markdown
+
+# The fleet ordering is acceptance everywhere BEFORE anything emits. markdown
+# emits the trailing `filename` (see markdown_blocks.test), so it must also
+# accept it wherever a duck_block is taken.
+#
+# Acceptance is via two registered implicit casts, cost 10. The cast is DuckDB's
+# own name-based struct cast, which matches children by name and skips a source
+# child the target lacks -- so `filename` is DROPPED and consumers do not widen
+# to read it. The registration is duck_block_utils'; markdown copies it rather
+# than approximating it.
+
+# ---------------------------------------------------------------------------
+# Positive: the widened shape binds wherever the canonical one does
+# ---------------------------------------------------------------------------
+
+# LIST(duck_block) parameter, from the real reader
+query I
+SELECT length(duck_blocks_to_md(list(b))) > 0
+FROM read_markdown_blocks('test/data/blocks_basic.md', filename := true) b;
+----
+true
+
+query I
+SELECT length(duck_blocks_to_sections(list(b))) > 0
+FROM read_markdown_blocks('test/data/blocks_basic.md', filename := true) b;
+----
+true
+
+# A bare block parameter, not a list
+query I
+SELECT rtrim(duck_block_to_md({'kind': 'block', 'element_type': 'paragraph', 'content': 'hi',
+                              'level': NULL::INTEGER, 'encoding': 'text',
+                              'attributes': MAP{}::MAP(VARCHAR, VARCHAR),
+                              'element_order': 0, 'filename': 'a.md'}), chr(10)) = 'hi';
+----
+true
+
+# The canonical 7-field shape is untouched by the widening
+query I
+SELECT rtrim(duck_block_to_md({'kind': 'block', 'element_type': 'paragraph', 'content': 'hi',
+                              'level': NULL::INTEGER, 'encoding': 'text',
+                              'attributes': MAP{}::MAP(VARCHAR, VARCHAR),
+                              'element_order': 0}), chr(10)) = 'hi';
+----
+true
+
+query I
+SELECT length(duck_blocks_to_md(list(b))) > 0
+FROM read_markdown_blocks('test/data/blocks_basic.md') b;
+----
+true
+
+# Emitters still emit the canonical 7-field shape; accepting the 8th does not
+# widen what markdown produces from a plain parse.
+query I
+SELECT typeof(parse_markdown_to_duck_blocks('# H')) LIKE '%element_order INTEGER)[]';
+----
+true
+
+# An untyped NULL stays unambiguous rather than becoming a doubly-matching call
+query I
+SELECT duck_blocks_to_md(NULL) IS NULL;
+----
+true
+
+# ---------------------------------------------------------------------------
+# Negative: acceptance is ONE exact shape. These prove the widening did not
+# turn into "any struct with the right first seven children".
+# ---------------------------------------------------------------------------
+
+# filename present but NOT trailing -- the whole point of the 6.4 change
+statement error
+SELECT duck_block_to_md({'filename': 'a.md', 'kind': 'block', 'element_type': 'paragraph',
+                         'content': 'hi', 'level': NULL::INTEGER, 'encoding': 'text',
+                         'attributes': MAP{}::MAP(VARCHAR, VARCHAR), 'element_order': 0});
+----
+No function matches
+
+# an eighth field under a different name
+statement error
+SELECT duck_block_to_md({'kind': 'block', 'element_type': 'paragraph', 'content': 'hi',
+                         'level': NULL::INTEGER, 'encoding': 'text',
+                         'attributes': MAP{}::MAP(VARCHAR, VARCHAR),
+                         'element_order': 0, 'src_path': 'a.md'});
+----
+No function matches
+
+# a ninth field
+statement error
+SELECT duck_block_to_md({'kind': 'block', 'element_type': 'paragraph', 'content': 'hi',
+                         'level': NULL::INTEGER, 'encoding': 'text',
+                         'attributes': MAP{}::MAP(VARCHAR, VARCHAR),
+                         'element_order': 0, 'filename': 'a.md', 'extra': 1});
+----
+No function matches
+
+# filename with a non-VARCHAR type
+statement error
+SELECT duck_block_to_md({'kind': 'block', 'element_type': 'paragraph', 'content': 'hi',
+                         'level': NULL::INTEGER, 'encoding': 'text',
+                         'attributes': MAP{}::MAP(VARCHAR, VARCHAR),
+                         'element_order': 0, 'filename': 7});
+----
+No function matches

--- a/test/sql/duck_block_filename_field.test
+++ b/test/sql/duck_block_filename_field.test
@@ -69,6 +69,37 @@ SELECT duck_blocks_to_md(NULL) IS NULL;
 true
 
 # ---------------------------------------------------------------------------
+# Hand-written literals: the widened shape needs its MAP child typed
+#
+# Acceptance is keyed on an EXACT source type, so an untyped `MAP{}` -- which
+# infers MAP("NULL", "NULL"), not MAP(VARCHAR, VARCHAR) -- is not the registered
+# source type and no registered cast matches; the child-count rule then refuses.
+# The canonical 7-field shape does not go through a registered cast at all, so
+# DuckDB's ordinary implicit struct cast coerces the MAP child and it binds
+# either way. That asymmetry is invisible until you hand-write an 8-field
+# literal, and it looks exactly like the cast being broken.
+query I
+SELECT rtrim(duck_block_to_md({'kind': 'block', 'element_type': 'paragraph', 'content': 'hi',
+                               'level': NULL::INTEGER, 'encoding': 'text',
+                               'attributes': MAP{}, 'element_order': 0}), chr(10)) = 'hi';
+----
+true
+
+statement error
+SELECT duck_block_to_md({'kind': 'block', 'element_type': 'paragraph', 'content': 'hi',
+                         'level': NULL::INTEGER, 'encoding': 'text',
+                         'attributes': MAP{}, 'element_order': 0, 'filename': 'a.md'});
+----
+No function matches
+
+statement error
+SELECT duck_blocks_to_md([{'kind': 'block', 'element_type': 'paragraph', 'content': 'hi',
+                           'level': NULL::INTEGER, 'encoding': 'text',
+                           'attributes': MAP{}, 'element_order': 0, 'filename': 'a.md'}]);
+----
+No function matches
+
+# ---------------------------------------------------------------------------
 # Negative: acceptance is ONE exact shape. These prove the widening did not
 # turn into "any struct with the right first seven children".
 # ---------------------------------------------------------------------------

--- a/test/sql/markdown_blocks.test
+++ b/test/sql/markdown_blocks.test
@@ -165,7 +165,34 @@ SELECT string_agg(element_order::VARCHAR, ',' ORDER BY element_order) FROM read_
 # =============================================================================
 
 query I
-SELECT file_path LIKE '%blocks_basic.md' FROM read_markdown_blocks('test/data/blocks_basic.md', include_filepath := true) LIMIT 1;
+SELECT filename LIKE '%blocks_basic.md' FROM read_markdown_blocks('test/data/blocks_basic.md', include_filepath := true) LIMIT 1;
+----
+true
+
+# Provenance is TRAILING, and that is load-bearing rather than cosmetic.
+# duck_block spec 6.4 keys acceptance on the exact 8-field struct with
+# `filename` LAST. Consumers read struct children BY INDEX, so a leading field
+# puts the file path at index 0 where every consumer expects `kind` -- shifting
+# every canonical field by one. Asserted as an exact type string so a
+# reordering fails here rather than downstream.
+query I
+SELECT typeof(list(b)) = 'STRUCT(kind VARCHAR, element_type VARCHAR, "content" VARCHAR, "level" INTEGER, "encoding" VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER, filename VARCHAR)[]'
+FROM read_markdown_blocks('test/data/blocks_basic.md', filename := true) b;
+----
+true
+
+# The deprecated alias produces the identical shape -- the parameter name never
+# reaches the data, only the column name and position do.
+query I
+SELECT typeof(list(b)) = 'STRUCT(kind VARCHAR, element_type VARCHAR, "content" VARCHAR, "level" INTEGER, "encoding" VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER, filename VARCHAR)[]'
+FROM read_markdown_blocks('test/data/blocks_basic.md', include_filepath := true) b;
+----
+true
+
+# Without provenance the shape is the canonical 7-field duck_block.
+query I
+SELECT typeof(list(b)) = 'STRUCT(kind VARCHAR, element_type VARCHAR, "content" VARCHAR, "level" INTEGER, "encoding" VARCHAR, attributes MAP(VARCHAR, VARCHAR), element_order INTEGER)[]'
+FROM read_markdown_blocks('test/data/blocks_basic.md') b;
 ----
 true
 
@@ -250,7 +277,7 @@ SELECT count(*) FROM read_markdown_blocks('test/data/blocks_*.md') WHERE kind = 
 58
 
 query I
-SELECT count(DISTINCT file_path) FROM read_markdown_blocks('test/data/blocks_*.md', include_filepath := true);
+SELECT count(DISTINCT filename) FROM read_markdown_blocks('test/data/blocks_*.md', include_filepath := true);
 ----
 9
 

--- a/test/sql/markdown_list_input.test
+++ b/test/sql/markdown_list_input.test
@@ -25,7 +25,7 @@ true
 
 # Named parameters work identically for the list form
 query I
-SELECT count(DISTINCT file_path) FROM read_markdown(['test/docs/*.md', 'test/markdown/*.md'], include_filepath := true);
+SELECT count(DISTINCT filename) FROM read_markdown(['test/docs/*.md', 'test/markdown/*.md'], include_filepath := true);
 ----
 13
 
@@ -67,7 +67,7 @@ SELECT (SELECT count(*) FROM read_markdown_blocks(['test/docs/*.md', 'test/markd
 true
 
 query I
-SELECT count(DISTINCT file_path) FROM read_markdown_blocks(['test/docs/*.md', 'test/markdown/*.md'], include_filepath := true);
+SELECT count(DISTINCT filename) FROM read_markdown_blocks(['test/docs/*.md', 'test/markdown/*.md'], include_filepath := true);
 ----
 13
 


### PR DESCRIPTION
Brings markdown's duck_block provenance in line with the fleet. Two commits: emit the trailing `filename`, then accept it.

## 1. `file_path` → `filename`, leading → trailing (`1dd4dbc`)

panduck reported two issues against the published build; I reproduced both here before changing anything, and both were accurate.

```
before: STRUCT(file_path, kind, element_type, content, level, encoding, attributes, element_order)
after:  STRUCT(kind, element_type, content, level, encoding, attributes, element_order, filename)
```

The name matches DuckDB core — `read_csv`, `read_json` and `read_parquet` all take a `filename` parameter and emit a `filename` column.

**The move mattered more than the rename.** duck_block consumers read struct children *by index*, so a leading field put the file path at index 0 where every consumer expects `kind`, shifting every canonical field by one. Spec 6.4 keys acceptance on the exact 8-field type with `filename` last, so the rename alone would have left the shape unbindable.

Applied to all three readers, not just `read_markdown_blocks` — `read_markdown` and `read_markdown_sections` also emitted a leading `file_path`. In each, the column now sits after the reader's standard columns and before the optional add-on extractor columns, so with no add-ons requested `read_markdown_blocks` yields exactly the canonical 8-field type.

`include_filepath` remains a deprecated alias producing the identical shape — the parameter name never reaches the data. Boolean form only: core's string form that renames the column is deliberately **not** accepted, since a renamed column produces a struct nothing accepts.

## 2. Accepting the widened shape (`9efd1cc`)

Emission alone left markdown unable to consume its own output:

```
SELECT duck_blocks_to_md(list(b)) FROM read_markdown_blocks('m.md', filename := true) b;
Binder Error: No function matches 'duck_blocks_to_md(STRUCT(..., filename VARCHAR)[])'
```

The fleet ordering is acceptance everywhere *before* anything emits, so this closes the gap in the same branch that opened it.

Two implicit casts at cost 10, both binding to DuckDB's own default cast for the pair — so the cast *is* the standard name-based struct cast, which matches children by name and skips a source child the target lacks, dropping `filename`. Consumers do not widen to read it. DuckDB's named struct cast already handles this shape; the only thing refusing the implicit path is the child-count rule in `cast_rules.cpp`, and the binder consults registered casts before that rule.

Registration copied verbatim from duck_block_utils rather than approximated — they own the spec. Both registrations are needed and neither is reached through the other: the LIST one covers `LIST(duck_block)` parameters, the struct one covers a bare block. Cost 10 is positive so it never beats an exact 7-field match, small so it beats any to-VARCHAR fallback; that's only safe when nothing is overloaded on its block argument, which I checked — all three take exactly one signature. No catalog type named `duck_block` is registered: it's a shape, not a catalog name.

## Tests

The negatives are the point — they prove acceptance is **one exact shape**, not "any struct whose first seven children match". All four still fail to bind: `filename` non-trailing, an eighth field under another name, a ninth field, and `filename` with a non-VARCHAR type. Plus exact-type-string assertions on emission for all three cases (new parameter, deprecated alias, no provenance), so a future reordering fails here rather than downstream.

50 test cases / 1815 assertions pass. Vocabulary drift, conformance and format all clean.

## Note

markdown's vendored vocabulary check still reports **upstream 6.3**, so the 6.4 constants aren't published where markdown vendors them. The literal `"filename"` becomes `Vocab::FIELD_FILENAME` on re-vendor; duck_block_utils will send the sha when it lands.
