### PR TITLE
chore: vendor duck_block spec 6.5

### DIFF
--- a/docs/doc_block_spec.md
+++ b/docs/doc_block_spec.md
@@ -5,7 +5,7 @@
 > The canonical duck_block specification is owned by `duck_block_utils`:
 > `docs/duck_blocks_spec.md` in `teaguesterling/duckdb_duck_block_utils`,
 > with the machine-readable vocabulary in `src/include/duck_block_vocabulary.hpp`
-> (`SPEC_VERSION`, currently 6.3). This repository vendors that header at
+> (`SPEC_VERSION`, currently 6.5). This repository vendors that header at
 > `src/include/duck_block_vocabulary.hpp` and checks it for drift with
 > `make check-vocabulary`.
 >
@@ -23,7 +23,7 @@
 >
 > Superseded 2026-09-01, against duck_block spec 6.1.
 
-**Version**: 2.0 (superseded — unrelated to duck_block `SPEC_VERSION`, now 6.3)
+**Version**: 2.0 (superseded — unrelated to duck_block `SPEC_VERSION`, now 6.5)
 **Status**: Historical
 **Last Updated**: 2026-09-01
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -85,31 +85,32 @@ SELECT duck_blocks_to_md(
 
 The `duck_block_utils` extension will provide format-agnostic block manipulation:
 
-### Planned Functions
+### Consuming markdown's blocks from duck_block_utils
 
-| Function | Description |
-|----------|-------------|
-| `duck_blocks_filter(blocks, types[])` | Keep only specified element types |
-| `duck_blocks_exclude(blocks, types[])` | Remove specified element types |
-| `duck_blocks_to_text(blocks)` | Extract plain text content |
-| `duck_blocks_toc(blocks)` | Generate table of contents |
-| `duck_blocks_validate(blocks)` | Check schema compliance |
-| `duck_blocks_stats(blocks)` | Block type statistics |
+These are no longer planned — `duck_blocks_filter`, `_exclude`, `_to_text`,
+`_toc`, `_validate` and `_stats` all ship in `duck_block_utils` today, and
+markdown's blocks feed them directly.
 
-### Example Usage (Planned)
+**This document does not reproduce their signatures.** They live in another
+repository, on its own release cadence, and a copy here goes stale silently:
+spec 6.5 reshaped four extractors so that `duck_blocks_headings`, `_links`,
+`_code_blocks` and `_toc` return **duck_blocks** rather than bespoke projection
+structs, with the previous shapes preserved as `_structs` siblings
+(`duck_blocks_toc_structs` and so on). An example pinned here would have been
+wrong the day that landed, and this one was.
+
+For the current surface, read `duck_block_utils`' own documentation — it is the
+authority, and `make check-vocabulary` in this repo verifies only the vendored
+*vocabulary constants*, not the function signatures.
 
 ```sql
 LOAD markdown;
 LOAD duck_block_utils;
 
--- Generate table of contents
-SELECT * FROM duck_blocks_toc(
+-- markdown produces blocks; duck_block_utils consumes them. Whatever the
+-- consuming function's current return shape is, this is the handoff:
+SELECT duck_blocks_to_text(
     (SELECT list(b ORDER BY element_order) FROM read_markdown_blocks('README.md') b)
-);
-
--- Get block type distribution
-SELECT * FROM duck_blocks_stats(
-    (SELECT list(b ORDER BY element_order) FROM read_markdown_blocks('docs/**/*.md') b)
 );
 ```
 

--- a/docs/markdown_doc_block.md
+++ b/docs/markdown_doc_block.md
@@ -7,7 +7,7 @@ The canonical vocabulary is the vendored header at `src/include/duck_block_vocab
 
 **Extension**: duckdb_markdown
 **Namespace**: `md`
-**Spec Version**: 6.3
+**Spec Version**: 6.5
 
 ## Overview
 

--- a/src/include/duck_block_vocabulary.hpp
+++ b/src/include/duck_block_vocabulary.hpp
@@ -158,9 +158,16 @@ struct DuckBlockVocabulary {
 	static constexpr uint64_t ATTRIBUTES_IDX = 5;
 	static constexpr uint64_t ELEMENT_ORDER_IDX = 6;
 
-	// Additional field indices for duck_block_ext
-	static constexpr uint64_t SOURCE_FORMAT_IDX = 7;
-	static constexpr uint64_t FILE_PATH_IDX = 8;
+	// The one OPTIONAL trailing field. A reader that emits a `filename` column makes
+	// `list(b)` an 8-field struct; consumers accept exactly that shape -- the seven
+	// canonical fields, then this -- and nothing else. Optional fields append in
+	// ADOPTION order: a later one takes index 8. Reserving slots ahead of adoption is
+	// what put `source_format` at 7 and `file_path` at 8 for a type nothing ever
+	// produced, and that reservation is why the first real optional field could not
+	// simply take the next index. Those two constants are gone; `duck_block_ext`
+	// itself stays registered, deprecated, for one release.
+	static constexpr uint64_t FILENAME_IDX = 7;
+	static constexpr const char *FIELD_FILENAME = "filename";
 
 	// Kind values
 	static constexpr const char *KIND_BLOCK = "block";
@@ -288,8 +295,71 @@ struct DuckBlockVocabulary {
 	//
 	//               Nothing renamed, nothing removed; a consumer on 6.1 is unaffected.
 	//
+	//   6.3 -> 6.4  ADDITIVE for the shape, with ONE REMOVAL and ONE DEPRECATION.
+	//               duck_block gains an optional trailing 8th field, `filename VARCHAR`,
+	//               so a reader can say which file each row came from without breaking
+	//               the `list(b)` idiom. Consumers MUST accept both the 7-field and the
+	//               8-field shape; producers MAY emit the 8th, opt-in behind
+	//               `filename := true`, DuckDB core's own convention. It is TRAILING
+	//               ONLY and the widened shape is exactly one type: a differently
+	//               named or differently placed extra field stays a binder error.
+	//               Functions that RETURN blocks return the 7-field shape: provenance
+	//               lives on the reader's rows and survives GROUP BY filename, not
+	//               duck_blocks_merge.
+	//
+	//               ROLLOUT ORDER, which is why the rule is stated: land acceptance in
+	//               every consumer BEFORE any reader emits, or every
+	//               `duck_blocks_toc(list(b))` in the field breaks with the binder
+	//               error the day the reader ships.
+	//
+	//               REMOVED: SOURCE_FORMAT_IDX (7) and FILE_PATH_IDX (8), the offsets
+	//               of a `duck_block_ext` type no function ever produced or consumed.
+	//               `filename` at 7 would otherwise contradict a published constant.
+	//               DEPRECATED: the `duck_block_ext` catalog type stays registered
+	//               for one release because a user's own `CAST(x AS duck_block_ext)`
+	//               is invisible to any grep of ours; it goes in 6.5.
+	//
+	//               A consumer on 6.3 that never referenced the two offsets is
+	//               unaffected until a reader it depends on starts emitting.
+	//
+	//   6.4 -> 6.5  BREAKING on the FUNCTION SURFACE, nothing in the struct shape.
+	//               Retrieval returns blocks, and a suffix names what the ORIGINAL
+	//               returned, so nobody is stranded:
+	//
+	//               * duck_blocks_get_section and duck_blocks_get_pages return
+	//                 LIST(duck_block) instead of VARCHAR; duck_blocks_sections_like's
+	//                 third column is `blocks` LIST(duck_block) instead of `content`
+	//                 VARCHAR, rows unchanged; named parameters removed entirely
+	//                 (output_format was the only one, on all three); page_rows gains
+	//                 a `blocks` column beside its existing four. The originals live
+	//                 on as duck_blocks_get_section_text, duck_blocks_get_pages_text,
+	//                 duck_blocks_sections_like_text -- defined as duck_blocks_to_text
+	//                 over the blocks form, which is byte-identical to the old default
+	//                 because that is literally what the old default computed.
+	//               * duck_blocks_headings, _toc, _code_blocks, _links return
+	//                 LIST(duck_block); today's projections live on, byte-for-byte and
+	//                 permanently, as duck_blocks_headings_structs, _toc_structs,
+	//                 _code_blocks_structs, _links_structs. toc_rows and page_rows keep
+	//                 their row shapes.
+	//               * ATTR_OUTLINE and ATTR_INDENT: the first attributes a function here
+	//                 COMPUTES rather than copies. Only on the output of the heading
+	//                 constructions.
+	//               * RECOVERY CONTRACT, now normative: element_order is dense from 0
+	//                 over the list a reader EMITS, synthetic markers included. Every
+	//                 projection or construction FROM a document carries it through
+	//                 unrenumbered, with gaps -- it is the join key back to the source
+	//                 and between the blocks and _structs forms. Only functions that
+	//                 build a standalone document (assemble, merge, reorder) renumber.
+	//               * Restated, because producers asked: `level` is never NULL (a flat
+	//                 format emits 1 everywhere); `filename` is opt-in and boolean-only.
+	//
+	//               Migration: a caller reading a projection field off duck_blocks_toc
+	//               (panduck's doc_toc) renames to duck_blocks_toc_structs; a caller
+	//               wanting text renames to the _text sibling. Failure to migrate is a
+	//               binder error, never a wrong answer.
+	//
 	// The rule above is what will be followed from here.
-	static constexpr const char *SPEC_VERSION = "6.3";
+	static constexpr const char *SPEC_VERSION = "6.5";
 
 	// ========================================================================
 	// Block type names
@@ -416,6 +486,13 @@ struct DuckBlockVocabulary {
 	static constexpr const char *ATTR_LIST_TYPE = "list_type";
 	static constexpr const char *ATTR_SOURCE_TYPE = "source_type";
 	static constexpr const char *ATTR_PANDOC_AST = "pandoc_ast";
+	// COMPUTED attributes -- set only by duck_block_utils' heading constructions
+	// (duck_blocks_headings / duck_blocks_toc), never emitted by a reader as if
+	// sourced. `outline` is the heading's position in the outline ("1.2.1"):
+	// positions, not the heading's own digit, so h1 -> h3 -> h2 reads 1, 1.1, 1.2.
+	// `indent` is heading level minus the document's minimum heading level.
+	static constexpr const char *ATTR_OUTLINE = "outline";
+	static constexpr const char *ATTR_INDENT = "indent";
 
 	// ========================================================================
 	// Role values, per the type that carries them

--- a/src/markdown_types.cpp
+++ b/src/markdown_types.cpp
@@ -2,9 +2,12 @@
 #include "duckdb_compat.hpp"
 #include "markdown_utils.hpp"
 #include "duck_block_functions.hpp"
+#include "duck_block_vocabulary.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
 
 namespace duckdb {
+
+using Vocab = DuckBlockVocabulary;
 
 //===--------------------------------------------------------------------===//
 // Markdown Type Definition
@@ -124,13 +127,9 @@ static bool DuckBlockListToMarkdownCast(Vector &source, Vector &result, idx_t co
 
 // The one accepted widened shape: duck_block plus a trailing `filename VARCHAR`,
 // exactly. Registration and shape supplied by duck_block_utils, who own the spec.
-//
-// The literal "filename" becomes Vocab FIELD_FILENAME once 6.4 is vendored here;
-// markdown's drift check still reports upstream 6.3, so the constant does not
-// exist locally yet.
 static LogicalType DuckBlockWithFilenameType() {
 	auto children = StructType::GetChildTypes(MarkdownTypes::DuckBlockType());
-	children.push_back(make_pair("filename", LogicalType::VARCHAR));
+	children.push_back(make_pair(Vocab::FIELD_FILENAME, LogicalType::VARCHAR));
 	return LogicalType::STRUCT(std::move(children));
 }
 


### PR DESCRIPTION
Re-vendors the vocabulary header from duck_block_utils main at `cfd8e28`, and swaps the `"filename"` literal for `Vocab::FIELD_FILENAME` as the comment there promised.

## What came in

`SPEC_VERSION` 6.5, plus `FIELD_FILENAME`, `FILENAME_IDX`, `ATTR_OUTLINE`, `ATTR_INDENT`.

`markdown_types.cpp` needed the vocabulary include and the local `using Vocab = DuckBlockVocabulary;` alias that the other three consumers each declare per translation unit — it had never referenced a constant before.

The three local-only constants markdown's 6.3 copy carried (`SOURCE_FORMAT_IDX = 7`, `FILE_PATH_IDX = 8`) are gone. Upstream's 6.5 header records them as REMOVED in its own changelog, having taken index 7 for `FILENAME_IDX`. They were dead here — no references in `src/` or `test/` — so nothing depended on them, but a *live* one would have been silently redefined rather than failing to compile.

## The drift check earned its warning

It reports "the version line is usually the least of what has drifted," and that was literally true. Bumping the two version strings was trivial. `docs/ecosystem.md` was the real find: a **"Planned Functions"** table listing six `duck_block_utils` functions that have all since shipped, plus an example calling `duck_blocks_toc` to generate a table of contents — which **6.5 reshaped to return duck_blocks**, moving that projection to `duck_blocks_toc_structs`. The example was wrong the day 6.5 landed.

That section now points at `duck_block_utils` as the authority and keeps only the handoff shape. A duplicated signature list for another repo's API, on its own release cadence, goes stale silently — and `make check-vocabulary` verifies the vendored **constants**, not function signatures, so nothing here would have caught it.

## Verification

50 test cases / 1818 assertions pass. Vocabulary drift now reports local 6.5 / upstream 6.5 in sync; conformance and format clean.

Note: duck_block_utils has a follow-up PR pending against `cfd8e28` (a test-only single-arrow lambda fix plus a CI concurrency fix). That does not change the vendored header, so this vendor is not blocked on it — but their *tag* is.