### PR TITLE
fix(frontmatter): match the fence the same way at both ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,19 @@ Available tokens: `wikilinks`, `tags`, and the `obsidian` flavor (= both). Unkno
 
 ### Frontmatter Handling
 
+**Where the block starts and stops.** The opening fence must be a line containing exactly
+`---` (YAML) or `+++` (Hugo's TOML), trailing spaces or tabs allowed, as the very first line
+of the document; a leading UTF-8 BOM is skipped. A line that merely *starts* with three
+delimiter characters — `----`, `---foo` — is not a fence at either end, so a document opening
+with a thematic break is read as having no frontmatter rather than swallowing the text after
+it, and a `----` rule further down does not close a block early and splice its surplus `-`
+into the body. A `---` block is closed by the next `---` or `...` line at column 0 (`...` is
+YAML's document-end marker: it closes, it never opens); a `+++` block only by `+++`. An
+empty block — `---` immediately followed by `---`, Jekyll's idiom — is recognised and yields
+no metadata rather than two thematic breaks. These are the same rules the `yaml` extension's
+`read_yaml_frontmatter` applies, so the two extensions agree about where a given document's
+frontmatter begins and ends.
+
 **This extension does not parse YAML.** Frontmatter — the block between the leading `---`
 delimiters — is read as **flat `key: value` pairs**: each line is split on its *first* `:`,
 both halves are whitespace-trimmed, and a pair of surrounding double quotes is stripped from

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -77,9 +77,18 @@ static size_t SkipBOM(const std::string &s) {
 //   setext heading whose text is "title: x". The metadata was not merely
 //   unparsed, it was silently reclassified as prose.
 //
-// Exactly three is deliberate, and matches Jekyll and gray-matter: `----` is a
-// rule, not a fence, at either end.
-static bool IsFrontmatterFenceLine(const std::string &s, size_t line, size_t line_end, char d) {
+// Exactly three is deliberate, and follows Jekyll, whose
+// `\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)`m rejects a four-dash line at BOTH
+// ends. The other readers were MEASURED rather than assumed (2026-09-07) and
+// they do not agree with each other, so "what everyone does" was not available
+// as a rule: gray-matter rejects `----` at the open with an explicit guard but
+// closes on a bare `str.indexOf('\n---')`, so there `----` DOES close a block
+// and leaves the surplus '-' at the head of the content -- precisely the bug
+// fixed here. python-frontmatter's boundary is `^-{3,}\s*$`, which takes `----`
+// at both ends. Strict-three is the only one of the three that cannot silently
+// mangle a body, and it is what duckdb_yaml's read_yaml_frontmatter enforces,
+// so the two extensions answer the same about the same file.
+static bool IsFenceRun(const std::string &s, size_t line, size_t line_end, char d) {
 	if (line_end - line < 3 || s[line] != d || s[line + 1] != d || s[line + 2] != d) {
 		return false;
 	}
@@ -90,9 +99,23 @@ static bool IsFrontmatterFenceLine(const std::string &s, size_t line, size_t lin
 	return q == line_end;
 }
 
-// Linear replacement for R"(^(---|\+\+\+)[ \t]*\r?\n([\s\S]*?)\r?\n?\1[ \t]*$)".
-// Requires the document to open with a fence line, then finds the earliest
-// following fence line. Returns the body between them. O(n), no recursion.
+// `...` is YAML's document-END marker. Jekyll closes a `---` block on it
+// (`(---|\.\.\.)` above) and so does duckdb_yaml's ExtractFrontmatter, which
+// has accepted it all along. This reader did not, so a file closed that way was
+// frontmatter to one extension and prose to the other -- and the README points
+// users at both over the same file (`read_yaml_frontmatter`, and
+// `yaml(md_extract_frontmatter(content))` for the in-process seam). It never
+// OPENS a block, and it has no meaning in a `+++` TOML block, hence the flag
+// and the `d == '-'` guard.
+static bool IsFrontmatterFenceLine(const std::string &s, size_t line, size_t line_end, char d,
+                                   bool allow_document_end) {
+	return IsFenceRun(s, line, line_end, d) || (allow_document_end && d == '-' && IsFenceRun(s, line, line_end, '.'));
+}
+
+// Linear replacement for R"(^(---|\+\+\+)[ \t]*\r?\n([\s\S]*?)\r?\n?(\1|\.\.\.)[ \t]*$)",
+// with the `...` alternative live only for the `---` dialect. Requires the
+// document to open with a fence line, then finds the earliest following fence
+// line. Returns the body between them. O(n), no recursion.
 //
 // `+++` is TOML frontmatter, which Hugo emits by default. It was not recognised
 // until 2026-09-01, and the failure was not a missing feature -- it was silent
@@ -115,7 +138,7 @@ static FrontmatterMatch FindFrontmatterDelimited(const std::string &s, char d) {
 	if (open_end > b && s[open_end - 1] == '\r') {
 		open_end--;
 	}
-	if (!IsFrontmatterFenceLine(s, b, open_end, d)) {
+	if (!IsFrontmatterFenceLine(s, b, open_end, d, /*allow_document_end=*/false)) {
 		return m;
 	}
 	const size_t body_start = open_eol + 1;
@@ -141,7 +164,7 @@ static FrontmatterMatch FindFrontmatterDelimited(const std::string &s, char d) {
 		if (content_end > line && s[content_end - 1] == '\r') {
 			content_end--;
 		}
-		if (IsFrontmatterFenceLine(s, line, content_end, d)) {
+		if (IsFrontmatterFenceLine(s, line, content_end, d, /*allow_document_end=*/true)) {
 			// The body ends before the newline separating it from this fence line.
 			// When the fence IS the first body line the body is empty, and the two
 			// offsets coincide -- do not step back past body_start.

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -55,10 +55,44 @@ static size_t SkipBOM(const std::string &s) {
 	return 0;
 }
 
-// Faithful linear replacement for R"(^(---|\+\+\+)\r?\n([\s\S]*?)\r?\n\1)".
-// Requires the string to begin with the delimiter then \r?\n, then finds the
-// earliest following "\r?\n" + delimiter. Returns the body between them. O(n),
-// no recursion.
+// True when s[line, line_end) is a frontmatter fence line: exactly three of the
+// delimiter character, then nothing but spaces or tabs. `line_end` excludes the
+// line's own '\n' and any '\r' before it.
+//
+// BOTH ends of the block go through this one predicate, which is the point. They
+// used to be written separately and disagreed in both directions (#21):
+//
+//   The CLOSE was a three-character prefix compare on the bytes after a '\n',
+//   with nothing checked after it, so any line merely BEGINNING with the fence
+//   closed the block. `----` -- a four-dash rule, or the setext underline that
+//   makes the line above it an <h2> -- closed a `---` block, and because the
+//   scan then resumed three bytes in, the surplus '-' was spliced onto the front
+//   of the body, where cmark read it as a list bullet and manufactured an empty
+//   list and list_item out of nothing.
+//
+//   The OPEN demanded a bare fence and rejected a trailing space, which Jekyll
+//   (`\A---\s*\n`), gray-matter and python-frontmatter all accept. An invisible
+//   space after the opening `---` therefore turned the whole block into body
+//   content: `--- \ntitle: x\n---` came back as a thematic break followed by a
+//   setext heading whose text is "title: x". The metadata was not merely
+//   unparsed, it was silently reclassified as prose.
+//
+// Exactly three is deliberate, and matches Jekyll and gray-matter: `----` is a
+// rule, not a fence, at either end.
+static bool IsFrontmatterFenceLine(const std::string &s, size_t line, size_t line_end, char d) {
+	if (line_end - line < 3 || s[line] != d || s[line + 1] != d || s[line + 2] != d) {
+		return false;
+	}
+	size_t q = line + 3;
+	while (q < line_end && (s[q] == ' ' || s[q] == '\t')) {
+		q++;
+	}
+	return q == line_end;
+}
+
+// Linear replacement for R"(^(---|\+\+\+)[ \t]*\r?\n([\s\S]*?)\r?\n?\1[ \t]*$)".
+// Requires the document to open with a fence line, then finds the earliest
+// following fence line. Returns the body between them. O(n), no recursion.
 //
 // `+++` is TOML frontmatter, which Hugo emits by default. It was not recognised
 // until 2026-09-01, and the failure was not a missing feature -- it was silent
@@ -70,36 +104,67 @@ static size_t SkipBOM(const std::string &s) {
 static FrontmatterMatch FindFrontmatterDelimited(const std::string &s, char d) {
 	FrontmatterMatch m;
 	m.delimiter = d;
-	// Opening delimiter: an optional BOM, then the fence then \r?\n
-	const size_t b = SkipBOM(s);
-	if (s.size() < b + 4 || s[b] != d || s[b + 1] != d || s[b + 2] != d) {
-		return m;
-	}
-	size_t p = b + 3;
-	if (p < s.size() && s[p] == '\r') {
-		p++;
-	}
-	if (p >= s.size() || s[p] != '\n') {
-		return m;
-	}
-	p++; // start of body
-	size_t body_start = p;
 
-	// Closing delimiter: earliest '\n' immediately followed by the same fence.
-	while (p < s.size()) {
-		if (s[p] == '\n' && p + 4 <= s.size() && s[p + 1] == d && s[p + 2] == d && s[p + 3] == d) {
-			size_t body_end = p; // at the '\n'
-			// The delimiter is \r?\n, so drop a trailing '\r' from the body.
-			if (body_end > body_start && s[body_end - 1] == '\r') {
-				body_end--;
+	// Opening fence: an optional BOM, then a line that is exactly the fence.
+	const size_t b = SkipBOM(s);
+	const size_t open_eol = s.find('\n', b);
+	if (open_eol == std::string::npos) {
+		return m; // a single unterminated line cannot open a block
+	}
+	size_t open_end = open_eol;
+	if (open_end > b && s[open_end - 1] == '\r') {
+		open_end--;
+	}
+	if (!IsFrontmatterFenceLine(s, b, open_end, d)) {
+		return m;
+	}
+	const size_t body_start = open_eol + 1;
+
+	// Closing fence: the first following line that is exactly the fence. The scan
+	// steps line by line from body_start, so the FIRST body line is itself a
+	// candidate -- and that is what makes an EMPTY block match.
+	//
+	// The previous scan looked for a '\n' immediately followed by the fence,
+	// starting at body_start. For `---\n---` the '\n' that precedes the closing
+	// fence IS the one that terminated the OPENING fence, one byte before
+	// body_start, so it was never examined and the block was reported as absent.
+	// Jekyll requires exactly that block at the head of a file for the file to be
+	// processed at all, and Hugo's `+++\n+++` has the same shape. Reported absent,
+	// both fences fell through to cmark: `---\n---` became two thematic breaks and
+	// `+++\n+++` became a paragraph of literal plus signs, so the fences leaked
+	// into the document body and no metadata block was ever emitted (#21).
+	size_t line = body_start;
+	while (line <= s.size()) {
+		const size_t eol = s.find('\n', line);
+		const size_t line_end = (eol == std::string::npos) ? s.size() : eol;
+		size_t content_end = line_end;
+		if (content_end > line && s[content_end - 1] == '\r') {
+			content_end--;
+		}
+		if (IsFrontmatterFenceLine(s, line, content_end, d)) {
+			// The body ends before the newline separating it from this fence line.
+			// When the fence IS the first body line the body is empty, and the two
+			// offsets coincide -- do not step back past body_start.
+			size_t body_end = line;
+			if (body_end > body_start) {
+				body_end--; // the '\n' that ended the last body line
+				if (body_end > body_start && s[body_end - 1] == '\r') {
+					body_end--;
+				}
 			}
 			m.found = true;
 			m.body_start = body_start;
 			m.body_len = body_end - body_start;
-			m.after_close = p + 4; // just past the closing fence
+			// Past the whole closing fence LINE, trailing whitespace included, so a
+			// fence written `--- ` does not leave that space behind as the body's
+			// first line.
+			m.after_close = line_end;
 			return m;
 		}
-		p++;
+		if (eol == std::string::npos) {
+			break;
+		}
+		line = eol + 1;
 	}
 	return m;
 }

--- a/test/sql/frontmatter_fence_edges.test
+++ b/test/sql/frontmatter_fence_edges.test
@@ -1,0 +1,214 @@
+# name: test/sql/frontmatter_fence_edges.test
+# description: frontmatter fence lines are matched the same way at both ends (#21)
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# The opening and closing frontmatter fences used to be recognised by two
+# separately written pieces of code, and they disagreed in both directions.
+# Every failure below is a silently wrong document body, never an error.
+#
+#   1. An EMPTY block was never found. The close was located by scanning from
+#      the first byte of the BODY for a '\n' followed by the fence -- but for
+#      `---\n---` the '\n' before the closing fence is the one that terminated
+#      the OPENING fence, one byte earlier, so it was never examined. Jekyll
+#      requires exactly this block at the head of a file for the file to be
+#      processed at all. Reported absent, both fences fell through to cmark:
+#      `---\n---` became two thematic breaks and Hugo's `+++\n+++` became a
+#      paragraph of literal plus signs.
+#
+#   2. The close was a three-character PREFIX compare, so `----` -- a four-dash
+#      rule, or a setext underline -- closed a `---` block, and the scan resumed
+#      three bytes in, splicing the surplus '-' onto the front of the body where
+#      cmark read it as a bullet and manufactured an empty list out of nothing.
+#
+#   3. The open rejected a trailing space that Jekyll (`\A---\s*\n`),
+#      gray-matter and python-frontmatter all accept, so one invisible character
+#      reclassified the entire block as prose: `--- \ntitle: x\n---` came back
+#      as a thematic break plus a setext heading reading "title: x".
+#
+# Both ends now go through one IsFrontmatterFenceLine predicate: exactly three
+# delimiter characters, then nothing but spaces or tabs.
+# =============================================================================
+
+# =============================================================================
+# 1. The empty block
+# =============================================================================
+
+statement ok
+COPY (SELECT E'---\n---\n# Body\n') TO '__TEST_DIR__/fm_empty.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+# Was: hr, hr, heading -- two thematic breaks conjured from the fences.
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_empty.md') ORDER BY element_order;
+----
+heading	Body
+
+statement ok
+COPY (SELECT E'+++\n+++\n# Body\n') TO '__TEST_DIR__/fm_empty_toml.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+# Was: a paragraph whose inline text was "+++", "", "+++" -- Hugo's empty block
+# rendered as literal prose.
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_empty_toml.md') ORDER BY element_order;
+----
+heading	Body
+
+statement ok
+COPY (SELECT E'---\r\n---\r\n# Body\r\n') TO '__TEST_DIR__/fm_empty_crlf.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+# Same block under CRLF line endings.
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_empty_crlf.md') ORDER BY element_order;
+----
+heading	Body
+
+# An empty block and nothing else is an empty document, not two rules.
+statement ok
+COPY (SELECT E'---\n---\n') TO '__TEST_DIR__/fm_empty_only.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+query I
+SELECT count(*) FROM read_markdown_blocks('__TEST_DIR__/fm_empty_only.md');
+----
+0
+
+# md_extract_metadata over an empty block is an empty map either way, but it
+# must not report the fences as content.
+query I
+SELECT cardinality(md_extract_metadata(E'---\n---\n# Body'));
+----
+0
+
+# =============================================================================
+# 2. The closing fence must be the whole line
+# =============================================================================
+
+statement ok
+COPY (SELECT E'---\ntitle: x\n----\n# Body\n') TO '__TEST_DIR__/fm_fourdash.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+# `----` does not close a `---` block, so this block is unterminated and there is
+# no frontmatter -- `title: x` and its underline are a setext heading, which is
+# what cmark and Jekyll both make of it.
+#
+# Was: metadata "title: x", then an empty `list` and `list_item` built out of the
+# surplus '-' that the prefix match left behind, then the heading.
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_fourdash.md') ORDER BY element_order;
+----
+hr	NULL
+heading	title: x
+heading	Body
+
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n----\n# Body') IS NULL;
+----
+true
+
+# A fence followed by text is not a fence.
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n--- nope\n# Body') IS NULL;
+----
+true
+
+# Trailing whitespace after the closing fence is accepted, and does not survive
+# into the body as a stray blank first line.
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n--- \n# Body') = 'title: x';
+----
+true
+
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n---\t\n# Body') = 'title: x';
+----
+true
+
+statement ok
+COPY (SELECT E'---\ntitle: x\n--- \n# Body\n') TO '__TEST_DIR__/fm_close_ws.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_close_ws.md') ORDER BY element_order;
+----
+metadata	title: x
+heading	Body
+
+# =============================================================================
+# 3. The opening fence tolerates trailing whitespace
+# =============================================================================
+
+statement ok
+COPY (SELECT E'--- \ntitle: x\n---\n# Body\n') TO '__TEST_DIR__/fm_open_ws.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+# Was: hr, heading "title: x", heading "Body" -- the metadata silently became a
+# setext heading in the body.
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_open_ws.md') ORDER BY element_order;
+----
+metadata	title: x
+heading	Body
+
+query I
+SELECT md_extract_metadata(E'--- \ntitle: x\n---\n# Body')['title'];
+----
+x
+
+# =============================================================================
+# 4. What must NOT become frontmatter
+# =============================================================================
+
+statement ok
+COPY (SELECT E'----\nintro text\n---\nafter\n') TO '__TEST_DIR__/fm_loose_open.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+# A document that merely OPENS with a four-dash rule is not a frontmatter block.
+# Accepting it would swallow everything up to the next `---` as unparsed
+# metadata and silently truncate the document to whatever followed.
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_loose_open.md') ORDER BY element_order;
+----
+hr	NULL
+heading	intro text
+paragraph	after
+
+query I
+SELECT md_extract_frontmatter(E'---foo\nbar\n---\nBody') IS NULL;
+----
+true
+
+# A `---` that is not at the head of the document is a thematic break.
+query I
+SELECT md_extract_frontmatter(E'Body\n---\nmore') IS NULL;
+----
+true
+
+# An unterminated opening fence yields no frontmatter.
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n') IS NULL;
+----
+true
+
+# =============================================================================
+# 5. Unchanged behaviour
+# =============================================================================
+
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n---\n# Body') = 'title: x';
+----
+true
+
+query I
+SELECT md_extract_frontmatter(E'---\na: 1\nb: 2\n---\nBody') = E'a: 1\nb: 2';
+----
+true
+
+# A leading BOM does not defeat the opening fence (already true; guard it).
+query I
+SELECT md_extract_frontmatter(chr(65279) || E'---\ntitle: x\n---\nBody') = 'title: x';
+----
+true
+
+# An indented `---` inside a block scalar is not a fence line, so it does not
+# truncate the block early.
+query I
+SELECT md_extract_frontmatter(E'---\ns: |\n  ---\nt: 2\n---\nBody') = E's: |\n  ---\nt: 2';
+----
+true

--- a/test/sql/frontmatter_fence_edges.test
+++ b/test/sql/frontmatter_fence_edges.test
@@ -29,7 +29,10 @@ require markdown
 #      as a thematic break plus a setext heading reading "title: x".
 #
 # Both ends now go through one IsFrontmatterFenceLine predicate: exactly three
-# delimiter characters, then nothing but spaces or tabs.
+# delimiter characters, then nothing but spaces or tabs. Section 6 adds the one
+# asymmetry that is real -- `...`, YAML's document-END marker, closes a `---`
+# block but never opens one -- and it exists so that this reader and
+# duckdb_yaml's read_yaml_frontmatter give the same answer about the same file.
 # =============================================================================
 
 # =============================================================================
@@ -212,3 +215,73 @@ query I
 SELECT md_extract_frontmatter(E'---\ns: |\n  ---\nt: 2\n---\nBody') = E's: |\n  ---\nt: 2';
 ----
 true
+
+# =============================================================================
+# 6. `...` closes a `---` block
+#
+# `...` is YAML's document-END marker. Jekyll closes on it -- its regexp is
+# `^((---|\.\.\.)\s*$\n?)` -- and so does duckdb_yaml's read_yaml_frontmatter,
+# which has accepted it since before this reader existed. This reader did not,
+# so the same file was frontmatter to one extension and prose to the other,
+# while the README sends users to BOTH over the same file (read_yaml_frontmatter
+# for real YAML, `yaml(md_extract_frontmatter(content))` for the in-process
+# seam). Neither reader raised; they just disagreed.
+#
+# Was: NULL from md_extract_frontmatter, and the fences plus the metadata
+# rendered into the body as an hr and a setext heading.
+# =============================================================================
+
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n...\n# Body') = 'title: x';
+----
+true
+
+statement ok
+COPY (SELECT E'---\ntitle: x\n...\n# Body\n') TO '__TEST_DIR__/fm_dots.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_dots.md') ORDER BY element_order;
+----
+metadata	title: x
+heading	Body
+
+# Still the YAML dialect: `...` is a YAML marker, not a third fence style, so
+# the block must not be relabelled.
+query I
+SELECT encoding FROM read_markdown_blocks('__TEST_DIR__/fm_dots.md') WHERE element_type = 'metadata';
+----
+yaml
+
+# Trailing whitespace after `...` is accepted, exactly as after `---`.
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n... \n# Body') = 'title: x';
+----
+true
+
+# Four dots is a rule, not a fence, the same way four dashes is.
+query I
+SELECT md_extract_frontmatter(E'---\ntitle: x\n....\n# Body') IS NULL;
+----
+true
+
+# `...` is a document END marker: it never OPENS a block.
+query I
+SELECT md_extract_frontmatter(E'...\ntitle: x\n---\n# Body') IS NULL;
+----
+true
+
+# It has no meaning inside a `+++` TOML block either -- only `+++` closes `+++`,
+# so the `...` line stays in the block where Hugo would leave it.
+query I
+SELECT md_extract_frontmatter(E'+++\ntitle = "x"\n...\n+++\nBody') = E'title = "x"\n...';
+----
+true
+
+# An empty block closed with `...` is still an empty block, not two rules.
+statement ok
+COPY (SELECT E'---\n...\n# Body\n') TO '__TEST_DIR__/fm_dots_empty.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+query II
+SELECT element_type, content FROM read_markdown_blocks('__TEST_DIR__/fm_dots_empty.md') ORDER BY element_order;
+----
+heading	Body


### PR DESCRIPTION
The frontmatter fence was recognised by two separately-written pieces of code that disagreed **in both directions**. Three ways to get a silently wrong document body, none of which raised.

## The bugs

**1. An empty block was never detected.** The close scan starts at `body_start` — but the `\n` before the closing fence of `---\n---` *is* the one that ended the opening fence, one byte earlier, so it was never examined. This is the Jekyll idiom.

```
---\n---\n# Body     ->  hr, hr, heading     (frontmatter treated as content)
+++\n+++             ->  a paragraph of literal plus signs
```

**2. The close was a 3-character prefix compare.** `----` closed a `---` block and spliced the surplus `-` onto the front of the body, where cmark manufactured an empty `list` + `list_item` out of nothing.

**3. The open rejected a trailing space** that Jekyll, gray-matter and python-frontmatter all accept:

```
--- \ntitle: x\n---   ->  hr, heading("title: x"), heading("Body")
```

Metadata silently reclassified as a setext heading.

## The fix

One shared `IsFrontmatterFenceLine` predicate, used at both ends, so open and close can no longer disagree about what a fence is.

## Verification

The new test file was watched failing before the fix: `src/markdown_utils.cpp` was reverted on its own, rebuilt, and the assertions confirmed red — then restored. Full suite green at **1866 assertions across 51 files**; `clang-format` clean.

## On issue #21 itself

**All five of the umbrella's checkboxes were already fixed** and never ticked — `620778d` (frontmatter docs), `0d46423` (the two table parsers), `56bd938` (JSON escaping), `72095d1` (`md_stats` exact mode), `31216c0` (malformed-input fixtures). Each was re-verified against a current build rather than taken from the checkbox. **This PR addresses none of what #21 describes**; it exists because of what turned up while verifying that #21 was stale.

## Deliberate follow-up, not folded in

`md_extract_frontmatter` conflates "no block" with "empty block" — both return NULL. That is real information loss, but it only became *meaningful* once empty blocks are detectable, and fixing it changes the API. An empty block carries no data either way, so nothing is lost today. Worth a second opinion before changing.
