### PR TITLE
fix(#59): element_order is dense from 0, as the recovery contract requires

### DIFF
--- a/docs/markdown_doc_block.md
+++ b/docs/markdown_doc_block.md
@@ -102,7 +102,7 @@ Returns rows with duck_block shape:
 | `level` | INTEGER | Structural DEPTH, minimum 1 — including frontmatter. A heading's rank is `attributes['heading_level']`, not this. (`read_markdown_sections` also has a `level` column, but that one is heading rank 0-6: a different measurement) |
 | `encoding` | VARCHAR | `text`, `json` (tables), `yaml`/`toml` (frontmatter) |
 | `attributes` | MAP(VARCHAR, VARCHAR) | Block metadata (heading_level, language, id, etc.) |
-| `element_order` | INTEGER | Position in document (1-indexed) |
+| `element_order` | INTEGER | Position in document (0-indexed, dense) |
 | `filename` | VARCHAR | Source file (when enabled). Trailing: duck_block spec 6.4 puts it after `element_order`. |
 
 **Note on heading levels:** For headings, the actual H1-H6 level is stored in `attributes['heading_level']`, while `level` indicates document nesting depth (always 1 for top-level blocks). This matches the duck_block_utils convention.

--- a/src/markdown_utils.cpp
+++ b/src/markdown_utils.cpp
@@ -1434,7 +1434,19 @@ std::vector<MarkdownBlock> ParseBlocks(const std::string &markdown_str, bool str
 		return blocks;
 	}
 
-	int32_t block_order = 1;
+	// 0, not 1. The recovery contract is normative: "element_order is dense from
+	// 0 over the list a reader EMITS, synthetic markers included" (see
+	// duck_block_vocabulary.hpp) and docs/doc_block_spec.md calls the column
+	// 0-indexed. This initializer is the only origin -- every ++ below and the
+	// counters threaded into EmitBlockChildren and EmitListStructural derive from
+	// it -- so it was the whole of the bug (#59).
+	//
+	// No validator could have caught this and none ever will: Block Validation
+	// rule 3 says "element_order is non-negative integer", which 1 satisfies.
+	// "Dense from 0" is a property of the LIST, and every validation predicate in
+	// the spec is about a single duck_block. webbed and panduck's native readers
+	// already emitted 0, so this reader was the outlier.
+	int32_t block_order = 0;
 
 	// Check for frontmatter first. The MATCH is used rather than the extracted
 	// string because the fence determines the encoding: `---` is YAML, `+++` is

--- a/test/sql/duck_block.test
+++ b/test/sql/duck_block.test
@@ -383,7 +383,10 @@ SELECT element_type FROM read_markdown_blocks('__TEST_DIR__/duck_block_test.md')
 ----
 heading
 
-# element_order is 1-indexed from the markdown parser
+# element_order is dense from 0 (#59). Note this assertion is self-referential --
+# it selects the column it filters on, so it returns 1 under either origin and
+# never tested the origin at all. Kept as a smoke check that the column binds;
+# duck_block_element_order_origin.test is what actually pins the contract.
 query I
 SELECT element_order FROM read_markdown_blocks('__TEST_DIR__/duck_block_test.md') WHERE element_order = 1 LIMIT 1;
 ----

--- a/test/sql/duck_block_element_order_origin.test
+++ b/test/sql/duck_block_element_order_origin.test
@@ -1,0 +1,149 @@
+# name: test/sql/duck_block_element_order_origin.test
+# description: element_order is dense from 0 over the list a reader emits (#59)
+# group: [sql]
+
+require markdown
+
+# =============================================================================
+# This reader emitted element_order starting at 1. Two normative statements,
+# both vendored in this repository, require 0:
+#
+#   docs/doc_block_spec.md:60
+#     | element_order | INTEGER | Yes | Sequential position in document (0-indexed) |
+#
+#   src/include/duck_block_vocabulary.hpp:347
+#     RECOVERY CONTRACT, now normative: element_order is dense from 0 over the
+#     list a reader EMITS, synthetic markers included.
+#
+# The cause was a single initializer, `int32_t block_order = 1`, from which
+# every other counter in ParseBlocks derived. It carried no comment, in a file
+# that documents its decisions heavily -- including, sixty lines below it, the
+# cost of frontmatter shifting body order, which was written down as "accepted
+# rather than hidden". An intentional departure from a normative rule would have
+# been recorded the same way.
+#
+# WHY NO VALIDATOR CAUGHT IT, which is the more useful half. Block Validation
+# rule 3 is "element_order is non-negative integer", and 1 satisfies it.
+# "Starts at 0" is a property of a LIST, while every validation predicate in the
+# spec is about a SINGLE duck_block -- so duck_blocks_validate() returned
+# valid:true for this output and always would. Not a check that was skipped: a
+# rule that is unenforceable as the spec is structured. That is the argument of
+# duck_block_utils#29, and this was its first worked example.
+#
+# So the assertions below are deliberately LIST-shaped -- min, density,
+# uniqueness over the whole emitted list -- because a per-block predicate
+# cannot express the rule that was broken.
+#
+# Reported by the duckeye session, measured on the installed build 75e9d0b and
+# reproduced here on main.
+# =============================================================================
+
+# =============================================================================
+# 1. The origin, across every shape
+# =============================================================================
+
+query I
+SELECT min(b.element_order) FROM unnest(parse_markdown_to_duck_blocks('just a paragraph')) AS t(b);
+----
+0
+
+query I
+SELECT min(b.element_order) FROM unnest(parse_markdown_to_duck_blocks(E'# H\n\nbody')) AS t(b);
+----
+0
+
+query I
+SELECT min(b.element_order) FROM unnest(parse_markdown_to_duck_blocks(E'- a\n- b')) AS t(b);
+----
+0
+
+query I
+SELECT min(b.element_order) FROM unnest(parse_markdown_to_duck_blocks(E'```sh\nls\n```')) AS t(b);
+----
+0
+
+query I
+SELECT min(b.element_order) FROM unnest(parse_markdown_to_duck_blocks(E'> quoted\n')) AS t(b);
+----
+0
+
+# =============================================================================
+# 2. Dense, and unique -- the two halves of "dense from 0"
+#
+# min=0 alone would be satisfied by 0,1,1,5. Density (count = max+1) and
+# uniqueness together pin the list to exactly 0..n-1.
+# =============================================================================
+
+query III
+SELECT min(b.element_order), max(b.element_order) - count(*) + 1, count(*) - count(DISTINCT b.element_order)
+FROM unnest(parse_markdown_to_duck_blocks(E'# H\n\npara\n\n- a\n- b\n\n> q\n\n```sh\nls\n```\n')) AS t(b);
+----
+0	0	0
+
+# Deeply nested: list inside list inside quote. Every counter in the walk has to
+# share the origin, not just the top-level one.
+query III
+SELECT min(b.element_order), max(b.element_order) - count(*) + 1, count(*) - count(DISTINCT b.element_order)
+FROM unnest(parse_markdown_to_duck_blocks(E'> - a\n>   - b\n>     - c\n>\n> after\n')) AS t(b);
+----
+0	0	0
+
+# =============================================================================
+# 3. Synthetic markers are included, not exempt
+#
+# The recovery contract says "synthetic markers included". The frontmatter block
+# is one: it has no cmark node behind it, this reader manufactures it. It takes
+# element_order 0 and the body follows from 1. (metadata is a BLOCK type in the
+# vocabulary -- TYPE_METADATA sits beside TYPE_CODE and TYPE_HR -- distinct from
+# the kind='value' MetaValue tree that models Pandoc's decomposed metadata.) -- which is also why a document
+# gaining frontmatter shifts every body order, a cost markdown_utils.cpp:1497
+# records as accepted.
+# =============================================================================
+
+query II
+SELECT b.element_order, b.kind || '/' || b.element_type
+FROM unnest(parse_markdown_to_duck_blocks(E'---\ntitle: T\n---\n\n# H\n\nbody\n')) AS t(b)
+ORDER BY b.element_order;
+----
+0	block/metadata
+1	block/heading
+2	block/paragraph
+
+# =============================================================================
+# 4. The table function agrees with the scalar
+#
+# read_markdown_blocks and parse_markdown_to_duck_blocks are separate emit
+# paths. Both are readers, so the contract binds both, and they must not
+# disagree with each other either.
+# =============================================================================
+
+statement ok
+COPY (SELECT E'# H\n\npara\n\n- a\n- b\n') TO '__TEST_DIR__/eo.md' (FORMAT CSV, HEADER false, QUOTE '');
+
+query III
+SELECT min(element_order), max(element_order) - count(*) + 1, count(*) - count(DISTINCT element_order)
+FROM read_markdown_blocks('__TEST_DIR__/eo.md');
+----
+0	0	0
+
+# =============================================================================
+# 5. The negative half: `level` is 1-origin and must NOT move
+#
+# `level` is the confusable neighbour -- an adjacent integer field on the same
+# struct, set in the same functions, incremented in the same walks. A fix that
+# shifted the origin of the wrong counter would still make section 1 pass.
+# Nothing in the spec makes level 0-based, and a top-level block is level 1.
+# =============================================================================
+
+query II
+SELECT min(b.level), max(b.level)
+FROM unnest(parse_markdown_to_duck_blocks(E'# H\n\npara\n')) AS t(b);
+----
+1	1
+
+# A list nests: list at 1, list_item at 2, the item's paragraph at 3.
+query I
+SELECT string_agg(b.level::VARCHAR, ',' ORDER BY b.element_order)
+FROM unnest(parse_markdown_to_duck_blocks(E'- a')) AS t(b);
+----
+1,2,3

--- a/test/sql/duck_block_metadata_position.test
+++ b/test/sql/duck_block_metadata_position.test
@@ -21,9 +21,9 @@ SELECT e.element_type, e.element_order, e.attributes['role']
 FROM (SELECT unnest(parse_markdown_to_duck_blocks(e'---\ntitle: T\n---\n\n# H\n\nBody.\n')) AS e)
 WHERE e.kind = 'block' ORDER BY e.element_order;
 ----
-metadata	1	frontmatter
-heading	2	NULL
-paragraph	3	NULL
+metadata	0	frontmatter
+heading	1	NULL
+paragraph	2	NULL
 
 # WRITER: metadata is found by TYPE, wherever it sits.
 #
@@ -112,7 +112,7 @@ true	true
 query I
 SELECT bool_and(is_first) FROM (
   SELECT (SELECT min(e.element_order) FROM (SELECT unnest(parse_markdown_to_duck_blocks(md)) AS e)
-          WHERE e.attributes['role'] = 'frontmatter') = 1 AS is_first
+          WHERE e.attributes['role'] = 'frontmatter') = 0 AS is_first
   FROM (VALUES (e'---\ntitle: T\n---\n\n# H\n\nBody.\n'),
                (e'---\ntitle: T\n---\n'),
                (e'+++\nt = 1\n+++\n\nB.\n'),

--- a/test/sql/markdown_blocks.test
+++ b/test/sql/markdown_blocks.test
@@ -12,7 +12,7 @@ require markdown
 query III
 SELECT kind, element_type, element_order FROM read_markdown_blocks('test/data/blocks_basic.md') LIMIT 1;
 ----
-block	heading	1
+block	heading	0
 
 # =============================================================================
 # Test: Basic read_markdown_blocks from file (flattened output)
@@ -158,7 +158,7 @@ true
 query I
 SELECT string_agg(element_order::VARCHAR, ',' ORDER BY element_order) FROM read_markdown_blocks('test/data/blocks_basic.md');
 ----
-1,2,3,4
+0,1,2,3
 
 # =============================================================================
 # Test: include_filepath option
@@ -203,7 +203,7 @@ true
 query IIIIIII
 SELECT kind, element_type, content IS NOT NULL, level, encoding, attributes IS NOT NULL, element_order FROM read_markdown_blocks('test/data/blocks_basic.md') WHERE element_type = 'heading';
 ----
-block	heading	true	1	text	true	1
+block	heading	true	1	text	true	0
 
 # =============================================================================
 # Test: Complex document with multiple block types

--- a/test/sql/markdown_malformed_inputs.test
+++ b/test/sql/markdown_malformed_inputs.test
@@ -104,7 +104,7 @@ query I
 SELECT b.content
 FROM (SELECT UNNEST(parse_markdown_to_duck_blocks(
   'para' || chr(13) || chr(10) || chr(13) || chr(10) || 'para2')) b)
-WHERE b.element_order = 1;
+WHERE b.element_order = 0;
 ----
 para
 

--- a/test/sql/readme_integration.test
+++ b/test/sql/readme_integration.test
@@ -103,11 +103,12 @@ FROM read_markdown_blocks('README.md') WHERE kind = 'block';
 ----
 true
 
-# Block order should be sequential starting from 1
+# Block order is dense from 0 (#59) -- the recovery contract's origin, shared
+# with webbed and panduck's native readers.
 query I
 SELECT min(element_order) FROM read_markdown_blocks('README.md');
 ----
-1
+0
 
 # THIS READER emits only these two kinds -- a property of read_markdown_blocks,
 # NOT a statement of which kinds are valid. The vocabulary also has `value`,


### PR DESCRIPTION
Fixes #59. Reported by the duckeye session; ruled non-conformant under any reading by duck_block_utils as vocabulary owner.

## One character

`src/markdown_utils.cpp:1437`, `int32_t block_order = 1` → `0`. It was the only origin in `ParseBlocks` — every `++` and both counters threaded into `EmitBlockChildren` and `EmitListStructural` derive from it — so it was the whole of the bug.

Two normative statements, both vendored in this repo, required 0:

| | |
|---|---|
| `docs/doc_block_spec.md:60` | `element_order … (0-indexed)` |
| `duck_block_vocabulary.hpp:347` | *RECOVERY CONTRACT, now normative: element_order is dense from 0 over the list a reader EMITS, synthetic markers included.* |

`webbed` and `panduck`'s native readers already emitted 0. `panduck`'s `.md` path emitted 1 **because it delegates here**, so the divergence sat exactly at the delegation boundary and reached consumers through two extensions.

## This removes an inconsistency rather than introducing one

Worth stating carefully, because I had it wrong at first and duck_block_utils corrected me. Calling this "a breaking change to emitted data" is true of markdown's output in isolation and misleading about the fleet: **anyone comparing `element_order` across `read_markdown_blocks` and `read_html_blocks` is getting wrong answers today.** After this they get right ones. The genuine regressions are consumers keying on markdown's absolute values *alone*, plus `panduck`'s `.md` path, which moves with us.

## Why no validator caught it — the part worth keeping

Block Validation rule 3 is *"element_order is non-negative integer"*, and 1 satisfies it. **"Dense from 0" is a property of a LIST, while every validation predicate in the spec is about a single `duck_block`.** So `duck_blocks_validate()` returned `valid: true` for this output and always would.

Not a check that was skipped — a rule that is *unenforceable as the spec is structured*. That is duck_block_utils#29's thesis, and this was its first worked example. The new test is therefore deliberately **list-shaped** — min, density, uniqueness over the whole emitted list — because a per-block predicate cannot express the rule that was broken.

## How it survived six spec versions

Two places in this repo wrote the divergence down as though it were the contract:

- `docs/markdown_doc_block.md:105` — "Position in document (1-indexed)"
- `test/sql/duck_block.test:386` — "element_order is 1-indexed from the markdown parser"

while `docs/doc_block_spec.md:60`, vendored alongside, said 0-indexed. Nobody reconciled them, so anyone who checked found local documentation agreeing with the code. Both corrected here.

The initializer carried no comment — in a file that documents its decisions heavily, including sixty lines below it the cost of frontmatter shifting body order, recorded as *"accepted rather than hidden"*. A deliberate departure from a normative rule would have been written down the same way. It now carries the rationale it should always have had.

## The test's negative half is `level`

`level` is the confusable neighbour: an adjacent integer on the same struct, set in the same functions, incremented in the same walks. A fix that shifted the wrong counter would still pass every origin assertion. So the test pins `level` at 1-origin — `1,2,3` for `list / list_item / paragraph` — **measured against the unfixed binary before the fix was written.**

Also pinned: the frontmatter block is a *synthetic marker*, which the contract explicitly includes, so it takes order 0 and the body follows from 1.

## A correction to my own estimate in #59

I told the issue this was "one character plus two test lines." **It was six assertion sites across five test files.** My figure came from `grep -E "element_order *(=|==) *[0-9]"`, which matches WHERE-clause forms and misses expected-result blocks entirely — where most of them lived. The suite was the instrument that found the rest, and #59 is corrected.

One of those six passes under **either** origin and is left as-is with a note explaining why: `duck_block.test:391` selects the column it filters on (`SELECT element_order … WHERE element_order = 1`), so it returns 1 regardless and never tested the origin at all.

## Verification

- Red: new test failed at line 45 pre-fix (`min(element_order)` = 1, expected 0).
- Green: **24 assertions**, all passed.
- Full suite: **`All tests passed (1934 assertions in 53 test cases)`**, exit 0 — up from 1910 in 52, exactly the 24 the new file adds, so nothing else moved.
- Build gated on `$?` with sha256 before/after confirming the binary under test was freshly built.
- `clang-format 11.0.1 --style=file` reports no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
